### PR TITLE
`AppSideNav::List:Link` - Fix background issue

### DIFF
--- a/.changeset/fuzzy-pumpkins-fix.md
+++ b/.changeset/fuzzy-pumpkins-fix.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/app-side-nav-->
+`AppSideNav::List::Link` - Applied transparent background to the element to avoid ovelapping with previous item's focus ring
+<!-- END -->

--- a/.changeset/fuzzy-pumpkins-fix.md
+++ b/.changeset/fuzzy-pumpkins-fix.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/app-side-nav-->
-`AppSideNav::List::Link` - Applied transparent background to the element to avoid ovelapping with previous item's focus ring
+`AppSideNav::List::Link` - Applied transparent background to the element to avoid overlapping with previous item's focus ring
 <!-- END -->

--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -70,7 +70,6 @@
 
 // <li> element
 .hds-app-side-nav__list-item {
-  position: relative; // for the "active" state indicator
   list-style-type: none;
 
   & + & {
@@ -99,6 +98,8 @@
   &:focus,
   &.mock-focus {
     @include hds-focus-ring-with-pseudo-element();
+    // to move the item link above the siblings elements when they have a solid background (eg. active) so that the focus ring is not cut out
+    z-index: 1;
   }
 
   // :Hover
@@ -130,6 +131,7 @@
   // Important: This element does not doing anything when interacted with so should not change color according to state
   &.active,
   &.active:hover:focus {
+    position: relative; // for the "active" indicator bar to be correctly positioned
     background: var(--token-color-surface-strong);
 
     // indicator bar

--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -89,8 +89,8 @@
     var(--token-app-side-nav-body-list-item-padding-horizontal);
   color: var(--token-app-side-nav-color-foreground-primary);
   text-decoration: none;
-  background: var(--token-app-side-nav-color-surface-primary);
-  // "Link" could render as an HTML button element so this overrides the default border style in that case:
+  // "Link" could render as an HTML button element so these override the default background and border styles in that case
+  background: transparent;
   border-color: transparent;
   border-width: 0;
   border-radius: var(--token-app-side-nav-body-list-item-border-radius);

--- a/showcase/app/components/mock/app/sidebar/app-side-nav.gts
+++ b/showcase/app/components/mock/app/sidebar/app-side-nav.gts
@@ -4,11 +4,15 @@
  */
 
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import style from 'ember-style-modifier/modifiers/style';
 
 // HDS components
 import {
   HdsAppSideNav,
   HdsAppSideNavList,
+  HdsFormToggleField,
 } from '@hashicorp/design-system-components/components';
 
 // types
@@ -19,8 +23,7 @@ export interface MockAppSidebarAppSideNavSignature {
   Args: {
     isResponsive?: HdsAppSideNavSignature['Args']['isResponsive'];
     isCollapsible?: HdsAppSideNavSignature['Args']['isCollapsible'];
-    showHeader?: boolean;
-    showFooter?: boolean;
+    showDevToggle?: boolean;
   };
   Element: HdsAppSideNavSignature['Element'];
 }
@@ -28,16 +31,17 @@ export interface MockAppSidebarAppSideNavSignature {
 export default class MockAppSidebarAppSideNav extends Component<MockAppSidebarAppSideNavSignature> {
   isResponsive;
   isCollapsible;
-  showHeader;
-  showFooter;
+  @tracked showMockInteractionState = false;
 
   constructor(owner: Owner, args: MockAppSidebarAppSideNavSignature['Args']) {
     super(owner, args);
     this.isResponsive = this.args.isResponsive ?? true;
     this.isCollapsible = this.args.isCollapsible ?? true;
-    this.showHeader = this.args.showHeader ?? true;
-    this.showFooter = this.args.showFooter ?? true;
   }
+
+  toggleMockInteractionState = () => {
+    this.showMockInteractionState = !this.showMockInteractionState;
+  };
 
   <template>
     <HdsAppSideNav
@@ -57,10 +61,30 @@ export default class MockAppSidebarAppSideNav extends Component<MockAppSidebarAp
         as |SNL|
       >
         <SNL.Title>Services</SNL.Title>
-        <SNL.Link @text="Boundary" @icon="boundary" @href="#" />
-        <SNL.Link @text="Consul" @icon="consul" @href="#" />
-        <SNL.Link @text="Packer" @icon="packer" @href="#" />
-        <SNL.Link @text="Vault" @icon="vault" @href="#" />
+        <SNL.Link
+          @text={{if this.showMockInteractionState "isActive" "Boundary"}}
+          @icon="boundary"
+          @href="#"
+          class="active"
+        />
+        <SNL.Link
+          @text={{if this.showMockInteractionState ":focus" "Consul"}}
+          @icon="consul"
+          @href="#"
+          class="mock-focus"
+        />
+        <SNL.Link
+          @text={{if this.showMockInteractionState ":hover" "Packer"}}
+          @icon="packer"
+          @href="#"
+          class="mock-hover"
+        />
+        <SNL.Link
+          @text={{if this.showMockInteractionState ":active" "Vault"}}
+          @icon="vault"
+          @href="#"
+          class="mock-active"
+        />
         <SNL.Link
           @text="Vault Secrets"
           @icon="vault-secrets-square"
@@ -110,6 +134,18 @@ export default class MockAppSidebarAppSideNav extends Component<MockAppSidebarAp
           @icon="guide"
           @text="Documentation"
         />
+        {{#if @showDevToggle}}
+          <SNL.ExtraAfter>
+            <div {{style margin="32px 6px"}}>
+              <HdsFormToggleField
+                {{on "change" this.toggleMockInteractionState}}
+                as |F|
+              >
+                <F.Label>Show mock states</F.Label>
+              </HdsFormToggleField>
+            </div>
+          </SNL.ExtraAfter>
+        {{/if}}
       </HdsAppSideNavList>
     </HdsAppSideNav>
   </template>

--- a/showcase/app/styles/showcase-pages/app-side-nav.scss
+++ b/showcase/app/styles/showcase-pages/app-side-nav.scss
@@ -57,6 +57,7 @@ body.page-components-app-side-nav {
   }
 
   .shw-component-sim-app-side-nav-list-link-wrapper {
+    margin: 0;
     padding: var(--token-app-side-nav-wrapper-padding-horizontal) var(--token-app-side-nav-wrapper-padding-vertical);
     background: $shw-component-app-side-nav-background;
     border: 1px solid $shw-component-app-side-nav-border-color;

--- a/showcase/app/styles/showcase-pages/app-side-nav.scss
+++ b/showcase/app/styles/showcase-pages/app-side-nav.scss
@@ -34,7 +34,7 @@ body.page-components-app-side-nav {
   // used to simulate an "header" container for the app-side-nav
   .shw-component-sim-app-side-nav-header {
     width: 280px;
-    padding: var(--token-app-side-nav-wrapper-padding-horizontal) var(--token-app-side-nav-wrapper-padding-vertical);
+    padding: var(--token-app-side-nav-wrapper-padding-vertical) var(--token-app-side-nav-wrapper-padding-horizontal);
     background: $shw-component-app-side-nav-background;
     border: 1px solid $shw-component-app-side-nav-border-color;
   }
@@ -43,7 +43,7 @@ body.page-components-app-side-nav {
   .shw-component-sim-app-side-nav-body {
     width: 280px;
     margin: 0;
-    padding: var(--token-app-side-nav-wrapper-padding-horizontal) var(--token-app-side-nav-wrapper-padding-vertical);
+    padding: var(--token-app-side-nav-wrapper-padding-vertical) var(--token-app-side-nav-wrapper-padding-horizontal);
     background: $shw-component-app-side-nav-background;
     border: 1px solid $shw-component-app-side-nav-border-color;
   }
@@ -51,21 +51,21 @@ body.page-components-app-side-nav {
   .shw-component-app-side-nav-home-link-wrapper {
     width: 80px;
     height: 80px;
-    padding: var(--token-app-side-nav-wrapper-padding-horizontal) var(--token-app-side-nav-wrapper-padding-vertical);
+    padding: var(--token-app-side-nav-wrapper-padding-vertical) var(--token-app-side-nav-wrapper-padding-horizontal);
     background: $shw-component-app-side-nav-background;
     border: 1px solid $shw-component-app-side-nav-border-color;
   }
 
   .shw-component-sim-app-side-nav-list-link-wrapper {
     margin: 0;
-    padding: var(--token-app-side-nav-wrapper-padding-horizontal) var(--token-app-side-nav-wrapper-padding-vertical);
+    padding: var(--token-app-side-nav-wrapper-padding-vertical) var(--token-app-side-nav-wrapper-padding-horizontal);
     background: $shw-component-app-side-nav-background;
     border: 1px solid $shw-component-app-side-nav-border-color;
   }
 
   .shw-component-sim-app-side-nav-elem-wrapper {
     width: fit-content;
-    padding: var(--token-app-side-nav-wrapper-padding-horizontal) var(--token-app-side-nav-wrapper-padding-vertical);
+    padding: var(--token-app-side-nav-wrapper-padding-vertical) var(--token-app-side-nav-wrapper-padding-horizontal);
     background: $shw-component-app-side-nav-background;
   }
 
@@ -82,7 +82,7 @@ body.page-components-app-side-nav {
 
   .shw-component-sim-other-elements {
     width: fit-content;
-    padding: var(--token-app-side-nav-wrapper-padding-horizontal) var(--token-app-side-nav-wrapper-padding-vertical);
+    padding: var(--token-app-side-nav-wrapper-padding-vertical) var(--token-app-side-nav-wrapper-padding-horizontal);
     background: $shw-component-app-side-nav-background;
 
     .hds-app-side-nav {

--- a/showcase/app/templates/page-components/app-side-nav/index.hbs
+++ b/showcase/app/templates/page-components/app-side-nav/index.hbs
@@ -393,36 +393,43 @@
         <SG.Item @label={{state}}>
           <Shw::Flex as |SF|>
             <SF.Item @grow={{true}}>
-              <div class="shw-component-sim-app-side-nav-list-link-wrapper">
+              <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+                <Hds::AppSideNav::List::Link @text="Packer" @icon="packer" @href="#" />
                 <Hds::AppSideNav::List::Link
-                  @text="Boundary"
-                  @icon="boundary"
+                  @text="Terraform"
+                  @icon="terraform"
                   @badge="Alpha"
                   @count="3"
                   @href="#"
                   mock-state-value={{state}}
                 />
-              </div>
+                <Hds::AppSideNav::List::Link @text="Vagrant" @icon="vagrant" @href="#" />
+              </ul>
             </SF.Item>
             <SF.Item @grow={{true}}>
-              <div class="shw-component-sim-app-side-nav-list-link-wrapper">
+              <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+                <Hds::AppSideNav::List::Link @text="Packer" @icon="packer" @href="#" />
                 <Hds::AppSideNav::List::Link
                   @text="This is a long text that should go on two lines"
-                  @icon="boundary"
+                  @icon="terraform"
                   @href="#"
                   mock-state-value={{state}}
                 />
-              </div>
+                <Hds::AppSideNav::List::Link @text="Vagrant" @icon="vagrant" @href="#" />
+              </ul>
             </SF.Item>
             <SF.Item @grow={{true}}>
-              <div class="shw-component-sim-app-side-nav-list-link-wrapper">
+              <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+                <Hds::AppSideNav::List::Link @text="Packer" @icon="packer" @href="#" />
                 <Hds::AppSideNav::List::Link
-                  @text="Boundary"
-                  @icon="boundary"
+                  @text="Terraform"
+                  @icon="terraform"
+                  @href="#"
                   @hasSubItems={{true}}
                   mock-state-value={{state}}
                 />
-              </div>
+                <Hds::AppSideNav::List::Link @text="Vagrant" @icon="vagrant" @href="#" />
+              </ul>
             </SF.Item>
           </Shw::Flex>
         </SG.Item>
@@ -434,16 +441,18 @@
     {{#let (array "default" "hover" "active" "focus") as |states|}}
       {{#each states as |state|}}
         <SG.Item>
-          <div class="shw-component-sim-app-side-nav-list-link-wrapper">
+          <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+            <Hds::AppSideNav::List::Link @text="Packer" @icon="packer" @href="#" />
             <Hds::AppSideNav::List::Link
-              @text="Boundary"
-              @icon="boundary"
+              @text="Terraform"
+              @icon="terraform"
               @href="#"
               @hasSubItems={{true}}
               @isActive={{true}}
               mock-state-value={{state}}
             />
-          </div>
+            <Hds::AppSideNav::List::Link @text="Vagrant" @icon="vagrant" @href="#" />
+          </ul>
         </SG.Item>
       {{/each}}
     {{/let}}

--- a/showcase/app/templates/page-components/app-side-nav/index.hbs
+++ b/showcase/app/templates/page-components/app-side-nav/index.hbs
@@ -261,127 +261,183 @@
 
   <Shw::Grid @columns={{4}} as |SG|>
     <SG.Item @label="Just text">
-      <Hds::AppSideNav::List::Link @text="Boundary" @href="#" />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @text="Boundary" @href="#" />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @href="#" />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @href="#" />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text + badge">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @badge="Alpha" />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @badge="Alpha" />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text + count">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @count="3" />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @count="3" />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text + count + badge">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @count="3" @badge="Alpha" />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @count="3" @badge="Alpha" />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text + yielded badgecount/badge">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary">
-        <Hds::BadgeCount @type="inverted" @size="small" @text="3" />
-        <Hds::Badge @type="inverted" @size="small" @color="success" @text="Beta" />
-      </Hds::AppSideNav::List::Link>
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary">
+          <Hds::BadgeCount @type="inverted" @size="small" @text="3" />
+          <Hds::Badge @type="inverted" @size="small" @color="success" @text="Beta" />
+        </Hds::AppSideNav::List::Link>
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + long text">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="This is a long text that should go on two lines" />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="This is a long text that should go on two lines" />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + long text + count + badge">
-      <Hds::AppSideNav::List::Link
-        @icon="boundary"
-        @text="This is a long text that should go on two lines"
-        @count="3"
-        @badge="Alpha"
-      />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link
+          @icon="boundary"
+          @text="This is a long text that should go on two lines"
+          @count="3"
+          @badge="Alpha"
+        />
+      </ul>
     </SG.Item>
 
     <SG.Item @label="Text, hasSubItems">
-      <Hds::AppSideNav::List::Link @text="Boundary" @href="#" @hasSubItems={{true}} />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @text="Boundary" @href="#" @hasSubItems={{true}} />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text, hasSubItems">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @href="#" @hasSubItems={{true}} />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @href="#" @hasSubItems={{true}} />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text + badge, hasSubItems">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @badge="Alpha" @hasSubItems={{true}} />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @badge="Alpha" @hasSubItems={{true}} />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text + count, hasSubItems">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @count="3" @hasSubItems={{true}} />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @count="3" @hasSubItems={{true}} />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text + count + badge, hasSubItems">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @count="3" @badge="Alpha" @hasSubItems={{true}} />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link
+          @icon="boundary"
+          @text="Boundary"
+          @count="3"
+          @badge="Alpha"
+          @hasSubItems={{true}}
+        />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text + yielded badgecount/badge, hasSubItems">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @hasSubItems={{true}}>
-        <Hds::BadgeCount @type="inverted" @size="small" @text="3" />
-        <Hds::Badge @type="inverted" @size="small" @color="success" @text="Beta" />
-      </Hds::AppSideNav::List::Link>
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @hasSubItems={{true}}>
+          <Hds::BadgeCount @type="inverted" @size="small" @text="3" />
+          <Hds::Badge @type="inverted" @size="small" @color="success" @text="Beta" />
+        </Hds::AppSideNav::List::Link>
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + long text, hasSubItems">
-      <Hds::AppSideNav::List::Link
-        @icon="boundary"
-        @text="This is a long text that should go on two lines"
-        @hasSubItems={{true}}
-      />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link
+          @icon="boundary"
+          @text="This is a long text that should go on two lines"
+          @hasSubItems={{true}}
+        />
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + long text + count + badge, hasSubItems">
-      <Hds::AppSideNav::List::Link
-        @icon="boundary"
-        @text="This is a long text that should go on two lines"
-        @count="3"
-        @badge="Alpha"
-        @hasSubItems={{true}}
-      />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link
+          @icon="boundary"
+          @text="This is a long text that should go on two lines"
+          @count="3"
+          @badge="Alpha"
+          @hasSubItems={{true}}
+        />
+      </ul>
     </SG.Item>
 
     <SG.Item @label="Just yielded content">
-      <Hds::AppSideNav::List::Link>
-        <Shw::Placeholder @height="20px" @text="yielded content" />
-      </Hds::AppSideNav::List::Link>
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link>
+          <Shw::Placeholder @height="20px" @text="yielded content" />
+        </Hds::AppSideNav::List::Link>
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + yielded content">
       {{! we've added an empty label on purpose, to test the layout in this case }}
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="">
-        <Shw::Placeholder @height="20px" @text="yielded content" />
-      </Hds::AppSideNav::List::Link>
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="">
+          <Shw::Placeholder @height="20px" @text="yielded content" />
+        </Hds::AppSideNav::List::Link>
+      </ul>
     </SG.Item>
     <SG.Item @label="Icon + text + yielded content">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary">
-        <Shw::Placeholder @height="20px" @width="auto" @flex="1 1 0" @text="yielded content" />
-      </Hds::AppSideNav::List::Link>
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary">
+          <Shw::Placeholder @height="20px" @width="auto" @flex="1 1 0" @text="yielded content" />
+        </Hds::AppSideNav::List::Link>
+      </ul>
     </SG.Item>
     <SG.Item @label="With hasSubItems">
-      <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @hasSubItems={{true}}>
-        <Shw::Placeholder @height="20px" @width="auto" @flex="1 1 0" @text="yielded content" />
-      </Hds::AppSideNav::List::Link>
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="boundary" @text="Boundary" @hasSubItems={{true}}>
+          <Shw::Placeholder @height="20px" @width="auto" @flex="1 1 0" @text="yielded content" />
+        </Hds::AppSideNav::List::Link>
+      </ul>
     </SG.Item>
     <SG.Item @label="Text with no style">
-      <Hds::AppSideNav::List::Link>
-        This text needs local styling
-      </Hds::AppSideNav::List::Link>
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link>
+          This text needs local styling
+        </Hds::AppSideNav::List::Link>
+      </ul>
     </SG.Item>
     <SG.Item @label="Text with local style">
-      <Hds::AppSideNav::List::Link>
-        <span class="hds-typography-body-200 hds-font-weight-medium">
-          This text is locally styled
-        </span>
-      </Hds::AppSideNav::List::Link>
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link>
+          <span class="hds-typography-body-200 hds-font-weight-medium">
+            This text is locally styled
+          </span>
+        </Hds::AppSideNav::List::Link>
+      </ul>
     </SG.Item>
     <SG.Item @label="Default link">
-      <Hds::AppSideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @href="#" />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link @icon="hashicorp" @text="HashiCorp Cloud Platform" @href="#" />
+      </ul>
     </SG.Item>
     <SG.Item @label="External link">
-      <Hds::AppSideNav::List::Link
-        @icon="hashicorp"
-        @text="HashiCorp Cloud Platform"
-        @isHrefExternal={{true}}
-        @href="#"
-      />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link
+          @icon="hashicorp"
+          @text="HashiCorp Cloud Platform"
+          @isHrefExternal={{true}}
+          @href="#"
+        />
+      </ul>
     </SG.Item>
     <SG.Item @label="Internal link">
-      <Hds::AppSideNav::List::Link
-        @icon="hashicorp"
-        @text="HashiCorp Cloud Platform"
-        @isHrefExternal={{false}}
-        @href="#"
-      />
+      <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+        <Hds::AppSideNav::List::Link
+          @icon="hashicorp"
+          @text="HashiCorp Cloud Platform"
+          @isHrefExternal={{false}}
+          @href="#"
+        />
+      </ul>
     </SG.Item>
   </Shw::Grid>
 
@@ -457,6 +513,59 @@
       {{/each}}
     {{/let}}
   </Shw::Grid>
+
+  <Shw::Text::H4>Focus before/after</Shw::Text::H4>
+
+  {{#let (array "before" "after") as |positions|}}
+    {{#each positions as |position|}}
+      <Shw::Grid @columns={{4}} as |SG|>
+        {{#let (array "default" "active") as |states|}}
+          {{#each states as |state|}}
+            <SG.Item @label="{{state}} / focus {{position}}">
+              <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+                <Hds::AppSideNav::List::Link
+                  @text="Packer"
+                  @icon="packer"
+                  @href="#"
+                  mock-state-value={{if (eq position "before") "focus"}}
+                />
+                <Hds::AppSideNav::List::Link @text="Terraform" @icon="terraform" @href="#" mock-state-value={{state}} />
+                <Hds::AppSideNav::List::Link
+                  @text="Vagrant"
+                  @icon="vagrant"
+                  @href="#"
+                  mock-state-value={{if (eq position "after") "focus"}}
+                />
+              </ul>
+            </SG.Item>
+          {{/each}}
+        {{/let}}
+        <SG.Item @label="with @isActive=true / focus {{position}}">
+          <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
+            <Hds::AppSideNav::List::Link
+              @text="Packer"
+              @icon="packer"
+              @href="#"
+              mock-state-value={{if (eq position "before") "focus"}}
+            />
+            <Hds::AppSideNav::List::Link
+              @text="Terraform"
+              @icon="terraform"
+              @href="#"
+              @hasSubItems={{true}}
+              @isActive={{true}}
+            />
+            <Hds::AppSideNav::List::Link
+              @text="Vagrant"
+              @icon="vagrant"
+              @href="#"
+              mock-state-value={{if (eq position "after") "focus"}}
+            />
+          </ul>
+        </SG.Item>
+      </Shw::Grid>
+    {{/each}}
+  {{/let}}
 
   <Shw::Divider @level={{2}} />
 

--- a/showcase/app/templates/page-layouts/app-frame/frameless/demo-full-app-frame-with-app-header-and-app-side-nav.hbs
+++ b/showcase/app/templates/page-layouts/app-frame/frameless/demo-full-app-frame-with-app-header-and-app-side-nav.hbs
@@ -6,6 +6,9 @@
 {{page-title "AppFrame Component - Frameless"}}
 
 <Mock::App>
+  <:sidebar as |S|>
+    <S.SideNav @showDevToggle={{true}} />
+  </:sidebar>
   <:main as |M|>
     <M.PageHeader @showActionButton={{true}} />
     <M.GenericTextContent />


### PR DESCRIPTION
### :pushpin: Summary

This is a follow-up of #3026. 

I've noticed that the focused state of the `AppSideNav::List:Link` items was covered by the following item in the list:

<img width="290" height="306" alt="screenshot_5184" src="https://github.com/user-attachments/assets/c1c59321-d38b-4f09-8100-8dcf6c09c009" />

The reason is that in #3026 I have applied an explicit background to it, the same color as the backdrop of their container. 

This issue didn't happen in the previous implementation (`SideNav::List:Link`):
<img width="294" height="355" alt="screenshot_5185" src="https://github.com/user-attachments/assets/02f7963b-8376-46be-8859-a6f947a5d847" />

The reason for this difference is that before the focus was applied via a pseudo-element, so the `z-index` would take care of the stacking, while in the new implementation of the side navigation the focus is applied as box shadow.

This PR fixes the issue.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the showcase for the status of `AppSideNav::List:Link` to make the problem visible
- set a transparent background color for `.hds-app-side-nav__list-item-link`

👉 👉 👉 **Preview**: https://hds-showcase-git-sidenav-list-link-fix-backgro-cf8dad-hashicorp.vercel.app/components/app-side-nav#states

### :camera_flash: Screenshots

**Before:** 
<img width="1113" height="758" alt="screenshot_5186" src="https://github.com/user-attachments/assets/1bf4b82a-535b-49a1-8963-dfed3feb3a75" />

**After:** 
<img width="1106" height="760" alt="screenshot_5187" src="https://github.com/user-attachments/assets/235d17b4-6c3a-4396-b6f5-93403d3908aa" />

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-5153

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>