### PR TITLE
Update `AppHeader` default breakpoint

### DIFF
--- a/.changeset/beige-seas-add.md
+++ b/.changeset/beige-seas-add.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppHeader` - Changed the default breakpoint from `lg` to `md`.

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -49,7 +49,7 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
   // Generates a unique ID for the Menu Content
   private _menuContentId = 'hds-menu-content-' + guidFor(this);
 
-  // we use the `lg` breakpoint for `desktop` viewports, but consumers can override its value
+  // we use the `md` breakpoint for `desktop` viewports, but consumers can override its value
   private _desktopMQVal = this.args.breakpoint ?? hdsBreakpoints['md'].px;
 
   constructor(owner: Owner, args: Record<string, never>) {

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -50,7 +50,7 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
   private _menuContentId = 'hds-menu-content-' + guidFor(this);
 
   // we use the `lg` breakpoint for `desktop` viewports, but consumers can override its value
-  private _desktopMQVal = this.args.breakpoint ?? hdsBreakpoints['sm'].px;
+  private _desktopMQVal = this.args.breakpoint ?? hdsBreakpoints['md'].px;
 
   constructor(owner: Owner, args: Record<string, never>) {
     super(owner, args);

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -50,7 +50,7 @@ export default class HdsAppHeader extends Component<HdsAppHeaderSignature> {
   private _menuContentId = 'hds-menu-content-' + guidFor(this);
 
   // we use the `lg` breakpoint for `desktop` viewports, but consumers can override its value
-  private _desktopMQVal = this.args.breakpoint ?? hdsBreakpoints['lg'].px;
+  private _desktopMQVal = this.args.breakpoint ?? hdsBreakpoints['sm'].px;
 
   constructor(owner: Owner, args: Record<string, never>) {
     super(owner, args);

--- a/showcase/app/components/mock/app/header/app-header.gts
+++ b/showcase/app/components/mock/app/header/app-header.gts
@@ -37,7 +37,7 @@ export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHe
   constructor(owner: Owner, args: MockAppHeaderAppHeaderSignature['Args']) {
     super(owner, args);
     this.showOrgPicker = this.args.showOrgPicker ?? true;
-    this.orgPickerLabel = this.args.orgPickerLabel ?? 'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW';
+    this.orgPickerLabel = this.args.orgPickerLabel ?? 'organization-name';
     this.showRegionPicker = this.args.showRegionPicker ?? true;
     this.showSearch = this.args.showSearch ?? true;
   }

--- a/showcase/app/components/mock/app/header/app-header.gts
+++ b/showcase/app/components/mock/app/header/app-header.gts
@@ -37,7 +37,7 @@ export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHe
   constructor(owner: Owner, args: MockAppHeaderAppHeaderSignature['Args']) {
     super(owner, args);
     this.showOrgPicker = this.args.showOrgPicker ?? true;
-    this.orgPickerLabel = this.args.orgPickerLabel ?? 'organization-name';
+    this.orgPickerLabel = this.args.orgPickerLabel ?? 'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW';
     this.showRegionPicker = this.args.showRegionPicker ?? true;
     this.showSearch = this.args.showSearch ?? true;
   }


### PR DESCRIPTION
### :pushpin: Summary

Updates the default breakpoint of the `AppHeader` from `lg` (1088px) to `md` (768px).

### :hammer_and_wrench: Detailed description

During the implementation of the Enterprise Navigation components, initial testing has solicited feedback around the default breakpoint at which the `AppHeader` collapses being too large; e.g., the elements in the `AppHeader` collapse into the small viewport menu at too large a size.

This presents some usability issues and can make it cumbersome to access the context switcher and other high-level navigation elements even at reasonable viewport widths (for example, when a desktop user has multiple tabs open next to one-another).

This was discussed in Slack [here](https://hashicorp.slack.com/archives/C05LKJ8LEC9/p1751312838907589).

While potentially out-of-date (or anecdotal), we do have [viewport usage metrics](https://docs.google.com/presentation/d/1g_az4DU9AmBtboGcs9NMz3y_CBvHuVvkuakh64FmQTQ/edit?slide=id.g35bd247b800_0_0#slide=id.g35bd247b800_0_0) from TFC which validates that this change will result in the `AppHeader` being displayed in its uncollapsed state for >95% of users.

What this does _not_ account for nor solve is very long strings in the context switcher that might result in wrapping. However, we believe this to be an edge case and the resulting experience is not broken.

The `AppSideNav` still collapses at the `lg` breakpoint, so while each component shifts at different breakpoints, it's logical to to keep the `AppSideNav` the same to free up space in the main page.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5164](https://hashicorp.atlassian.net/browse/HDS-5164)
Figma file: [Enterprise Nav Breakpoints](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/branch/pSzkRloc6ln3rFr1EEXRyp/HDS-Components-v2.0?m=auto&node-id=86866-12829&t=f9rvV6wF0OpLeuOk-1)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5164]: https://hashicorp.atlassian.net/browse/HDS-5164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