### PR TITLE
`CodeEditor`: indicate that `[CE].Title` and `[CE].Description` have bound args 

### DIFF
--- a/.changeset/rare-items-repeat.md
+++ b/.changeset/rare-items-repeat.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/code-editor -->
+`CodeEditor` - fixed the type of the CodeEditor signature to indicate that the `[CE].Title` and `[CE].Description` have bound arguments.
+<!-- END -->

--- a/packages/components/src/components/hds/code-editor/index.ts
+++ b/packages/components/src/components/hds/code-editor/index.ts
@@ -9,6 +9,10 @@ import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
 import { guidFor } from '@ember/object/internals';
 
+import HdsCodeEditorDescription from './description.ts';
+import HdsCodeEditorTitle from './title.ts';
+
+import type { WithBoundArgs } from '@glint/template';
 import type Owner from '@ember/owner';
 import type { ComponentLike } from '@glint/template';
 import type { HdsCodeEditorSignature as HdsCodeEditorModifierSignature } from '../../../modifiers/hds-code-editor.ts';
@@ -28,8 +32,14 @@ export interface HdsCodeEditorSignature {
   Blocks: {
     default: [
       {
-        Title?: ComponentLike<HdsCodeEditorTitleSignature>;
-        Description?: ComponentLike<HdsCodeEditorDescriptionSignature>;
+        Title?: WithBoundArgs<
+          typeof HdsCodeEditorTitle,
+          'onInsert' | 'editorId'
+        >;
+        Description?: WithBoundArgs<
+          typeof HdsCodeEditorDescription,
+          'onInsert' | 'editorId'
+        >;
         Generic?: ComponentLike<HdsCodeEditorGenericSignature>;
       },
     ];


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue that came up in the TypeScript showcase project. The CodeEditor component does not correctly indicate that some arguments for the `[CE].Title` and `[CE].Description` are set by the index component.

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>