### PR TITLE
Website - Fix incorrect type name and acceptance test comments

### DIFF
--- a/website/docs/icons/library/index.js
+++ b/website/docs/icons/library/index.js
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
-import { AVAILABLE_NAMES } from '@hashicorp/design-system-components/components/hds/icon/index';
+import { NAMES } from '@hashicorp/design-system-components/components/hds/icon/index';
 
 import catalog from '@hashicorp/flight-icons/catalog.json';
 
@@ -19,7 +19,7 @@ export default class Index extends Component {
   @service router;
 
   allIcons = catalog.assets
-    .filter(({ iconName }) => AVAILABLE_NAMES.includes(iconName))
+    .filter(({ iconName }) => NAMES.includes(iconName))
     .map(({ iconName, fileName, size, description, category }) => {
       category = category.toLowerCase(); // category names in json begin with uppercase letter
 

--- a/website/tests/acceptance/components/icon-test.js
+++ b/website/tests/acceptance/components/icon-test.js
@@ -8,7 +8,7 @@ import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 
-module('Acceptance | components/icon tile', function (hooks) {
+module('Acceptance | components/icon', function (hooks) {
   setupApplicationTest(hooks);
 
   test('visiting /components/icon', async function (assert) {

--- a/website/tests/acceptance/components/icon-tile-test.js
+++ b/website/tests/acceptance/components/icon-tile-test.js
@@ -8,7 +8,7 @@ import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'website/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 
-module('Acceptance | components/icon tile', function (hooks) {
+module('Acceptance | components/icon-tile', function (hooks) {
   setupApplicationTest(hooks);
 
   test('visiting /components/icon-tile', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged this PR would update an imported type for `COLORS` to its new type name, which was changed recently in #3063 .

It also fixes a couple incorrect path names in the acceptance test comments of the website icons.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>