### PR TITLE
Website - Improve clarity/accuracy of how the `@isHrefExternal` argument is documented across multiple components

### DIFF
--- a/showcase/app/templates/page-components/app-side-nav/index.hbs
+++ b/showcase/app/templates/page-components/app-side-nav/index.hbs
@@ -364,8 +364,14 @@
         </span>
       </Hds::AppSideNav::List::Link>
     </SG.Item>
+    <SG.Item @label="Default link">
+      <Hds::AppSideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @href="#" />
+    </SG.Item>
     <SG.Item @label="External link">
-      <Hds::AppSideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @isHrefExternal={{true}} />
+      <Hds::AppSideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @isHrefExternal={{true}} @href="#" />
+    </SG.Item>
+    <SG.Item @label="Internal link">
+      <Hds::AppSideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @isHrefExternal={{false}} @href="#" />
     </SG.Item>
   </Shw::Grid>
 

--- a/showcase/app/templates/page-components/app-side-nav/index.hbs
+++ b/showcase/app/templates/page-components/app-side-nav/index.hbs
@@ -368,10 +368,20 @@
       <Hds::AppSideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @href="#" />
     </SG.Item>
     <SG.Item @label="External link">
-      <Hds::AppSideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @isHrefExternal={{true}} @href="#" />
+      <Hds::AppSideNav::List::Link
+        @icon="hashicorp"
+        @text="HashiCorp Cloud Platform"
+        @isHrefExternal={{true}}
+        @href="#"
+      />
     </SG.Item>
     <SG.Item @label="Internal link">
-      <Hds::AppSideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @isHrefExternal={{false}} @href="#" />
+      <Hds::AppSideNav::List::Link
+        @icon="hashicorp"
+        @text="HashiCorp Cloud Platform"
+        @isHrefExternal={{false}}
+        @href="#"
+      />
     </SG.Item>
   </Shw::Grid>
 

--- a/showcase/app/templates/page-components/side-nav.hbs
+++ b/showcase/app/templates/page-components/side-nav.hbs
@@ -841,7 +841,12 @@
       <Hds::SideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @href="#" @isHrefExternal={{true}} />
     </SG.Item>
     <SG.Item @label="Internal link">
-      <Hds::SideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @href="#" @isHrefExternal={{false}} />
+      <Hds::SideNav::List::Link
+        @icon="hashicorp"
+        @text="HashiCorp Cloud Platform"
+        @href="#"
+        @isHrefExternal={{false}}
+      />
     </SG.Item>
   </Shw::Grid>
 

--- a/showcase/app/templates/page-components/side-nav.hbs
+++ b/showcase/app/templates/page-components/side-nav.hbs
@@ -834,8 +834,14 @@
         </span>
       </Hds::SideNav::List::Link>
     </SG.Item>
+    <SG.Item @label="Default link">
+      <Hds::SideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @href="#" />
+    </SG.Item>
     <SG.Item @label="External link">
-      <Hds::SideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @isHrefExternal={{true}} />
+      <Hds::SideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @href="#" @isHrefExternal={{true}} />
+    </SG.Item>
+    <SG.Item @label="Internal link">
+      <Hds::SideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @href="#" @isHrefExternal={{false}} />
     </SG.Item>
   </Shw::Grid>
 

--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -59,8 +59,8 @@ The `AppFooter::StatusLink` component, yielded as contextual component.
   <C.Property @name="href">
     Pass a custom href for the link. (URL parameter that’s passed down to the `<a>` element.)
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    Controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -115,8 +115,8 @@ The `AppFooter::Link` component, yielded as contextual component.
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    Controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -60,7 +60,7 @@ The `AppFooter::StatusLink` component, yielded as contextual component.
     Pass a custom href for the link. (URL parameter that’s passed down to the `<a>` element.)
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -116,7 +116,7 @@ The `AppFooter::Link` component, yielded as contextual component.
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/app-header/partials/code/component-api.md
+++ b/website/docs/components/app-header/partials/code/component-api.md
@@ -63,7 +63,7 @@ The `AppHeader::HomeLink` component uses the generic `Hds::Interactive` componen
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/app-header/partials/code/component-api.md
+++ b/website/docs/components/app-header/partials/code/component-api.md
@@ -54,7 +54,7 @@ The `AppHeader::HomeLink` component uses the generic `Hds::Interactive` componen
     Used to display text inline with the logo. If `@isIconOnly` is set to `true`, this value will instead be passed to the `aria-label` of the `<a>` tag.
   </C.Property>
   <C.Property @name="isIconOnly" @type="boolean" @default="true">
