### PR TITLE
Mini Hack: `Layout Grid` - responsive column widths

### DIFF
--- a/packages/components/src/components/hds/layout/grid/index.ts
+++ b/packages/components/src/components/hds/layout/grid/index.ts
@@ -29,6 +29,11 @@ export interface HdsLayoutGridSignature {
     tag?: AvailableTagNames;
     columnMinWidth?: string;
     columnWidth?: string;
+
+    columnWidthSm?: string;
+    columnWidthMd?: string;
+    columnWidthLg?: string;
+
     align?: HdsLayoutGridAligns;
     gap?: HdsLayoutGridGaps | [HdsLayoutGridGaps, HdsLayoutGridGaps];
   };
@@ -104,6 +109,15 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
     const inlineStyles: {
       '--hds-layout-grid-column-min-width'?: string;
       '--hds-layout-grid-column-fill-type'?: string;
+
+      // responsize
+      '--hds-layout-grid-column-width-sm'?: string;
+      '--hds-layout-grid-column-width-md'?: string;
+      '--hds-layout-grid-column-width-lg'?: string;
+
+      '--hds-layout-grid-column-fill-type-sm'?: string;
+      '--hds-layout-grid-column-fill-type-md'?: string;
+      '--hds-layout-grid-column-fill-type-lg'?: string;
     } = {};
 
     // if both columnMinWidth and columnWidth are passed in, we throw an error
@@ -119,6 +133,25 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
       inlineStyles['--hds-layout-grid-column-min-width'] =
         this.args.columnWidth;
       inlineStyles['--hds-layout-grid-column-fill-type'] = 'auto-fill';
+    }
+
+    // Responsize column widths
+    if (this.args.columnWidthSm) {
+      inlineStyles['--hds-layout-grid-column-width-sm'] =
+        this.args.columnWidthSm;
+      inlineStyles['--hds-layout-grid-column-fill-type-sm'] = 'auto-fill';
+    }
+
+    if (this.args.columnWidthMd) {
+      inlineStyles['--hds-layout-grid-column-width-md'] =
+        this.args.columnWidthMd;
+      inlineStyles['--hds-layout-grid-column-fill-type-md'] = 'auto-fill';
+    }
+
+    if (this.args.columnWidthLg) {
+      inlineStyles['--hds-layout-grid-column-width-lg'] =
+        this.args.columnWidthLg;
+      inlineStyles['--hds-layout-grid-column-fill-type-lg'] = 'auto-fill';
     }
 
     return inlineStyles;
@@ -141,6 +174,19 @@ export default class HdsLayoutGrid extends Component<HdsLayoutGridSignature> {
         classes.push(`hds-layout-grid--row-gap-${this.gap[0]}`);
         classes.push(`hds-layout-grid--column-gap-${this.gap[0]}`);
       }
+    }
+
+    // add classes based on responsive width arguments
+    if (this.args.columnWidthSm) {
+      classes.push('hds-layout-grid--column-width-sm');
+    }
+
+    if (this.args.columnWidthMd) {
+      classes.push('hds-layout-grid--column-width-md');
+    }
+
+    if (this.args.columnWidthLg) {
+      classes.push('hds-layout-grid--column-width-lg');
     }
 
     return classes.join(' ');

--- a/packages/components/src/styles/components/layout/grid.scss
+++ b/packages/components/src/styles/components/layout/grid.scss
@@ -7,17 +7,21 @@
 // LAYOUT > GRID
 //
 
