### PR TITLE
StepperList - Fix type for `status`

### DIFF
--- a/.changeset/eight-lies-bathe.md
+++ b/.changeset/eight-lies-bathe.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/stepper/list -->
+`Stepper::List` - Fixed type for `status` argument in `List::Step` to be `HdsStepperStatuses` instead of enum `HdsStepperStatusesValues`
+<!-- END -->

--- a/packages/components/src/components/hds/stepper/list/step.ts
+++ b/packages/components/src/components/hds/stepper/list/step.ts
@@ -26,7 +26,7 @@ export const MAPPING_STATUS_TO_SR_ONLY_TEXT = HdsStepperStatusToSrOnlyText;
 
 export interface HdsStepperListStepSignature {
   Args: {
-    status?: HdsStepperStatusesValues;
+    status?: HdsStepperStatuses;
     titleTag?: HdsStepperTitleTags;
     stepIds?: HdsStepperListStepIds;
     didInsertNode?: (element: HTMLElement) => void;

--- a/showcase/app/controllers/page-components/stepper/list.ts
+++ b/showcase/app/controllers/page-components/stepper/list.ts
@@ -8,9 +8,8 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { deepTracked } from 'ember-deep-tracked';
 
+import type { HdsStepperStatuses } from '@hashicorp/design-system-components/components/hds/stepper/types';
 import type { PageComponentsStepperListModel } from 'showcase/routes/page-components/stepper/list';
-
-import { HdsStepperStatusesValues as STEP_STATUSES_ENUM } from '@hashicorp/design-system-components/components/hds/stepper/types';
 
 // basic function that clones an array of objects (not deep)
 export const clone = <T>(arr: T[]): T[] => {
@@ -19,7 +18,7 @@ export const clone = <T>(arr: T[]): T[] => {
 
 type ListData = {
   title: string;
-  status: STEP_STATUSES_ENUM;
+  status: HdsStepperStatuses;
   description: string;
 };
 
@@ -27,19 +26,19 @@ const DEFAULT_DATA: ListData[] = [
   {
     title: 'Step 1',
     // TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169
-    status: STEP_STATUSES_ENUM.Complete,
+    status: 'complete',
     description: 'Description for Step 1',
   },
   {
     title: 'Step 2',
     // TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169
-    status: STEP_STATUSES_ENUM.Progress,
+    status: 'progress',
     description: 'Description for Step 2',
   },
   {
     title: 'Step 3',
     // TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169
-    status: STEP_STATUSES_ENUM.Incomplete,
+    status: 'incomplete',
     description: 'Description for Step 3',
   },
 ];
@@ -47,14 +46,11 @@ const DEFAULT_DATA: ListData[] = [
 const updateSteps = (steps: ListData[], stepNumber: number) => {
   steps.forEach((step, index) => {
     if (index < stepNumber) {
-      // TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169
-      step.status = STEP_STATUSES_ENUM.Complete;
+      step.status = 'complete';
     } else if (index === stepNumber) {
-      // TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169
-      step.status = STEP_STATUSES_ENUM.Progress;
+      step.status = 'progress';
     } else {
-      // TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169
-      step.status = STEP_STATUSES_ENUM.Incomplete;
+      step.status = 'incomplete';
     }
   });
 };
@@ -62,14 +58,11 @@ const updateSteps = (steps: ListData[], stepNumber: number) => {
 const updateStepsProcessing = (steps: ListData[], stepNumber: number) => {
   steps.forEach((step, index) => {
     if (index < stepNumber) {
-      // TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169
-      step.status = STEP_STATUSES_ENUM.Complete;
+      step.status = 'complete';
     } else if (index === stepNumber) {
-      // TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169
-      step.status = STEP_STATUSES_ENUM.Processing;
+      step.status = 'processing';
     } else {
-      // TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169
-      step.status = STEP_STATUSES_ENUM.Incomplete;
+      step.status = 'incomplete';
     }
   });
 };

--- a/showcase/app/routes/page-components/stepper/list.ts
+++ b/showcase/app/routes/page-components/stepper/list.ts
@@ -6,7 +6,6 @@
 import Route from '@ember/routing/route';
 
 import { STATUSES as STEP_STATUSES } from '@hashicorp/design-system-components/components/hds/stepper/step/indicator';
-import { HdsStepperStatusesValues as STEP_STATUSES_ENUM } from '@hashicorp/design-system-components/components/hds/stepper/types';
 
 import type { ModelFrom } from 'showcase/utils/ModelFromRoute';
 
@@ -17,8 +16,6 @@ export default class PageComponentsStepperListRoute extends Route {
   model() {
     return {
       STEP_STATUSES,
-      // TODO: will not need this after https://hashicorp.atlassian.net/browse/HDS-5169
-      STEP_STATUSES_ENUM,
     };
   }
 }

--- a/showcase/app/templates/page-components/stepper/list.hbs
+++ b/showcase/app/templates/page-components/stepper/list.hbs
@@ -14,64 +14,56 @@
   <Shw::Grid @columns={{2}} as |SG|>
     <SG.Item @label="Default">
       <Hds::Stepper::List @titleTag="h3" @ariaLabel="Label" {{style width="200px"}} as |S|>
-        {{! TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169 }}
-        <S.Step @status={{@model.STEP_STATUSES_ENUM.Complete}}>
+        <S.Step @status="complete">
           <:title>Title</:title>
           <:description>Description</:description>
           <:content>
             <Shw::Placeholder @text="Step 1: Generic content" @height="20" />
           </:content>
         </S.Step>
-        {{! TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169 }}
-        <S.Step @status={{@model.STEP_STATUSES_ENUM.Complete}}>
+        <S.Step @status="complete">
           <:title>Title</:title>
           <:description>Description</:description>
           <:content>
             <Shw::Placeholder @text="Step 2: Generic content" @height="20" />
           </:content>
         </S.Step>
-        {{! TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169 }}
-        <S.Step @status={{@model.STEP_STATUSES_ENUM.Progress}}>
+        <S.Step @status="progress">
           <:title>Title</:title>
           <:description>Description</:description>
           <:content>
             <Shw::Placeholder @text="Step 3: Generic content" @height="20" />
           </:content>
         </S.Step>
-        {{! TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169 }}
-        <S.Step @status={{@model.STEP_STATUSES_ENUM.Incomplete}}>
+        <S.Step @status="incomplete">
           <:title>Title</:title>
         </S.Step>
       </Hds::Stepper::List>
     </SG.Item>
     <SG.Item @label="All complete">
       <Hds::Stepper::List @titleTag="h3" {{style width="200px"}} @ariaLabel="Label" as |S|>
-        {{! TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169 }}
-        <S.Step @status={{@model.STEP_STATUSES_ENUM.Complete}}>
+        <S.Step @status="complete">
           <:title>Title</:title>
           <:description>Description</:description>
           <:content>
             <Shw::Placeholder @text="Step 1: Generic content" @height="20" />
           </:content>
         </S.Step>
-        {{! TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169 }}
-        <S.Step @status={{@model.STEP_STATUSES_ENUM.Complete}}>
+        <S.Step @status="complete">
           <:title>Title</:title>
           <:description>Description</:description>
           <:content>
             <Shw::Placeholder @text="Step 2: Generic content" @height="20" />
           </:content>
         </S.Step>
-        {{! TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169 }}
-        <S.Step @status={{@model.STEP_STATUSES_ENUM.Complete}}>
+        <S.Step @status="complete">
           <:title>Title</:title>
           <:description>Description</:description>
           <:content>
             <Shw::Placeholder @text="Step 3: Generic content" @height="20" />
           </:content>
         </S.Step>
-        {{! TODO: will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169 }}
-        <S.Step @status={{@model.STEP_STATUSES_ENUM.Complete}}>
+        <S.Step @status="complete">
           <:title>Title</:title>
         </S.Step>
       </Hds::Stepper::List>
@@ -91,7 +83,6 @@
     {{#each @model.STEP_STATUSES as |status|}}
       <SG.Item @label="{{capitalize status}}">
         <Hds::Stepper::List @ariaLabel="Label" as |S|>
-          {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5169 }}
           <S.Step @status={{status}}>
             <:title>Title</:title>
             <:description>Description</:description>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the type of the `status` argument in the `Stepper::List::Step` from `HdsStepperStatusesValues` to `HdsStepperStatuses`. 

The type of the component currently is incorrectly set to the enum value instead of the type value.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5169](https://hashicorp.atlassian.net/browse/HDS-5169)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>