### PR TITLE
AppHeader: add close callback to yielded blocks

### DIFF
--- a/.changeset/thirty-ravens-study.md
+++ b/.changeset/thirty-ravens-study.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/app-header -->
-`AppHeader` - return `close` callback to the `:globalActions` and `:utilityActions` named blocks so the menu actions can be hidden programmatically.
+`AppHeader` - return `close` callback to the `:globalActions` and `:utilityActions` named blocks so the menu actions can be hidden programmatically when the component is in a mobile view.
 <!-- END -->

--- a/.changeset/thirty-ravens-study.md
+++ b/.changeset/thirty-ravens-study.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+<!-- START components/app-header -->
+`AppHeader` - return `close` callback to the `:globalActions` and `:utilityActions` named blocks so the actions can be hidden programmatically.
+<!-- END -->

--- a/.changeset/thirty-ravens-study.md
+++ b/.changeset/thirty-ravens-study.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/app-header -->
-`AppHeader` - return `close` callback to the `:globalActions` and `:utilityActions` named blocks so the actions can be hidden programmatically.
+`AppHeader` - return `close` callback to the `:globalActions` and `:utilityActions` named blocks so the menu actions can be hidden programmatically.
 <!-- END -->

--- a/packages/components/src/components/hds/app-header/index.hbs
+++ b/packages/components/src/components/hds/app-header/index.hbs
@@ -32,11 +32,11 @@
 
   <div class="hds-app-header__actions" id={{this._menuContentId}}>
     <div class="hds-app-header__global-actions">
-      {{yield to="globalActions"}}
+      {{yield (hash close=this.close) to="globalActions"}}
     </div>
 
     <div class="hds-app-header__utility-actions">
-      {{yield to="utilityActions"}}
+      {{yield (hash close=this.close) to="utilityActions"}}
     </div>
   </div>
 </div>

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -24,8 +24,16 @@ export interface HdsAppHeaderSignature {
   };
   Blocks: {
     logo?: [];
-    globalActions?: [];
-    utilityActions?: [];
+    globalActions?: [
+      {
+        close: () => void;
+      },
+    ];
+    utilityActions?: [
+      {
+        close: () => void;
+      },
+    ];
   };
   Element: HTMLDivElement;
 }
@@ -117,6 +125,12 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
   @action
   onClickToggle(): void {
     this._isOpen = !this._isOpen;
+  }
+
+  @action close(): void {
+    if (this._isOpen && !this._isDesktop) {
+      this._isOpen = false;
+    }
   }
 
   @action

