### PR TITLE
Remove `ember-math-helpers` dependency

### DIFF
--- a/.changeset/cold-timers-speak.md
+++ b/.changeset/cold-timers-speak.md
@@ -1,0 +1,9 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/advanced-table -->
+
+`AdvancedTable` - Removed `ember-math-helpers` dev dependency
+
+<!-- END -->

--- a/.changeset/cold-timers-speak.md
+++ b/.changeset/cold-timers-speak.md
@@ -3,7 +3,5 @@
 ---
 
 <!-- START components/table/advanced-table -->
-
 `AdvancedTable` - Removed `ember-math-helpers` dev dependency
-
 <!-- END -->

--- a/.changeset/cold-timers-speak.md
+++ b/.changeset/cold-timers-speak.md
@@ -2,7 +2,7 @@
 "@hashicorp/design-system-components": patch
 ---
 
-<!-- START components/advanced-table -->
+<!-- START components/table/advanced-table -->
 
 `AdvancedTable` - Removed `ember-math-helpers` dev dependency
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -98,7 +98,6 @@
     "concurrently": "^9.1.2",
     "ember-basic-dropdown": "^8.6.1",
     "ember-source": "^6.4.0",
-    "ember-math-helpers": "^5.0.0",
     "ember-template-lint": "^7.0.2",
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "eslint": "^9.23.0",

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -49,11 +49,8 @@
               @align={{column.align}}
               @tooltip={{column.tooltip}}
               @hasResizableColumns={{@hasResizableColumns}}
-              @isLastColumn={{eq index (sub this._tableModel.columns.length 1)}}
               @isStickyColumn={{if (and (eq index 0) @hasStickyFirstColumn) true}}
               @isStickyColumnPinned={{this.isStickyColumnPinned}}
-              @previousColumn={{get this._tableModel.columns (sub index 1)}}
-              @nextColumn={{get this._tableModel.columns (add index 1)}}
               @tableHeight={{this._tableHeight}}
               @onColumnResize={{@onColumnResize}}
               {{this._setColumnWidth column}}
@@ -68,12 +65,9 @@
               @hasResizableColumns={{@hasResizableColumns}}
               @isExpanded={{this._tableModel.expandState}}
               @isExpandable={{column.isExpandable}}
-              @isLastColumn={{eq index (sub this._tableModel.columns.length 1)}}
               @isStickyColumn={{if (and (eq index 0) @hasStickyFirstColumn) true}}
               @isStickyColumnPinned={{this.isStickyColumnPinned}}
               @isVisuallyHidden={{column.isVisuallyHidden}}
-              @previousColumn={{get this._tableModel.columns (sub index 1)}}
-              @nextColumn={{get this._tableModel.columns (add index 1)}}
               @tableHeight={{this._tableHeight}}
               @tooltip={{column.tooltip}}
               @onClickToggle={{this._tableModel.toggleAll}}

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -82,7 +82,7 @@ export default class HdsAdvancedTableColumn {
   }
 
   get isLast(): boolean {
-    return this.index === this.table.columns.length - 1;
+    return this.index !== -1 && this.index === this.table.columns.length - 1;
   }
 
   get siblings(): {

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -67,6 +67,41 @@ export default class HdsAdvancedTableColumn {
     }
   }
 
