### PR TITLE
`ButtonSet` - Update  docs (HDS-5238)

### DIFF
--- a/website/docs/components/button-set/partials/code/how-to-use.md
+++ b/website/docs/components/button-set/partials/code/how-to-use.md
@@ -15,7 +15,7 @@ The basic invocation `ButtonSet` should include two or more buttons to be provid
 </Hds::ButtonSet>
 ```
 
-Other button-like components can also be used as children such as the [Dropdown](/components/dropdown).
+Other button-like components, such as the [Dropdown](/components/dropdown), can also be used as children.
 
 ```handlebars
 <Hds::ButtonSet>
@@ -42,31 +42,6 @@ If you want buttons with equal widths, set `@isFullWidth` to `true` on the `Butt
 <Hds::ButtonSet {{style maxWidth="15rem"}}>
   <Hds::Button @text="Save" @isFullWidth={{true}} />
   <Hds::Button @text="Cancel" @color="secondary" @href="https://hashicorp.com" @isFullWidth={{true}} />
-</Hds::ButtonSet>
-```
-
-!!! Warning
-
-**Code alert**
-
-The `Dropdown` does not have an `isFullWidth` option for the outer wrapper. Setting isFullWidth to “true” on the nested ToggleButton does not have the same effect.
-
-!!!
-
-```handlebars
-<Hds::ButtonSet>
-  <Hds::Dropdown as |D|>
-    <D.ToggleButton @isFullWidth={{true}} @color="secondary" @text="Select an option" />
-    <D.Title @text="Title Text" />
-    <D.Description @text="Descriptive text goes here." />
-    <D.Interactive @href="#">Add</D.Interactive>
-    <D.Interactive @href="#">Add More</D.Interactive>
-    <D.Interactive @href="#">Add Another Thing Too</D.Interactive>
-    <D.Separator />
-    <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
-  </Hds::Dropdown>
-
-  <Hds::Button @isFullWidth={{true}} @text="Submit" type="submit" />
 </Hds::ButtonSet>
 ```
 

--- a/website/docs/components/button-set/partials/code/how-to-use.md
+++ b/website/docs/components/button-set/partials/code/how-to-use.md
@@ -1,6 +1,12 @@
 ## How to use this component
 
-The basic invocation should include two or more buttons to be provided as children:
+!!! Info
+
+For guidance on button organization, grouping of button types, and related information please refer to the [button organization](/patterns/button-organization) pattern documentation.
+
+!!!
+
+The basic invocation `ButtonSet` should include two or more buttons to be provided as children. (If used with only one button there will be no noticeable visual difference.)
 
 ```handlebars
 <Hds::ButtonSet>
@@ -9,7 +15,7 @@ The basic invocation should include two or more buttons to be provided as childr
 </Hds::ButtonSet>
 ```
 
-Other button-like components can also be used as children such as the `Dropdown`.
+Other button-like components can also be used as children such as the [Dropdown](/components/dropdown).
 
 ```handlebars
 <Hds::ButtonSet>
@@ -32,8 +38,6 @@ Other button-like components can also be used as children such as the `Dropdown`
 
 If you want buttons with equal widths, set `@isFullWidth` to `true` on the `Button` components. Since the ButtonSet is full-width (100%) by default, you will likely want to constrain its overall width by adding a `max-width` to the `ButtonSet` container (via an inline style or CSS class).
 
-Note: .
-
 ```handlebars
 <Hds::ButtonSet {{style maxWidth="15rem"}}>
   <Hds::Button @text="Save" @isFullWidth={{true}} />
@@ -41,7 +45,13 @@ Note: .
 </Hds::ButtonSet>
 ```
 
-Issue: The `Dropdown` does not have an `isFullWidth` option for the outer wrapper. Setting isFullWidth to “true” on the nested ToggleButton does not have the same effect.
+!!! Warning
+
+**Code alert**
+
+The `Dropdown` does not have an `isFullWidth` option for the outer wrapper. Setting isFullWidth to “true” on the nested ToggleButton does not have the same effect.
+
+!!!
 
 ```handlebars
 <Hds::ButtonSet>

--- a/website/docs/components/button-set/partials/code/how-to-use.md
+++ b/website/docs/components/button-set/partials/code/how-to-use.md
@@ -6,7 +6,7 @@ For guidance on button organization, grouping of button types, and related infor
 
 !!!
 