+@use "../../mixins/breakpoints" as *;
+
 .hds-layout-grid {
   // Note: "Unitless 0" <length>s aren’t supported in math functions so we use 0px as a default value within calc()
   // https://drafts.csswg.org/css-values/#calc-type-checking
-  // We initialize the variable here to prevent inheritance issues in nested grids
+
+  // We initialize the variables here to prevent inheritance issues in nested grids
   --hds-layout-grid-column-min-width: 0px;
+  --hds-layout-grid-column-fill-type: auto-fit;
 
   display: grid;
 
   // The column gap value is subtracted from the column-min-width to prevent overflow & simplify API for consumers
   grid-template-columns: repeat(
-    var(--hds-layout-grid-column-fill-type, auto-fit),
+    var(--hds-layout-grid-column-fill-type),
     minmax(calc(var(--hds-layout-grid-column-min-width) - var(--hds-layout-grid-column-gap)), 1fr)
   );
 
@@ -25,6 +29,41 @@
   // For the gap size variants, we override the value of the gap custom properties to set the desired sizes.
   // These variables can be used by the consumers as an escape hatch if they need to set non-standard gap values (but adds a bit of friction to it)
   gap: var(--hds-layout-grid-row-gap) var(--hds-layout-grid-column-gap);
+}
+
+// responsive column widths (sm, md, lg)
+
+// Note: We repeat the calculation using the view specific variables as
+// resetting just the variable values themselves doesn't work as the inline styles take precedence
+
+// "sm" view, 0–768px (mobile devices)
+.hds-layout-grid--column-width-sm {
+  @include hds-breakpoint-below("md") {
+    grid-template-columns: repeat(
+      var(--hds-layout-grid-column-fill-type-sm),
+      minmax(calc(var(--hds-layout-grid-column-width-sm) - var(--hds-layout-grid-column-gap)), 1fr)
+    );
+  }
+}
+
+// "md" view, 768px–1088px (tablets and small laptops)
+.hds-layout-grid--column-width-md {
+  @include hds-breakpoint-between("md", "lg") {
+    grid-template-columns: repeat(
+      var(--hds-layout-grid-column-fill-type-md),
+      minmax(calc(var(--hds-layout-grid-column-width-md) - var(--hds-layout-grid-column-gap)), 1fr)
+    );
+  }
+}
+
+// "lg" view, 1088px–above (large laptops and desktops)
+.hds-layout-grid--column-width-lg {
+  @include hds-breakpoint-above("lg") {
+    grid-template-columns: repeat(
+      var(--hds-layout-grid-column-fill-type-lg),
+      minmax(calc(var(--hds-layout-grid-column-width-lg) - var(--hds-layout-grid-column-gap)), 1fr)
+    );
+  }
 }
 
 // align

--- a/showcase/app/templates/page-layouts/grid.hbs
+++ b/showcase/app/templates/page-layouts/grid.hbs
@@ -106,6 +106,45 @@
         </Hds::Layout::Grid>
       </Shw::Outliner>
     </SG.Item>
+
+    <SG.Item @label="50% width columns">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @gap="24" @columnWidth="50%">
+          <Shw::Placeholder @text="#1" @height="40" />
+          <Shw::Placeholder @text="#2" @height="40" />
+          <Shw::Placeholder @text="#3" @height="40" />
+          <Shw::Placeholder @text="#4" @height="40" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
+  <Shw::Text::H3>Responsive column width</Shw::Text::H3>
+
+  <Shw::Grid @columns={{1}} @gap="1.5rem" class="shw-layout-grid-example-tint-flex-items" as |SG|>
+    <SG.Item @label="sm view = 1 column, md view = 2 columns, & lg view = 3 columns">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @gap="24" @columnWidthSm="100%" @columnWidthMd="50%" @columnWidthLg="33.33%">
+          <Shw::Placeholder @text="#1" @height="40" />
+          <Shw::Placeholder @text="#2" @height="40" />
+          <Shw::Placeholder @text="#3" @height="40" />
+          <Shw::Placeholder @text="#4" @height="40" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
+
+    <SG.Item @label="sm view = 1 column, all other views = 3 columns">
+      <Shw::Outliner>
+        <Hds::Layout::Grid @gap="24" @columnWidthSm="100%" @columnWidth="33.33%">
+          <Shw::Placeholder @text="#1" @height="40" />
+          <Shw::Placeholder @text="#2" @height="40" />
+          <Shw::Placeholder @text="#3" @height="40" />
+          <Shw::Placeholder @text="#4" @height="40" />
+        </Hds::Layout::Grid>
+      </Shw::Outliner>
+    </SG.Item>
   </Shw::Grid>
 
   <Shw::Divider @level={{2}} />


### PR DESCRIPTION
# Mini Hackday Project

### :pushpin: Summary

If merged, this PR adds responsive column widths options for the `Layout::Grid` component.

**Preview**: coming up...

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<img width="758" height="352" alt="image" src="https://github.com/user-attachments/assets/580bfcef-2675-4ad3-897d-bbc8d8eb2aec" />

<!-- 
### :link: External links

Issues, RFC, etc.
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]
 -->

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>