### PR TITLE
Alert, Tag, Text, Tooltip Button - Type fixes

### DIFF
--- a/packages/components/src/components/hds/alert/index.ts
+++ b/packages/components/src/components/hds/alert/index.ts
@@ -21,9 +21,9 @@ import type { HdsAlertDescriptionSignature } from './description.ts';
 import type { HdsIconSignature } from '../icon';
 import type Owner from '@ember/owner';
 
-export const TYPES: string[] = Object.values(HdsAlertTypeValues);
-export const DEFAULT_COLOR = HdsAlertColorValues.Neutral;
-export const COLORS: string[] = Object.values(HdsAlertColorValues);
+export const TYPES: HdsAlertTypes[] = Object.values(HdsAlertTypeValues);
+export const DEFAULT_COLOR: HdsAlertColors = HdsAlertColorValues.Neutral;
+export const COLORS: HdsAlertColors[] = Object.values(HdsAlertColorValues);
 
 export const MAPPING_COLORS_TO_ICONS = {
   [HdsAlertColorValues.Neutral]: 'info',

--- a/packages/components/src/components/hds/tag/index.ts
+++ b/packages/components/src/components/hds/tag/index.ts
@@ -14,9 +14,9 @@ import { HdsTagTooltipPlacementValues } from './types.ts';
 import type { HdsTagTooltipPlacements } from './types.ts';
 import type { HdsInteractiveSignature } from '../interactive/';
 
-export const COLORS: string[] = Object.values(HdsTagColorValues);
+export const COLORS: HdsTagColors[] = Object.values(HdsTagColorValues);
 export const DEFAULT_COLOR = HdsTagColorValues.Primary;
-export const TOOLTIP_PLACEMENTS: string[] = Object.values(
+export const TOOLTIP_PLACEMENTS: HdsTagTooltipPlacements[] = Object.values(
   HdsTagTooltipPlacementValues
 );
 export const DEFAULT_TOOLTIP_PLACEMENT = HdsTagTooltipPlacementValues.Top;

--- a/packages/components/src/components/hds/text/body.ts
+++ b/packages/components/src/components/hds/text/body.ts
@@ -25,7 +25,7 @@ type HdsTextBodySizeNumber = Extract<
 >;
 type HdsTextBodySizeString = `${HdsTextBodySizeNumber}`;
 export type HdsTextBodySizes = HdsTextBodySizeNumber | HdsTextBodySizeString;
-export const AVAILABLE_SIZES = [
+export const SIZES: HdsTextBodySizes[] = [
   HdsTextSizeValues.ThreeHundred,
   HdsTextSizeValues.TwoHundred,
   HdsTextSizeValues.OneHundred,
@@ -37,10 +37,7 @@ export type HdsTextBodyWeight = Extract<
   HdsTextWeights,
   'regular' | 'medium' | 'semibold'
 >;
-export const AVAILABLE_WEIGHTS_PER_SIZE: Record<
-  HdsTextBodySizes,
-  HdsTextBodyWeight[]
-> = {
+export const WEIGHTS_PER_SIZE: Record<HdsTextBodySizes, HdsTextBodyWeight[]> = {
   300: [
     HdsTextWeightValues.Regular,
     HdsTextWeightValues.Medium,
@@ -78,14 +75,7 @@ export interface HdsTextBodySignature {
 }
 
 export default class HdsTextBody extends Component<HdsTextBodySignature> {
-  /**
-   * Sets the "size" for the text
-   * Accepted values: see AVAILABLE_SIZES
-   *
-   * @param size
-   * @type {HdsTextBodySizes}
-   *
-   */
+  // Sets the "size" for the text
   get size(): HdsTextBodySizes {
     let { size = DEFAULT_SIZE } = this.args;
 
@@ -95,35 +85,28 @@ export default class HdsTextBody extends Component<HdsTextBodySignature> {
     }
 
     assert(
-      `@size for "Hds::Text::Body" must be one of the following: ${AVAILABLE_SIZES.join(
+      `@size for "Hds::Text::Body" must be one of the following: ${SIZES.join(
         ', '
       )}; received: ${size}`,
-      AVAILABLE_SIZES.includes(size)
+      SIZES.includes(size)
     );
 
     return size;
   }
 
-  /**
-   * Sets the "weight" for the text
-   * Accepted values: see AVAILABLE_WEIGHTS_PER_SIZE
-   *
-   * @param weight
-   * @type {HdsTextWeights}
-   *
-   */
+  // Sets the "weight" for the text
   get weight(): HdsTextWeights {
     const { weight = DEFAULT_WEIGHT } = this.args;
 
-    const availableWeights = AVAILABLE_WEIGHTS_PER_SIZE[this.size];
+    const weights = WEIGHTS_PER_SIZE[this.size];
 
     assert(
       `@weight for "Hds::Text::Body" with @size=${
         this.size
-      } must be one of the following: ${availableWeights.join(
+      } must be one of the following: ${weights.join(
         ', '
       )}; received: ${weight}`,
-      availableWeights.includes(weight)
+      weights.includes(weight)
     );
 
     return weight;

--- a/packages/components/src/components/hds/text/code.ts
+++ b/packages/components/src/components/hds/text/code.ts
@@ -25,7 +25,7 @@ type HdsTextCodeSizeNumber = Extract<
 >;
 type HdsTextCodeSizeString = `${HdsTextCodeSizeNumber}`;
 export type HdsTextCodeSizes = HdsTextCodeSizeNumber | HdsTextCodeSizeString;
-export const AVAILABLE_SIZES = [
+export const SIZES: HdsTextCodeSizes[] = [
   HdsTextSizeValues.ThreeHundred,
   HdsTextSizeValues.TwoHundred,
   HdsTextSizeValues.OneHundred,
@@ -34,10 +34,7 @@ export const DEFAULT_SIZE = HdsTextSizeValues.TwoHundred;
 
 export const DEFAULT_WEIGHT = HdsTextWeightValues.Regular;
 export type HdsTextCodeWeight = Extract<HdsTextWeights, 'regular' | 'bold'>;
-export const AVAILABLE_WEIGHTS_PER_SIZE: Record<
-  HdsTextCodeSizes,
-  HdsTextCodeWeight[]
-> = {
+export const WEIGHTS_PER_SIZE: Record<HdsTextCodeSizes, HdsTextCodeWeight[]> = {
   [HdsTextSizeValues.ThreeHundred]: [
     HdsTextWeightValues.Regular,
     HdsTextWeightValues.Bold,
@@ -72,14 +69,7 @@ export interface HdsTextCodeSignature {
 }
 
 export default class HdsTextCode extends Component<HdsTextCodeSignature> {
-  /**
-   * Sets the "size" for the text
-   * Accepted values: see AVAILABLE_SIZES
-   *
-   * @type {HdsTextCodeSizes}
-   *
-   * @param size
-   */
+  // Sets the "size" for the text
   get size(): HdsTextCodeSizes {
     let { size = DEFAULT_SIZE } = this.args;
 
@@ -89,35 +79,28 @@ export default class HdsTextCode extends Component<HdsTextCodeSignature> {
     }
 
     assert(
-      `@size for "Hds::Text::Code" must be one of the following: ${AVAILABLE_SIZES.join(
+      `@size for "Hds::Text::Code" must be one of the following: ${SIZES.join(
         ', '
       )}; received: ${size}`,
-      AVAILABLE_SIZES.includes(size)
+      SIZES.includes(size)
     );
 
     return size;
   }
 
-  /**
-   * Sets the "weight" for the text
-   * Accepted values: see AVAILABLE_WEIGHTS_PER_SIZE
-   *
-   * @type {string}
-   *
-   * @param variant
-   */
+  // Sets the "weight" for the text
   get weight(): HdsTextCodeWeight {
     const { weight = DEFAULT_WEIGHT } = this.args;
 
-    const availableWeights = AVAILABLE_WEIGHTS_PER_SIZE[this.size];
+    const weights = WEIGHTS_PER_SIZE[this.size];
 
     assert(
       `@weight for "Hds::Text::Code" with @size=${
         this.size
-      } must be one of the following: ${availableWeights.join(
+      } must be one of the following: ${weights.join(
         ', '
       )}; received: ${weight}`,
-      availableWeights.includes(weight)
+      weights.includes(weight)
     );
 
     return weight;

--- a/packages/components/src/components/hds/text/display.ts
+++ b/packages/components/src/components/hds/text/display.ts
@@ -21,7 +21,7 @@ export const DEFAULT_SIZE = HdsTextSizeValues.TwoHundred;
 
 // Filter out reverse mappings from enum
 // https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings
-export const SIZES = Object.values(HdsTextSizeValues).filter(
+export const SIZES: HdsTextSizes[] = Object.values(HdsTextSizeValues).filter(
   (v): boolean => typeof v === 'number'
 ) as HdsTextSizes[];
 
@@ -39,10 +39,7 @@ export const DEFAULT_WEIGHTS_PER_SIZE: Record<
   [HdsTextSizeValues.TwoHundred]: HdsTextWeightValues.Semibold,
   [HdsTextSizeValues.OneHundred]: HdsTextWeightValues.Medium,
 };
-export const AVAILABLE_WEIGHTS_PER_SIZE: Record<
-  HdsTextSizes,
-  HdsTextDisplayWeight[]
-> = {
+export const WEIGHTS_PER_SIZE: Record<HdsTextSizes, HdsTextDisplayWeight[]> = {
   [HdsTextSizeValues.FiveHundred]: [HdsTextWeightValues.Bold],
   [HdsTextSizeValues.FourHundred]: [
     HdsTextWeightValues.Medium,
@@ -78,14 +75,7 @@ export interface HdsTextDisplaySignature {
 }
 
 export default class HdsTextDisplay extends Component<HdsTextDisplaySignature> {
-  /**
-   * Sets the "size" for the text
-   * Accepted values: see AVAILABLE_SIZES
-   *
-   * @type {HdsTextSizes}
-   *
-   * @param size
-   */
+  // Sets the "size" for the text
   get size(): HdsTextSizes {
     let { size = DEFAULT_SIZE } = this.args;
 
@@ -104,26 +94,19 @@ export default class HdsTextDisplay extends Component<HdsTextDisplaySignature> {
     return size;
   }
 
-  /**
-   * Sets the "weight" for the text
-   * Accepted values: see AVAILABLE_WEIGHTS_PER_SIZE
-   *
-   * @type {HdsTextDisplayWeight}
-   *
-   * @param variant
-   */
+  // Sets the "weight" for the text
   get weight(): HdsTextDisplayWeight {
     let { weight } = this.args;
 
     if (weight) {
-      const availableWeights = AVAILABLE_WEIGHTS_PER_SIZE[this.size];
+      const weights = WEIGHTS_PER_SIZE[this.size];
       assert(
         `@weight for "Hds::Text::Display" with @size=${
           this.size
-        } must be one of the following: ${availableWeights.join(
+        } must be one of the following: ${weights.join(
           ', '
         )}; received: ${weight}`,
-        availableWeights.includes(weight)
+        weights.includes(weight)
       );
     } else {
       // use the default (first item in the array)

--- a/packages/components/src/components/hds/text/index.ts
+++ b/packages/components/src/components/hds/text/index.ts
@@ -15,8 +15,8 @@ import type {
   HdsTextWeights,
 } from './types.ts';
 
-export const AVAILABLE_COLORS: string[] = Object.values(HdsTextColorValues);
-export const AVAILABLE_ALIGNS: string[] = Object.values(HdsTextAlignValues);
+export const COLORS: HdsTextColors[] = Object.values(HdsTextColorValues);
+export const ALIGNS: HdsTextAligns[] = Object.values(HdsTextAlignValues);
 
 // A union of all types in the HTMLElementTagNameMap interface
 type AvailableElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap];
@@ -38,25 +38,14 @@ export interface HdsTextSignature {
 }
 
 export default class HdsText extends Component<HdsTextSignature> {
-  /**
-   * Get a tag to render based on the `@tag` argument passed or the value of `this.size` (via mapping)
-   *
-   * @method #componentTag
-   * @return {HdsTextTags} The html tag to use in the dynamic render of the component
-   */
+  // Get a tag to render based on the `@tag` argument passed or the value of `this.size` (via mapping)
   get componentTag(): HdsTextTags {
     const { tag = 'span' } = this.args;
 
     return tag;
   }
 
-  /**
-   * Sets the "variant" (style) for the text
-   * Accepted values: see AVAILABLE_VARIANTS
-   *
-   * @param variant
-   * @type {string}
-   */
+  // Sets the "variant" (style) for the text
   get variant(): string {
     const { group, size } = this.args;
 
@@ -65,66 +54,44 @@ export default class HdsText extends Component<HdsTextSignature> {
     return `${group}-${size}`;
   }
 
-  /**
-   * Sets the alignment of the text
-   * Accepted values: see AVAILABLE_ALIGNS
-   *
-   * @param align
-   * @type {HdsTextAligns}
-   */
+  // Sets the alignment of the text
   get align(): HdsTextAligns | undefined {
     const { align } = this.args;
 
     if (align) {
       assert(
-        `@align for "Hds::Text" must be one of the following: ${AVAILABLE_ALIGNS.join(
+        `@align for "Hds::Text" must be one of the following: ${ALIGNS.join(
           ', '
         )}; received: ${align}`,
-        AVAILABLE_ALIGNS.includes(align)
+        ALIGNS.includes(align)
       );
     }
 
     return align;
   }
 
-  /**
-   * Sets the color of the text as pre-defined value
-   * Accepted values: see AVAILABLE_COLORS
-   *
-   * @param color
-   * @type {HdsTextColors}
-   */
+  // Sets the color of the text as pre-defined value
   get predefinedColor(): HdsTextColors | undefined {
     const { color } = this.args;
 
-    if (color && AVAILABLE_COLORS.includes(color)) {
+    if (color && COLORS.includes(color as HdsTextColors)) {
       return color as HdsTextColors;
     } else {
       return undefined;
     }
   }
 
-  /**
-   * Sets the color of the text as custom value (via inline style)
-   *
-   * @param color
-   * @type {string}
-   */
+  // Sets the color of the text as custom value (via inline style)
   get customColor(): string | undefined {
     const { color } = this.args;
 
-    if (color && !AVAILABLE_COLORS.includes(color)) {
+    if (color && !COLORS.includes(color as HdsTextColors)) {
       return color as HdsTextColors;
     } else {
       return undefined;
     }
   }
 
-  /**
-   * Get the class names to apply to the component.
-   * @method #classNames
-   * @return {string} The "class" attribute to apply to the component.
-   */
   get classNames(): string {
     const classes = ['hds-text'];
 

--- a/packages/components/src/components/hds/tooltip-button/index.ts
+++ b/packages/components/src/components/hds/tooltip-button/index.ts
@@ -11,7 +11,9 @@ import type { Props as TippyProps } from 'tippy.js';
 import { HdsTooltipPlacementValues } from './types.ts';
 import type { HdsTooltipPlacements } from './types.ts';
 
-export const PLACEMENTS: string[] = Object.values(HdsTooltipPlacementValues);
+export const PLACEMENTS: HdsTooltipPlacements[] = Object.values(
+  HdsTooltipPlacementValues
+);
 
 export interface HdsTooltipSignature {
   Args: {

--- a/showcase/app/routes/page-components/text.js
+++ b/showcase/app/routes/page-components/text.js
@@ -7,19 +7,19 @@ import Route from '@ember/routing/route';
 
 import {
   SIZES as DISPLAY_AVAILABLE_SIZES,
-  AVAILABLE_WEIGHTS_PER_SIZE as DISPLAY_AVAILABLE_WEIGHTS_PER_SIZE,
+  WEIGHTS_PER_SIZE as DISPLAY_AVAILABLE_WEIGHTS_PER_SIZE,
 } from '@hashicorp/design-system-components/components/hds/text/display';
 import {
-  AVAILABLE_SIZES as BODY_AVAILABLE_SIZES,
-  AVAILABLE_WEIGHTS_PER_SIZE as BODY_AVAILABLE_WEIGHTS_PER_SIZE,
+  SIZES as BODY_AVAILABLE_SIZES,
+  WEIGHTS_PER_SIZE as BODY_AVAILABLE_WEIGHTS_PER_SIZE,
 } from '@hashicorp/design-system-components/components/hds/text/body';
 import {
-  AVAILABLE_SIZES as CODE_AVAILABLE_SIZES,
-  AVAILABLE_WEIGHTS_PER_SIZE as CODE_AVAILABLE_WEIGHTS_PER_SIZE,
+  SIZES as CODE_AVAILABLE_SIZES,
+  WEIGHTS_PER_SIZE as CODE_AVAILABLE_WEIGHTS_PER_SIZE,
 } from '@hashicorp/design-system-components/components/hds/text/code';
 import {
-  AVAILABLE_ALIGNS,
-  AVAILABLE_COLORS,
+  ALIGNS as AVAILABLE_ALIGNS,
+  COLORS as AVAILABLE_COLORS,
 } from '@hashicorp/design-system-components/components/hds/text/index';
 
 export default class PageComponentsTextRoute extends Route {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would create stronger type definitions, and resolve various showcase linting issues in the following components.

- Alert
- Tag
- Text
- TooltipButton

### :hammer_and_wrench: Detailed description

In all of the components listed above, some of the exported values are set to `string[]` instead of the array of values the export is associated with.

This cause type errors in the showcase as these exports were used to define testing values, and set as string arrays, but the component expected values from other types such as `HdsTextColors`.

In the Text component another update is to remove the `AVAILABLE_` prefix from all exports. This aligns with the naming structure commonly used in other components for these values. 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5163](https://hashicorp.atlassian.net/browse/HDS-5163)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5163]: https://hashicorp.atlassian.net/browse/HDS-5163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