### PR TITLE
`CodeBlock`: fix type of exported const

### DIFF
--- a/packages/components/src/components/hds/code-block/index.ts
+++ b/packages/components/src/components/hds/code-block/index.ts
@@ -44,7 +44,9 @@ import 'prismjs/components/prism-yaml';
 import 'prismjs/components/prism-markup-templating';
 import 'prismjs/components/prism-handlebars';
 
-export const LANGUAGES: string[] = Object.values(HdsCodeBlockLanguageValues);
+export const LANGUAGES: HdsCodeBlockLanguages[] = Object.values(
+  HdsCodeBlockLanguageValues
+);
 
 export interface HdsCodeBlockSignature {
   Args: {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the type of the exported array from CodeBlock.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>