-    Indicates if the Home Link will only contain a icon/logo. If set to `false`, the `@text` property will be rendered adjacent to the logo. 
+    Indicates if the Home Link will only contain a icon/logo. If set to `false`, the `@text` property will be rendered adjacent to the logo.
   </C.Property>
   <C.Property @name="color" @type="string">
     Used to specify an optional custom color provided as any valid CSS color. For more details on acceptable values, see the [Icon color argument](/components/icon?tab=code#fill). If unspecified, it will use the App Headers’s default white text color.
@@ -62,8 +62,8 @@ The `AppHeader::HomeLink` component uses the generic `Hds::Interactive` componen
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/app-side-nav/partials/code/component-api.md
+++ b/website/docs/components/app-side-nav/partials/code/component-api.md
@@ -134,7 +134,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external, in which case (for security reasons) we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+    Controls whether or not the `<a>` link is external, in which case (for security reasons) we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -191,7 +191,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons). If explicitly set to `true`, it displays also a right aligned “external-link” icon.
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons). If explicitly set to `true`, it displays also a right aligned “external-link” icon.
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/app-side-nav/partials/code/component-api.md
+++ b/website/docs/components/app-side-nav/partials/code/component-api.md
@@ -133,8 +133,8 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external, in which case (for security reasons) we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -190,8 +190,8 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default. If set to `true`, displays a right aligned “external-link” icon.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons). If explicitly set to `true`, it displays also a right aligned “external-link” icon.
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/button/partials/code/component-api.md
+++ b/website/docs/components/button/partials/code/component-api.md
@@ -26,8 +26,8 @@
   <C.Property @name="href">
     URL parameter that is passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    Controls if the `<a>` link is external and so for security reasons we need to add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo/LinkToExternal>` component.

--- a/website/docs/components/button/partials/code/component-api.md
+++ b/website/docs/components/button/partials/code/component-api.md
@@ -27,7 +27,7 @@
     URL parameter that is passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo/LinkToExternal>` component.

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -127,7 +127,7 @@ By default, the link is considered "external", which means that the `target=“_
 <Hds::Button @text="Visit website" @icon="external-link" @iconPosition="trailing" @href="https://hashicorp.com" />
 ```
 
-If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
+If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" or "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
 #### With @route
 

--- a/website/docs/components/button/partials/code/how-to-use.md
+++ b/website/docs/components/button/partials/code/how-to-use.md
@@ -114,17 +114,20 @@ If you’re passing an `@href` or a `@route` argument to the component, this wil
 !!! Info
 
 The `Hds::Button` component uses the generic `Hds::Interactive` component. For more details about how this utility component works, please refer to [its documentation page](/utilities/interactive).
+
 !!!
 
 #### With @href
 
 If you pass an `@href` argument, an `<a>` link will be generated.
 
-`target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument but can be overridden. If the `href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` and it will not add the `target` and `rel` attributes.
+By default, the link is considered "external", which means that the `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied to the `<a>` element. This is the most common case, as internal links are generally handled using a `@route` argument.
 
 ```handlebars
 <Hds::Button @text="Visit website" @icon="external-link" @iconPosition="trailing" @href="https://hashicorp.com" />
 ```
+
+If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
 #### With @route
 

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -227,8 +227,8 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
   <C.Property @name="href">
     URL passed to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    Indicates whether or not the `<a>` link is external, in which case `target="_blank"` and `rel="noopener noreferrer"` attributes are added automatically.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters passed as arguments to the `<LinkTo/LinkToExternal>` component.
@@ -287,8 +287,8 @@ The `Dropdown::ListItem::Checkmark` component, yielded as contextual component.
   <C.Property @name="href">
     URL passed to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    Indicates whether or not the `<a>` link is external, in which case `target="_blank"` and `rel="noopener noreferrer"` attributes are added automatically.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Indicates whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters passed as arguments to the `<LinkTo/LinkToExternal>` component.

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -228,7 +228,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
     URL passed to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters passed as arguments to the `<LinkTo/LinkToExternal>` component.

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -272,7 +272,7 @@ To visually indicate that the link points to an external resource, you can use `
 </ul>
 ```
 