-The basic invocation `ButtonSet` should include two or more buttons to be provided as children. (If used with only one button there will be no noticeable visual difference.)
+The basic `ButtonSet` invocation should include two or more buttons to be provided as children. (If used with only one button there will be no noticeable visual difference.)
 
 ```handlebars
 <Hds::ButtonSet>

--- a/website/docs/components/button-set/partials/code/how-to-use.md
+++ b/website/docs/components/button-set/partials/code/how-to-use.md
@@ -1,6 +1,6 @@
 ## How to use this component
 
-The basic invocation requires two or more buttons to be provided as children:
+The basic invocation should include two or more buttons to be provided as children:
 
 ```handlebars
 <Hds::ButtonSet>
@@ -9,14 +9,54 @@ The basic invocation requires two or more buttons to be provided as children:
 </Hds::ButtonSet>
 ```
 
-### Equal width buttons
-
-If you want to have buttons with equal width, apply a width (via inline style or CSS class) to the `ButtonSet` container and the argument `@isFullWidth={{true}}` to the `Button` components:
+Other button-like components can also be used as children such as the `Dropdown`.
 
 ```handlebars
-<Hds::ButtonSet {{style width="15rem"}}>
+<Hds::ButtonSet>
+  <Hds::Dropdown as |D|>
+    <D.ToggleButton @color="secondary" @text="Select an option" />
+    <D.Title @text="Title Text" />
+    <D.Description @text="Descriptive text goes here." />
+    <D.Interactive @href="#">Add</D.Interactive>
+    <D.Interactive @href="#">Add More</D.Interactive>
+    <D.Interactive @href="#">Add Another Thing Too</D.Interactive>
+    <D.Separator />
+    <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
+  </Hds::Dropdown>
+
+  <Hds::Button @text="Submit" type="submit" />
+</Hds::ButtonSet>
+```
+
+### Equal width buttons
+
+If you want buttons with equal widths, set `@isFullWidth` to `true` on the `Button` components. To constrain the overall max-width, you can also add a width to the `ButtonSet` container (via an inline style or CSS class).
+
+Note: The ButtonSet is full-width (100%) by default.
+
+```handlebars
+<Hds::ButtonSet {{style maxWidth="15rem"}}>
   <Hds::Button @text="Save" @isFullWidth={{true}} />
   <Hds::Button @text="Cancel" @color="secondary" @href="https://hashicorp.com" @isFullWidth={{true}} />
+</Hds::ButtonSet>
+```
+
+Issue: The `Dropdown` does not have an `isFullWidth` option for the outer wrapper. Setting isFullWidth to “true” on the nested ToggleButton does not have the same effect.
+
+```handlebars
+<Hds::ButtonSet>
+  <Hds::Dropdown as |D|>
+    <D.ToggleButton @isFullWidth={{true}} @color="secondary" @text="Select an option" />
+    <D.Title @text="Title Text" />
+    <D.Description @text="Descriptive text goes here." />
+    <D.Interactive @href="#">Add</D.Interactive>
+    <D.Interactive @href="#">Add More</D.Interactive>
+    <D.Interactive @href="#">Add Another Thing Too</D.Interactive>
+    <D.Separator />
+    <D.Interactive @route="components" @icon="trash" @color="critical">Delete</D.Interactive>
+  </Hds::Dropdown>
+
+  <Hds::Button @isFullWidth={{true}} @text="Submit" type="submit" />
 </Hds::ButtonSet>
 ```
 

--- a/website/docs/components/button-set/partials/code/how-to-use.md
+++ b/website/docs/components/button-set/partials/code/how-to-use.md
@@ -30,9 +30,9 @@ Other button-like components can also be used as children such as the `Dropdown`
 
 ### Equal width buttons
 
-If you want buttons with equal widths, set `@isFullWidth` to `true` on the `Button` components. To constrain the overall max-width, you can also add a width to the `ButtonSet` container (via an inline style or CSS class).
+If you want buttons with equal widths, set `@isFullWidth` to `true` on the `Button` components. Since the ButtonSet is full-width (100%) by default, you will likely want to constrain its overall width by adding a `max-width` to the `ButtonSet` container (via an inline style or CSS class).
 
-Note: The ButtonSet is full-width (100%) by default.
+Note: .
 
 ```handlebars
 <Hds::ButtonSet {{style maxWidth="15rem"}}>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates web docs for the `ButtonSet` clarifying usage examples.

👉 **Preview**: https://hds-website-git-kristin-hds-5238-update-button-d71644-hashicorp.vercel.app/components/button-set?tab=code

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-5238](https://hashicorp.atlassian.net/browse/HDS-5238)

***

### :eyes: Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5238]: https://hashicorp.atlassian.net/browse/HDS-5238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