+  get index(): number {
+    const { columns } = this.table;
+
+    if (columns.length === 0) {
+      return -1;
+    }
+
+    return columns.findIndex((column) => column.key === this.key);
+  }
+
+  get isFirst(): boolean {
+    return this.index === 0;
+  }
+
+  get isLast(): boolean {
+    return this.index === this.table.columns.length - 1;
+  }
+
+  get siblings(): {
+    previous?: HdsAdvancedTableColumn;
+    next?: HdsAdvancedTableColumn;
+  } {
+    const { index, table } = this;
+    const { columns } = table;
+
+    if (index === -1) {
+      return {};
+    }
+
+    return {
+      previous: this.isFirst ? undefined : columns[index - 1],
+      next: this.isLast ? undefined : columns[index + 1],
+    };
+  }
+
   constructor(args: {
     column: HdsAdvancedTableColumnType;
     table: HdsAdvancedTableModel;

--- a/packages/components/src/components/hds/advanced-table/th-context-menu.hbs
+++ b/packages/components/src/components/hds/advanced-table/th-context-menu.hbs
@@ -14,7 +14,7 @@
     <D.Interactive
       @icon={{option.icon}}
       data-test-context-option-key={{option.key}}
-      {{on "click" (fn option.action @column @previousColumn @nextColumn D.close)}}
+      {{on "click" (fn option.action @column D.close)}}
     >
       {{option.label}}
     </D.Interactive>

--- a/packages/components/src/components/hds/advanced-table/th-context-menu.ts
+++ b/packages/components/src/components/hds/advanced-table/th-context-menu.ts
@@ -37,19 +37,25 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
   @tracked private _element!: HdsDropdownSignature['Element'];
 
   get _options(): HdsAdvancedTableThContextMenuOption[] {
-    const { hasResizableColumns } = this.args;
+    const { column, hasResizableColumns } = this.args;
 
     let options: HdsAdvancedTableThContextMenuOption[] = [];
 
     if (hasResizableColumns) {
+      if (!column.isLast) {
+        options = [
+          ...options,
+          {
+            key: 'resize-column',
+            label: 'Resize column',
+            icon: 'resize-column',
+            action: this.resizeColumn.bind(this),
+          },
+        ];
+      }
+
       options = [
         ...options,
-        {
-          key: 'resize-column',
-          label: 'Resize column',
-          icon: 'resize-column',
-          action: this.resizeColumn.bind(this),
-        },
         {
           key: 'reset-column-width',
           label: 'Reset column width',

--- a/packages/components/src/components/hds/advanced-table/th-context-menu.ts
+++ b/packages/components/src/components/hds/advanced-table/th-context-menu.ts
@@ -19,8 +19,6 @@ interface HdsAdvancedTableThContextMenuOption {
   icon: HdsDropdownToggleIconSignature['Args']['icon'];
   action: (
     column: HdsAdvancedTableColumn,
-    previousColumn?: HdsAdvancedTableColumn,
-    nextColumn?: HdsAdvancedTableColumn,
     dropdownCloseCallback?: () => void
   ) => void;
 }
@@ -28,8 +26,6 @@ interface HdsAdvancedTableThContextMenuOption {
 export interface HdsAdvancedTableThContextMenuSignature {
   Args: {
     column: HdsAdvancedTableColumn;
-    previousColumn?: HdsAdvancedTableColumn;
-    nextColumn?: HdsAdvancedTableColumn;
     hasResizableColumns?: boolean;
     resizeHandleElement?: HdsAdvancedTableThResizeHandleSignature['Element'];
     onColumnResize?: HdsAdvancedTableSignature['Args']['onColumnResize'];
@@ -74,11 +70,11 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
   @action
   resetColumnWidth(
     column: HdsAdvancedTableColumn,
-    previousColumn?: HdsAdvancedTableColumn,
-    nextColumn?: HdsAdvancedTableColumn,
     dropdownCloseCallback?: () => void
   ): void {
     const { onColumnResize } = this.args;
+
+    const { previous: previousColumn, next: nextColumn } = column.siblings;
 
     previousColumn?.onNextColumnWidthRestored(column.imposedWidthDelta);
     nextColumn?.onPreviousColumnWidthRestored();

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
@@ -52,7 +52,6 @@ function calculateEffectiveDelta(
 export interface HdsAdvancedTableThResizeHandleSignature {
   Args: {
     column: HdsAdvancedTableColumn;
-    nextColumn?: HdsAdvancedTableColumn;
     hasResizableColumns: HdsAdvancedTableSignature['Args']['hasResizableColumns'];
     tableHeight?: number;
     onColumnResize?: HdsAdvancedTableSignature['Args']['onColumnResize'];
@@ -129,7 +128,8 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     event.preventDefault();
     event.stopPropagation();
 
-    const { column, nextColumn } = this.args;
+    const { column } = this.args;
+    const { next: nextColumn } = column.siblings;
 
     const currentColumnPxWidth = column.pxWidth;
     const currentNextColumnPxWidth = nextColumn?.pxWidth;
@@ -167,7 +167,8 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     event.preventDefault();
     event.stopPropagation();
 
-    const { column, nextColumn } = this.args;
+    const { column } = this.args;
+    const { next: nextColumn } = column.siblings;
 
     this.resizing = {
       startX: event.clientX,
@@ -218,7 +219,8 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
 
     event.preventDefault();
 
-    const { column, nextColumn } = this.args;
+    const { column } = this.args;
+    const { next: nextColumn } = column.siblings;
     const { startX, startColumnPxWidth, startNextColumnPxWidth } =
       this.resizing;
     const deltaX = event.clientX - startX;
@@ -236,7 +238,8 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     window.removeEventListener('pointermove', this._boundResize);
     window.removeEventListener('pointerup', this._boundStopResize);
 
-    const { column, nextColumn } = this.args;
+    const { column } = this.args;
+    const { next: nextColumn } = column.siblings;
 
     this._setNextColumnImposedWidthDelta(nextColumn, this._nextColumnDelta);
 

--- a/packages/components/src/components/hds/advanced-table/th-sort.hbs
+++ b/packages/components/src/components/hds/advanced-table/th-sort.hbs
@@ -47,18 +47,15 @@
         {{#if this.showContextMenu}}
           <Hds::AdvancedTable::ThContextMenu
             @column={{@column}}
-            @previousColumn={{@previousColumn}}
-            @nextColumn={{@nextColumn}}
             @hasResizableColumns={{@hasResizableColumns}}
             @resizeHandleElement={{this._resizeHandleElement}}
             @onColumnResize={{@onColumnResize}}
           />
         {{/if}}
 
-        {{#if (and @hasResizableColumns (not @isLastColumn))}}
+        {{#if (and @hasResizableColumns (not @column.isLast))}}
           <Hds::AdvancedTable::ThResizeHandle
             @column={{@column}}
-            @nextColumn={{@nextColumn}}
             @hasResizableColumns={{@hasResizableColumns}}
             @tableHeight={{@tableHeight}}
             @onColumnResize={{@onColumnResize}}

--- a/packages/components/src/components/hds/advanced-table/th-sort.ts
+++ b/packages/components/src/components/hds/advanced-table/th-sort.ts
@@ -9,7 +9,6 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { focusable, type FocusableElement } from 'tabbable';
-import HdsAdvancedTableColumn from './models/column.ts';
 import type Owner from '@ember/owner';
 import { modifier } from 'ember-modifier';
 
@@ -44,10 +43,7 @@ export interface HdsAdvancedTableThSortSignature {
     tooltip?: string;
     rowspan?: number;
     colspan?: number;
-    previousColumn?: HdsAdvancedTableColumn;
-    nextColumn?: HdsAdvancedTableColumn;
     tableHeight?: number;
-    isLastColumn?: boolean;
     isStickyColumn?: boolean;
     isStickyColumnPinned?: boolean;
     onColumnResize?: HdsAdvancedTableSignature['Args']['onColumnResize'];

--- a/packages/components/src/components/hds/advanced-table/th.hbs
+++ b/packages/components/src/components/hds/advanced-table/th.hbs
@@ -69,18 +69,15 @@
       {{#if this.showContextMenu}}
         <Hds::AdvancedTable::ThContextMenu
           @column={{@column}}
-          @previousColumn={{@previousColumn}}
-          @nextColumn={{@nextColumn}}
           @hasResizableColumns={{@hasResizableColumns}}
           @resizeHandleElement={{this._resizeHandleElement}}
           @onColumnResize={{@onColumnResize}}
         />
       {{/if}}
 
-      {{#if (and @hasResizableColumns (not @isLastColumn))}}
+      {{#if (and @hasResizableColumns (not @column.isLast))}}
         <Hds::AdvancedTable::ThResizeHandle
           @column={{@column}}
-          @nextColumn={{@nextColumn}}
           @hasResizableColumns={{@hasResizableColumns}}
           @tableHeight={{@tableHeight}}
           @onColumnResize={{@onColumnResize}}

--- a/packages/components/src/components/hds/advanced-table/th.ts
+++ b/packages/components/src/components/hds/advanced-table/th.ts
@@ -38,13 +38,10 @@ export interface HdsAdvancedTableThSignature {
     hasResizableColumns?: boolean;
     isExpanded?: HdsAdvancedTableExpandState;
     isExpandable?: boolean;
-    isLastColumn?: boolean;
     isStickyColumn?: boolean;
     isStickyColumnPinned?: boolean;
     isVisuallyHidden?: boolean;
     newLabel?: string;
-    previousColumn?: HdsAdvancedTableColumn;
-    nextColumn?: HdsAdvancedTableColumn;
     parentId?: string;
     rowspan?: number;
     scope?: HdsAdvancedTableScope;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,9 +253,6 @@ importers:
       ember-basic-dropdown:
         specifier: ^8.6.1
         version: 8.6.2(@babel/core@7.27.1)(@ember/string@4.0.1)(@ember/test-helpers@4.0.4(@babel/core@7.27.1)(@glint/template@1.5.2)(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)))(@glimmer/component@1.1.2(@babel/core@7.27.1))(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.27.1))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.2(@babel/core@7.27.1)))(@glint/template@1.5.2)(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5))
-      ember-math-helpers:
-        specifier: ^5.0.0
-        version: 5.0.0(@babel/core@7.27.1)(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5))
       ember-source:
         specifier: ^6.4.0
         version: 6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)
@@ -9832,7 +9829,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.13.0:

--- a/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
+++ b/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
@@ -229,4 +229,252 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
       'width is restored to original value',
     );
   });
+
+  test('index getter returns correct column position', function (assert) {
+    // Create mock table with multiple columns
+    const mockTable = {
+      columns: [
+        new HdsAdvancedTableColumn({
+          column: { label: 'First', key: 'first' },
+          table: null,
+        }),
+        new HdsAdvancedTableColumn({
+          column: { label: 'Second', key: 'second' },
+          table: null,
+        }),
+        new HdsAdvancedTableColumn({
+          column: { label: 'Third', key: 'third' },
+          table: null,
+        }),
+      ],
+    };
+
+    // Set table reference for each column
+    mockTable.columns.forEach((col) => (col.table = mockTable));
+
+    assert.strictEqual(
+      mockTable.columns[0].index,
+      0,
+      'first column has index 0',
+    );
+    assert.strictEqual(
+      mockTable.columns[1].index,
+      1,
+      'second column has index 1',
+    );
+    assert.strictEqual(
+      mockTable.columns[2].index,
+      2,
+      'third column has index 2',
+    );
+  });
+
+  test('index getter returns -1 when table has no columns', function (assert) {
+    const mockTable = { columns: [] };
+    const column = new HdsAdvancedTableColumn({
+      column: { label: 'Test', key: 'test' },
+      table: mockTable,
+    });
+
+    assert.strictEqual(column.index, -1, 'returns -1 when no columns exist');
+  });
+
+  test('index getter returns -1 when column key does not exist in table', function (assert) {
+    const mockTable = {
+      columns: [
+        new HdsAdvancedTableColumn({
+          column: { label: 'Other', key: 'other' },
+          table: null,
+        }),
+      ],
+    };
+    mockTable.columns[0].table = mockTable;
+
+    const column = new HdsAdvancedTableColumn({
+      column: { label: 'Test', key: 'nonexistent' },
+      table: mockTable,
+    });
+
+    assert.strictEqual(
+      column.index,
+      -1,
+      'returns -1 when column key not found',
+    );
+  });
+
+  test('isFirst getter identifies first column correctly', function (assert) {
+    const mockTable = {
+      columns: [
+        new HdsAdvancedTableColumn({
+          column: { label: 'First', key: 'first' },
+          table: null,
+        }),
+        new HdsAdvancedTableColumn({
+          column: { label: 'Second', key: 'second' },
+          table: null,
+        }),
+      ],
+    };
+
+    mockTable.columns.forEach((col) => (col.table = mockTable));
+
+    assert.true(
+      mockTable.columns[0].isFirst,
+      'first column returns true for isFirst',
+    );
+    assert.false(
+      mockTable.columns[1].isFirst,
+      'second column returns false for isFirst',
+    );
+  });
+
+  test('isFirst getter returns false when index is -1', function (assert) {
+    const mockTable = { columns: [] };
+    const column = new HdsAdvancedTableColumn({
+      column: { label: 'Test', key: 'test' },
+      table: mockTable,
+    });
+
+    assert.false(column.isFirst, 'returns false when index is -1');
+  });
+
+  test('isLast getter identifies last column correctly', function (assert) {
+    const mockTable = {
+      columns: [
+        new HdsAdvancedTableColumn({
+          column: { label: 'First', key: 'first' },
+          table: null,
+        }),
+        new HdsAdvancedTableColumn({
+          column: { label: 'Second', key: 'second' },
+          table: null,
+        }),
+        new HdsAdvancedTableColumn({
+          column: { label: 'Third', key: 'third' },
+          table: null,
+        }),
+      ],
+    };
+
+    mockTable.columns.forEach((col) => (col.table = mockTable));
+
+    assert.false(
+      mockTable.columns[0].isLast,
+      'first column returns false for isLast',
+    );
+    assert.false(
+      mockTable.columns[1].isLast,
+      'middle column returns false for isLast',
+    );
+    assert.true(
+      mockTable.columns[2].isLast,
+      'last column returns true for isLast',
+    );
+  });
+
+  test('isLast getter returns false when index is -1', function (assert) {
+    const mockTable = { columns: [] };
+    const column = new HdsAdvancedTableColumn({
+      column: { label: 'Test', key: 'test' },
+      table: mockTable,
+    });
+
+    assert.false(column.isLast, 'returns false when index is -1');
+  });
+
+  test('siblings getter returns correct previous and next columns', function (assert) {
+    const mockTable = {
+      columns: [
+        new HdsAdvancedTableColumn({
+          column: { label: 'First', key: 'first' },
+          table: null,
+        }),
+        new HdsAdvancedTableColumn({
+          column: { label: 'Second', key: 'second' },
+          table: null,
+        }),
+        new HdsAdvancedTableColumn({
+          column: { label: 'Third', key: 'third' },
+          table: null,
+        }),
+      ],
+    };
+
+    mockTable.columns.forEach((col) => (col.table = mockTable));
+
+    // Test first column siblings
+    const firstSiblings = mockTable.columns[0].siblings;
+    assert.strictEqual(
+      firstSiblings.previous,
+      undefined,
+      'first column has no previous sibling',
+    );
+    assert.strictEqual(
+      firstSiblings.next,
+      mockTable.columns[1],
+      'first column next is second column',
+    );
+
+    // Test middle column siblings
+    const middleSiblings = mockTable.columns[1].siblings;
+    assert.strictEqual(
+      middleSiblings.previous,
+      mockTable.columns[0],
+      'middle column previous is first column',
+    );
+    assert.strictEqual(
+      middleSiblings.next,
+      mockTable.columns[2],
+      'middle column next is third column',
+    );
+
+    // Test last column siblings
+    const lastSiblings = mockTable.columns[2].siblings;
+    assert.strictEqual(
+      lastSiblings.previous,
+      mockTable.columns[1],
+      'last column previous is second column',
+    );
+    assert.strictEqual(
+      lastSiblings.next,
+      undefined,
+      'last column has no next sibling',
+    );
+  });
+
+  test('siblings getter returns empty object when index is -1', function (assert) {
+    const mockTable = { columns: [] };
+    const column = new HdsAdvancedTableColumn({
+      column: { label: 'Test', key: 'test' },
+      table: mockTable,
+    });
+
+    const siblings = column.siblings;
+    assert.deepEqual(siblings, {}, 'returns empty object when index is -1');
+  });
+
+  test('siblings getter works with single column', function (assert) {
+    const mockTable = {
+      columns: [
+        new HdsAdvancedTableColumn({
+          column: { label: 'Only', key: 'only' },
+          table: null,
+        }),
+      ],
+    };
+
+    mockTable.columns[0].table = mockTable;
+
+    const siblings = mockTable.columns[0].siblings;
+    assert.strictEqual(
+      siblings.previous,
+      undefined,
+      'single column has no previous sibling',
+    );
+    assert.strictEqual(
+      siblings.next,
+      undefined,
+      'single column has no next sibling',
+    );
+  });
 });


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will remove the `ember-math-helpers` dependency in favor of a more declarative approach.

### :hammer_and_wrench: Detailed description

Instead of calculating the index of an AdvancedTable column in-template, the `HdsAdvancedTableColumn` model will maintain references to its siblings, making it easy to determine them at any level of the component hierarchy.

Other:
- Removed erroneous "Resize column" option from the last column in the table's context menu

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>