-If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
+If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" or "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
 #### Rendering a LinkTo (with `@route`)
 

--- a/website/docs/components/dropdown/partials/code/how-to-use.md
+++ b/website/docs/components/dropdown/partials/code/how-to-use.md
@@ -219,7 +219,13 @@ To change this behavior, you can use the `@preserveContentInDom` argument so tha
 ### ListItem::Interactive
 
 `ListItem::Interactive` renders the correct element based on the passing of a `@route`, `@href`, or the addition of a click event (e.g.,
-`\{{on "click" this.myAction}}`). Internally, the component uses the [Hds::Interactive](/utilities/interactive) utility component.
+`\{{on "click" this.myAction}}`).
+
+!!! Info
+
+The `ListItem::Interactive` component uses the generic `Hds::Interactive` component. For more details about how this utility component works, please refer to [its documentation page](/utilities/interactive).
+
+!!!
 
 #### Rendering a button
 
@@ -245,13 +251,6 @@ You can pass an `@icon` argument to add a leading icon:
 
 #### Rendering a link with `@href`
 
-!!! Info
-
-**Internal Link?**
-
-When using the `@href` argument, you’re indicating an external link (instead of a route). So, a few relevant HTML attributes are added—`target="_blank"` and `rel="noopener noreferrer"`. However, if the `@href` really _does_ point to an internal link or uses a different protocol (e.g., `mailto` or `ftp`), pass `@isHrefExternal={{false}}` to the component and it will not add any extra HTML attributes.
-!!!
-
 If you pass an `@href` argument, a link (`<a>` element) will be generated:
 
 ```handlebars
@@ -261,8 +260,9 @@ If you pass an `@href` argument, a link (`<a>` element) will be generated:
   </Hds::Dropdown::ListItem::Interactive>
 </ul>
 ```
+By default, the link is considered "external", which means that the `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied to the `<a>` element. This is the most common case, as internal links are generally handled using a `@route` argument.
 
-To indicate that the link points to an external resource, you can use `@trailingIcon` and assign it an icon name like `external-link`, `docs-link`, `guide-link`, or `learn-link`.
+To visually indicate that the link points to an external resource, you can use `@trailingIcon` and assign it an icon name like `external-link`, `docs-link`, `guide-link`, or `learn-link`.
 
 ```handlebars
 <ul class="hds-dropdown__list">
@@ -271,6 +271,8 @@ To indicate that the link points to an external resource, you can use `@trailing
   </Hds::Dropdown::ListItem::Interactive>
 </ul>
 ```
+
+If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
 #### Rendering a LinkTo (with `@route`)
 

--- a/website/docs/components/link/inline/partials/code/component-api.md
+++ b/website/docs/components/link/inline/partials/code/component-api.md
@@ -14,7 +14,7 @@
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/link/inline/partials/code/component-api.md
+++ b/website/docs/components/link/inline/partials/code/component-api.md
@@ -13,8 +13,8 @@
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    Controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/link/inline/partials/code/how-to-use.md
+++ b/website/docs/components/link/inline/partials/code/how-to-use.md
@@ -47,23 +47,23 @@ Inline Links use the generic `Hds::Interactive` component. Learn more about [how
 
 #### With `@href`
 
-To generate an `<a>` link, pass an `@href` argument with a URL as the value. 
+To generate an `<a>` link, pass an `@href` argument with a URL as the value.
 
-`target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument. 
+By default, the link is considered "external", which means that the `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied to the `<a>` element. This is the most common case, as internal links are generally handled using a `@route` argument.
 
 ```handlebars
 Lorem <Hds::Link::Inline @icon="external-link" @href="https://www.hashicorp.com">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
 ```
 
-If the `@href` argument points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{true}}` to the component and it will omit the `target` and `rel` attributes.
+If the `@href` argument points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
-#### With `@route` 
+#### With `@route`
 
 All the standard arguments for the `<LinkTo/LinkToExternal>` components are supported (e.g., `models/model/query/current-when/replace`).
 
 ##### For `<LinkTo>`
 
-To generate an `<a>` link using a `<LinkTo>` Ember component, pass a `@route` argument. 
+To generate an `<a>` link using a `<LinkTo>` Ember component, pass a `@route` argument.
 
 ```handlebars
 Lorem <Hds::Link::Inline @route="my.page.route" @model="my.page.model">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.