--- a/packages/components/src/components/hds/app-side-nav/list/index.hbs
+++ b/packages/components/src/components/hds/app-side-nav/list/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<nav class="hds-app-side-nav__list-wrapper" aria-labelledby="hds-app-side-nav-header" ...attributes>
+<nav class="hds-app-side-nav__list-wrapper" aria-label="Application local" ...attributes>
   {{yield (hash ExtraBefore=(component "hds/yield"))}}
   <ul class="hds-app-side-nav__list" role="list" aria-labelledby={{this.titleIds}}>
     {{yield

--- a/showcase/app/components/mock/app/header/app-header.gts
+++ b/showcase/app/components/mock/app/header/app-header.gts
@@ -52,11 +52,11 @@ export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHe
           @href="#"
         />
       </:logo>
-      <:globalActions>
+      <:globalActions as |actions|>
         {{#if this.showOrgPicker}}
           <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text={{this.orgPickerLabel}} @icon="org" />
-            <dd.Checkmark>
+            <dd.Checkmark {{on "click" actions.close}}>
               my-organization
             </dd.Checkmark>
           </HdsDropdown>
@@ -66,8 +66,11 @@ export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHe
         {{#if this.showRegionPicker}}
           <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text="Europe" @icon="globe" />
-            <dd.Checkmark @selected={{true}}>Europe</dd.Checkmark>
-            <dd.Checkmark>Americas</dd.Checkmark>
+            <dd.Checkmark
+              @selected={{true}}
+              {{on "click" actions.close}}
+            >Europe</dd.Checkmark>
+            <dd.Checkmark {{on "click" actions.close}}>Americas</dd.Checkmark>
           </HdsDropdown>
         {{/if}}
 
@@ -77,10 +80,7 @@ export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHe
         <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
           <dd.ToggleIcon @icon="help" @text="help menu" />
           <dd.Title @text="Help & Support" />
-          <dd.Interactive
-            @route="page-components.app-header"
-            {{on "click" actions.close}}
-          >Documentation</dd.Interactive>
+          <dd.Interactive @href="#">Documentation</dd.Interactive>
           <dd.Interactive @href="#">Tutorials</dd.Interactive>
           <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
           <dd.Interactive @href="#">Changelog</dd.Interactive>

--- a/showcase/app/components/mock/app/header/app-header.gts
+++ b/showcase/app/components/mock/app/header/app-header.gts
@@ -4,6 +4,7 @@
  */
 
 import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
 
 // HDS components
 import {
@@ -61,7 +62,7 @@ export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHe
           </HdsDropdown>
         {{/if}}
       </:globalActions>
-      <:utilityActions>
+      <:utilityActions as |actions|>
         {{#if this.showRegionPicker}}
           <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
             <dd.ToggleButton @text="Europe" @icon="globe" />
@@ -76,7 +77,10 @@ export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHe
         <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
           <dd.ToggleIcon @icon="help" @text="help menu" />
           <dd.Title @text="Help & Support" />
-          <dd.Interactive @href="#">Documentation</dd.Interactive>
+          <dd.Interactive
+            @route="page-components.app-header"
+            {{on "click" actions.close}}
+          >Documentation</dd.Interactive>
           <dd.Interactive @href="#">Tutorials</dd.Interactive>
           <dd.Interactive @href="#">Terraform Provider</dd.Interactive>
           <dd.Interactive @href="#">Changelog</dd.Interactive>

--- a/showcase/tests/integration/components/hds/app-header/index-test.js
+++ b/showcase/tests/integration/components/hds/app-header/index-test.js
@@ -84,60 +84,37 @@ module('Integration | Component | hds/app-header/index', function (hooks) {
   });
 
   // Close callback
-  test('it should hide the actions when the "close" function is called from global actions', async function (assert) {
+  test('it should hide the actions when the "close" function is called in mobile view', async function (assert) {
     await render(hbs`
 <Hds::AppHeader id='test-app-header' @breakpoint='10000px'>
     <:globalActions as |actions|>
     <Hds::Button id='test-global-action' {{on 'click' actions.close}} @text="Global action" />
   </:globalActions>
+    <:utilityActions as |actions|>
+        <Hds::Button id='test-utility-action' {{on 'click' actions.close}} @text="Utility action" />
+  </:utilityActions>
 </Hds::AppHeader>`);
+
+    // test global actions close
     await click('.hds-app-header__menu-button');
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-open');
     await click('#test-global-action');
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
-  });
 
-  test('it should not do anything when the "close" function is called from global actions in desktop view', async function (assert) {
-    await render(hbs`
-<Hds::AppHeader id='test-app-header' >
-    <:globalActions as |actions|>
-    <Hds::Button id='test-global-action' {{on 'click' actions.close}} @text="Global action" />
-  </:globalActions>
-</Hds::AppHeader>`);
-    assert.dom('#test-app-header').hasClass('hds-app-header--is-desktop');
-    assert
-      .dom('#test-app-header')
-      .doesNotHaveClass('hds-app-header--menu-is-open');
-    assert
-      .dom('#test-app-header')
-      .doesNotHaveClass('hds-app-header--menu-is-closed');
-    await click('#test-global-action');
-    assert.dom('#test-app-header').hasClass('hds-app-header--is-desktop');
-    assert
-      .dom('#test-app-header')
-      .doesNotHaveClass('hds-app-header--menu-is-open');
-    assert
-      .dom('#test-app-header')
-      .doesNotHaveClass('hds-app-header--menu-is-closed');
-  });
-
-  test('it should hide the actions when the "close" function is called from utility actions', async function (assert) {
-    await render(hbs`
-<Hds::AppHeader id='test-app-header' @breakpoint='10000px'>
-  <:utilityActions as |actions|>
-        <Hds::Button id='test-utility-action' {{on 'click' actions.close}} @text="Utility action" />
-  </:utilityActions>
-</Hds::AppHeader>`);
+    // test utility actions close
     await click('.hds-app-header__menu-button');
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-open');
     await click('#test-utility-action');
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
   });
 
-  test('it should not do anything when the "close" function is called from utility actions in desktop view', async function (assert) {
+  test('it should not do anything when the "close" function is called in desktop view', async function (assert) {
     await render(hbs`
 <Hds::AppHeader id='test-app-header' >
-    <:utilityActions as |actions|>
+    <:globalActions as |actions|>
+    <Hds::Button id='test-global-action' {{on 'click' actions.close}} @text="Global action" />
+  </:globalActions>
+      <:utilityActions as |actions|>
     <Hds::Button id='test-utility-action' {{on 'click' actions.close}} @text="Utility action" />
   </:utilityActions>
 </Hds::AppHeader>`);
@@ -148,6 +125,18 @@ module('Integration | Component | hds/app-header/index', function (hooks) {
     assert
       .dom('#test-app-header')
       .doesNotHaveClass('hds-app-header--menu-is-closed');
+
+    // test global actions close
+    await click('#test-global-action');
+    assert.dom('#test-app-header').hasClass('hds-app-header--is-desktop');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-open');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-closed');
+
+    // test utility actions close
     await click('#test-utility-action');
     assert.dom('#test-app-header').hasClass('hds-app-header--is-desktop');
     assert

--- a/showcase/tests/integration/components/hds/app-header/index-test.js
+++ b/showcase/tests/integration/components/hds/app-header/index-test.js
@@ -83,6 +83,81 @@ module('Integration | Component | hds/app-header/index', function (hooks) {
     assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
   });
 
+  // Close callback
+  test('it should hide the actions when the "close" function is called from global actions', async function (assert) {
+    await render(hbs`
+<Hds::AppHeader id='test-app-header' @breakpoint='10000px'>
+    <:globalActions as |actions|>
+    <Hds::Button id='test-global-action' {{on 'click' actions.close}} @text="Global action" />
+  </:globalActions>
+</Hds::AppHeader>`);
+    await click('.hds-app-header__menu-button');
+    assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-open');
+    await click('#test-global-action');
+    assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
+  });
+
+  test('it should not do anything when the "close" function is called from global actions in desktop view', async function (assert) {
+    await render(hbs`
+<Hds::AppHeader id='test-app-header' >
+    <:globalActions as |actions|>
+    <Hds::Button id='test-global-action' {{on 'click' actions.close}} @text="Global action" />
+  </:globalActions>
+</Hds::AppHeader>`);
+    assert.dom('#test-app-header').hasClass('hds-app-header--is-desktop');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-open');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-closed');
+    await click('#test-global-action');
+    assert.dom('#test-app-header').hasClass('hds-app-header--is-desktop');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-open');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-closed');
+  });
+
+  test('it should hide the actions when the "close" function is called from utility actions', async function (assert) {
+    await render(hbs`
+<Hds::AppHeader id='test-app-header' @breakpoint='10000px'>
+  <:utilityActions as |actions|>
+        <Hds::Button id='test-utility-action' {{on 'click' actions.close}} @text="Utility action" />
+  </:utilityActions>
+</Hds::AppHeader>`);
+    await click('.hds-app-header__menu-button');
+    assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-open');
+    await click('#test-utility-action');
+    assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
+  });
+
+  test('it should not do anything when the "close" function is called from utility actions in desktop view', async function (assert) {
+    await render(hbs`
+<Hds::AppHeader id='test-app-header' >
+    <:utilityActions as |actions|>
+    <Hds::Button id='test-utility-action' {{on 'click' actions.close}} @text="Utility action" />
+  </:utilityActions>
+</Hds::AppHeader>`);
+    assert.dom('#test-app-header').hasClass('hds-app-header--is-desktop');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-open');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-closed');
+    await click('#test-utility-action');
+    assert.dom('#test-app-header').hasClass('hds-app-header--is-desktop');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-open');
+    assert
+      .dom('#test-app-header')
+      .doesNotHaveClass('hds-app-header--menu-is-closed');
+  });
+
   // OPTIONS
 
   // Breakpoint


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would return a close callback to the yielded blocks in AppHeader. 

It also fixes a small bug @MelSumner found where the accessible name for the nav element includes the word navigation, which makes screen readers announce "Application local navigation navigation"

To see the callbacks working, test [the demos on the AppHeader showcase page](https://hds-showcase-git-hds-5156-enterprise-nav-fixes-hashicorp.vercel.app/components/app-header#demo).
1. Go to the small viewport example
2. Open the actions menu
3. Click one of the options in the org picker or region picker
4. See that the actions menu is now closed

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5156](https://hashicorp.atlassian.net/browse/HDS-5156)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5156]: https://hashicorp.atlassian.net/browse/HDS-5156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