### PR TITLE
`AppSideNav::List:Link` - Fix styles when rendered as `button`

### DIFF
--- a/.changeset/grumpy-bulldogs-hammer.md
+++ b/.changeset/grumpy-bulldogs-hammer.md
@@ -1,0 +1,11 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START /components/app-side-nav -->
+`AppSideNav::List::Link` - Removed extra transparent border and background when rendered as a `<button>` element
+<!-- END -->
+
+<!-- START /components/side-nav -->
+`SideNav::List::Link` - Removed extra transparent border when rendered as a `<button>` element
+<!-- END -->

--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -92,6 +92,7 @@
   background: var(--token-app-side-nav-color-surface-primary);
   // "Link" could render as an HTML button element so this overrides the default border style in that case:
   border-color: transparent;
+  border-width: 0;
   border-radius: var(--token-app-side-nav-body-list-item-border-radius);
 
   // :Focus

--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -89,6 +89,7 @@
     var(--token-app-side-nav-body-list-item-padding-horizontal);
   color: var(--token-app-side-nav-color-foreground-primary);
   text-decoration: none;
+  background: var(--token-app-side-nav-color-surface-primary);
   // "Link" could render as an HTML button element so this overrides the default border style in that case:
   border-color: transparent;
   border-radius: var(--token-app-side-nav-body-list-item-border-radius);

--- a/packages/components/src/styles/components/side-nav/content.scss
+++ b/packages/components/src/styles/components/side-nav/content.scss
@@ -92,6 +92,7 @@
   background: var(--token-side-nav-color-surface-primary);
   // "Link" could render as an HTML button element so this overrides the default border style in that case:
   border-color: transparent;
+  border-width: 0;
   border-radius: var(--token-side-nav-body-list-item-border-radius);
 
   &:focus,

--- a/showcase/app/templates/page-components/app-side-nav/index.hbs
+++ b/showcase/app/templates/page-components/app-side-nav/index.hbs
@@ -403,7 +403,6 @@
                 <Hds::AppSideNav::List::Link
                   @text="Boundary"
                   @icon="boundary"
-                  @href="#"
                   @hasSubItems={{true}}
                   mock-state-value={{state}}
                 />

--- a/showcase/app/templates/page-components/side-nav.hbs
+++ b/showcase/app/templates/page-components/side-nav.hbs
@@ -873,7 +873,6 @@
                 <Hds::SideNav::List::Link
                   @text="Boundary"
                   @icon="boundary"
-                  @href="#"
                   @hasSubItems={{true}}
                   mock-state-value={{state}}
                 />


### PR DESCRIPTION
### :pushpin: Summary

While working on https://github.com/hashicorp/design-system/pull/3025 I noticed that when the `AppSideNav::List:Link` is rendered as a `<button>`, it inherits some of the styles from the HTML element itself. 

<img width="337" height="483" alt="modified" src="https://github.com/user-attachments/assets/8d1dc178-eb38-42b8-8f78-8f35bbe7a5ed" />

This PR addresses this issue.

### :hammer_and_wrench: Detailed description

In this PR I have:
- applied explicit background color to `.hds-app-side-nav__list-item-link` element
    - this issue didn't happen in the old `.hds-side-nav__list-item-link` element because in that case a `background-color` was specifically assigned
- removed invisible border on `.hds-[app-]side-nav__list-item-link` elements
- updated showcase pages to include visual testing for use case where `.hds-[app-]side-nav__list-item-link` is a button

### :camera_flash: Screenshots

**Before:**
<img width="1122" height="959" alt="screenshot_5172" src="https://github.com/user-attachments/assets/970aa857-b341-4767-9a9a-1bf98a540f89" />

**After:**
<img width="1109" height="955" alt="screenshot_5170" src="https://github.com/user-attachments/assets/b5f871c7-cbad-43aa-8b3b-987f595e9f87" />

### :link: External links

Jira ticket: 

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>