--- a/website/docs/components/link/inline/partials/code/how-to-use.md
+++ b/website/docs/components/link/inline/partials/code/how-to-use.md
@@ -55,7 +55,7 @@ By default, the link is considered "external", which means that the `target=“_
 Lorem <Hds::Link::Inline @icon="external-link" @href="https://www.hashicorp.com">ipsum dolor</Hds::Link::Inline> sit amet consectetur adipiscing elit.
 ```
 
-If the `@href` argument points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
+If the `@href` argument points to an internal link, or uses a different protocol (e.g., "mailto" or "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
 #### With `@route`
 

--- a/website/docs/components/link/standalone/partials/code/component-api.md
+++ b/website/docs/components/link/standalone/partials/code/component-api.md
@@ -17,8 +17,8 @@
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    Controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/link/standalone/partials/code/component-api.md
+++ b/website/docs/components/link/standalone/partials/code/component-api.md
@@ -18,7 +18,7 @@
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/link/standalone/partials/code/how-to-use.md
+++ b/website/docs/components/link/standalone/partials/code/how-to-use.md
@@ -31,7 +31,7 @@ There are two available colors for a Standalone Link: `primary` and `secondary`.
 
 ```handlebars
 <Hds::Link::Standalone @color="secondary" @icon="collections" @text="Read tutorial" @href="..." />
-```  
+```
 
 ### Size
 
@@ -53,13 +53,15 @@ Standalone Links use the generic `Hds::Interactive` component. Learn more about 
 
 #### With `@href`
 
-To generate an `<a>` link, pass an `@href` argument with a URL as the value. 
+To generate an `<a>` link, pass an `@href` argument with a URL as the value.
 
-`target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument. 
+By default, the link is considered "external", which means that the `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied to the `<a>` element. This is the most common case, as internal links are generally handled using a `@route` argument.
 
 ```handlebars
 <Hds::Link::Standalone @icon="terraform" @text="Request a demo" @href="https://www.hashicorp.com/request-demo/terraform" />
 ```
+
+If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
 #### With `@route`
 
@@ -67,7 +69,7 @@ All the standard arguments for the `<LinkTo/LinkToExternal>` components are supp
 
 ##### For `<LinkTo>`
 
-To generate an `<a>` link using a `<LinkTo>` Ember component, pass a `@route` argument. 
+To generate an `<a>` link using a `<LinkTo>` Ember component, pass a `@route` argument.
 
 ```handlebars
 <Hds::Link::Standalone @icon="collections" @text="Go to the index page" @route="my.page.route" @model="my.page.model" />

--- a/website/docs/components/link/standalone/partials/code/how-to-use.md
+++ b/website/docs/components/link/standalone/partials/code/how-to-use.md
@@ -61,7 +61,7 @@ By default, the link is considered "external", which means that the `target=“_
 <Hds::Link::Standalone @icon="terraform" @text="Request a demo" @href="https://www.hashicorp.com/request-demo/terraform" />
 ```
 
-If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
+If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" or "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
 #### With `@route`
 

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -116,7 +116,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -155,7 +155,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -270,7 +270,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -327,7 +327,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons). If explicitly set to `true`, it displays also a right aligned “external-link” icon.
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons). If explicitly set to `true`, it displays also a right aligned “external-link” icon.
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/side-nav/partials/code/component-api.md
+++ b/website/docs/components/side-nav/partials/code/component-api.md
@@ -115,8 +115,8 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -154,8 +154,8 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -269,8 +269,8 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.
@@ -326,8 +326,8 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default. If set to `true`, displays a right aligned “external-link” icon.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons). If explicitly set to `true`, it displays also a right aligned “external-link” icon.
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -15,8 +15,8 @@
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean">
+    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/components/tag/partials/code/component-api.md
+++ b/website/docs/components/tag/partials/code/component-api.md
@@ -16,7 +16,7 @@
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean">
-    Controls if the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external. When left `undefined` or explicitly set to `true` it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/utilities/interactive/partials/code/component-api.md
+++ b/website/docs/utilities/interactive/partials/code/component-api.md
@@ -6,8 +6,8 @@
   <C.Property @name="href">
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
-  <C.Property @name="isHrefExternal" @type="boolean" @default="false">
-    This controls if the `<a>` link is external. For security reasons, we add the `target="_blank"` and `rel="noopener noreferrer"` attributes to it by default.
+  <C.Property @name="isHrefExternal" @type="boolean" @default="true">
+    Controls if the `<a>` link is external, in which case it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/utilities/interactive/partials/code/component-api.md
+++ b/website/docs/utilities/interactive/partials/code/component-api.md
@@ -7,7 +7,7 @@
     URL parameter that’s passed down to the `<a>` element.
   </C.Property>
   <C.Property @name="isHrefExternal" @type="boolean" @default="true">
