### PR TITLE
 `AppSideNav::Panel` - Fix focus ring cut off issue (HDS-5165)

### DIFF
--- a/.changeset/rich-suits-count.md
+++ b/.changeset/rich-suits-count.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/app-side-nav-->
-`AppSideNav::Panel - Fixed issue causing focusring of first and last items within the Panel to be cut off
+`AppSideNav::Panel - Fixed issue causing the focus ring of the first and last items within the Panel to be cut off
 <!-- END -->

--- a/.changeset/rich-suits-count.md
+++ b/.changeset/rich-suits-count.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
+<!-- START components/app-side-nav-->
 `AppSideNav::Panel - Fixed issue causing focusring of first and last items within the Panel to be cut off
+<!-- END -->

--- a/.changeset/rich-suits-count.md
+++ b/.changeset/rich-suits-count.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppSideNav::Panel - Fixed issue causing focusring of first and last items within the Panel to be cut off

--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -35,14 +35,11 @@
 .hds-app-side-nav__content-panel {
   padding: 0 var(--token-app-side-nav-wrapper-padding-horizontal);
 
-  // the panel itself should not be scrollable,
-  // applying the style in this way prevents focus rings from being cut off
-  &:not(:has(:focus, .mock-focus)) {
-    overflow: hidden;
-  }
-
   &[aria-hidden="true"] {
     max-height: 0; // prevents hidden panels from causing scrolling
+    // prevent unwanted scrolling when navigating from panel with long content to panel with short content
+    // applying only to hidden panels, prevents Item focus rings from being cut off
+    overflow: hidden;
   }
 }
 

--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -34,7 +34,12 @@
 
 .hds-app-side-nav__content-panel {
   padding: 0 var(--token-app-side-nav-wrapper-padding-horizontal);
-  overflow: hidden; // the panel itself does not need to be scrollable
+
+  // the panel itself should not be scrollable,
+  // applying the style in this way prevents focus rings from being cut off
+  &:not(:has(:focus, .mock-focus)) {
+    overflow: hidden;
+  }
 
   &[aria-hidden="true"] {
     max-height: 0; // prevents hidden panels from causing scrolling


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes an issue with the focus ring of top and bottom items being cut off when used inside the `AppSideNav` Panel.

**Preview**: https://hds-showcase-git-kristin-hds-5165-fix-appsiden-ca24d0-hashicorp.vercel.app/components/app-side-nav

**To test**: tab through links within AppSideNav examples using content injected via portal

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-5165](https://hashicorp.atlassian.net/browse/HDS-5165)
* Related PR: https://github.com/hashicorp/design-system/pull/3032

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5165]: https://hashicorp.atlassian.net/browse/HDS-5165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