-    Controls if the `<a>` link is external, in which case it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
+    Controls whether or not the `<a>` link is external, in which case it adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tag (for security reasons).
   </C.Property>
   <C.Property @name="route/models/model/query/current-when/replace">
     Parameters that are passed down as arguments to the `<LinkTo>`/`<LinkToExternal>` components.

--- a/website/docs/utilities/interactive/partials/code/how-to-use.md
+++ b/website/docs/utilities/interactive/partials/code/how-to-use.md
@@ -7,7 +7,7 @@ This component is intended only for internal Helios use. If you need to use it, 
 
 ### Default use for `<button>`
 
-When no `@href` or `@route` arguments are provided, it generates an HTML `<button>` element. 
+When no `@href` or `@route` arguments are provided, it generates an HTML `<button>` element.
 
 The `type=“button”` HTML attribute is applied to the element by default, but can be overwritten using the “splattributes”.
 
@@ -26,7 +26,7 @@ We can’t support direct use of the `href` HTML attribute because we rely on th
 
 Provide an `@href` argument to generate an HTML `<a>` link element.
 
-`target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied by default. This is the most common case, as internal links are generally handled using a `@route` argument but can be overridden.
+By default, the link is considered "external", which means that the `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied to the `<a>` element. This is the most common case, as internal links are generally handled using a `@route` argument.
 
 ```handlebars{data-execute=false}
 <Hds::Interactive @href="https://google.com">
@@ -34,9 +34,10 @@ Provide an `@href` argument to generate an HTML `<a>` link element.
 </Hds::Interactive>
 ```
 
+
 #### Adding `@isHrefExternal={{false}}`
 
-Provide an `@isHrefExternal` argument to generate an HTML `<a>` link element **without** the HTML `target` and `rel` attributes.
+If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
 ```handlebars{data-execute=false}
 <Hds::Interactive @href="#your-local-anchor-id" @isHrefExternal={{false}}>

--- a/website/docs/utilities/interactive/partials/code/how-to-use.md
+++ b/website/docs/utilities/interactive/partials/code/how-to-use.md
@@ -37,7 +37,7 @@ By default, the link is considered "external", which means that the `target=“_
 
 #### Adding `@isHrefExternal={{false}}`
 
-If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" of "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
+If the `@href` points to an internal link, or uses a different protocol (e.g., "mailto" or "ftp"), pass `@isHrefExternal={{false}}` to the component and it will omit the `target` and `rel` attributes.
 
 ```handlebars{data-execute=false}
 <Hds::Interactive @href="#your-local-anchor-id" @isHrefExternal={{false}}>


### PR DESCRIPTION
### :pushpin: Summary

This PR is the result of this conversation: https://hashicorp.slack.com/archives/C025N5V4PFZ/p1752603803426089

### :hammer_and_wrench: Detailed description

In this PR I have:

- updated the “How to use” sections related to `@isHrefExternal` for different components
- updated the “Component API” documentation for multiple components that had `@isHrefExternal` arguments
- updated showcase for `AppSideNav/SideNav` with more use cases for `@isHrefExternal`
  - this is a special case, compared with the other components, because we explicitly use the `@isHrefExternal` argument to determine if show the external icon or not, without a default, but at the same time the argument is forwarded to the `Hds::Interactive` component, which has a default `true` for this argument.

### :camera_flash: Screenshots

**Before:**
<img width="839" height="207" alt="screenshot_5162" src="https://github.com/user-attachments/assets/c191f6da-1466-40d4-86b5-c8fb5d5d9134" />

**After:**
<img width="841" height="155" alt="screenshot_5163" src="https://github.com/user-attachments/assets/263e3b11-f540-4518-8f51-ce8ab477df12" />

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-5152

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>