### PR TITLE
`AdvancedTable` Column resize bug fix

### DIFF
--- a/.changeset/tender-carrots-fix.md
+++ b/.changeset/tender-carrots-fix.md
@@ -1,0 +1,8 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+<!-- START components/advanced-table -->
+
+- Fixed bug with automatic column resizing and scroll-shadow placement.
+<!-- END -->

--- a/.changeset/tender-carrots-fix.md
+++ b/.changeset/tender-carrots-fix.md
@@ -2,7 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-<!-- START components/advanced-table -->
-
-- Fixed bug with automatic column resizing and scroll-shadow placement.
+<!-- START components/table/advanced-table -->
+`AdvancedTable` - Fixed bug with automatic column resizing and scroll-shadow placement.
 <!-- END -->

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -6,7 +6,6 @@
   class="hds-advanced-table__container
     {{(if this.isStickyHeaderPinned 'hds-advanced-table__container--header-is-pinned')}}"
   {{did-update this.setupTableModelData @columns @model @sortBy @sortOrder}}
-  {{this._registerTableElement}}
   ...attributes
 >
   {{! Caption }}

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -24,6 +24,7 @@
       --hds-advanced-table-sticky-column-offset=this.stickyColumnOffset
       max-height=@maxHeight
     }}
+    {{this._registerGridElement}}
     {{this._setUpScrollWrapper}}
   >
     {{! Header }}

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -54,7 +54,6 @@
               @tableHeight={{this._tableHeight}}
               @onColumnResize={{@onColumnResize}}
               @onPinFirstColumn={{this._onPinFirstColumn}}
-              {{this._setColumnWidth column}}
             >
               {{column.label}}
             </Hds::AdvancedTable::ThSort>
@@ -74,7 +73,6 @@
               @onClickToggle={{this._tableModel.toggleAll}}
               @onColumnResize={{@onColumnResize}}
               @onPinFirstColumn={{this._onPinFirstColumn}}
-              {{this._setColumnWidth column}}
             >
               {{column.label}}
             </Hds::AdvancedTable::Th>

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -55,6 +55,7 @@
               @tableHeight={{this._tableHeight}}
               @onColumnResize={{@onColumnResize}}
               @onPinFirstColumn={{this._onPinFirstColumn}}
+              {{this._registerThElement column}}
             >
               {{column.label}}
             </Hds::AdvancedTable::ThSort>
@@ -74,6 +75,7 @@
               @onClickToggle={{this._tableModel.toggleAll}}
               @onColumnResize={{@onColumnResize}}
               @onPinFirstColumn={{this._onPinFirstColumn}}
+              {{this._registerThElement column}}
             >
               {{column.label}}
             </Hds::AdvancedTable::Th>

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -6,6 +6,7 @@
   class="hds-advanced-table__container
     {{(if this.isStickyHeaderPinned 'hds-advanced-table__container--header-is-pinned')}}"
   {{did-update this.setupTableModelData @columns @model @sortBy @sortOrder}}
+  {{this._registerTableElement}}
   ...attributes
 >
   {{! Caption }}

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -386,7 +386,6 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     // if there is a select checkbox, the first column has a 'min-content' width to hug the checkbox content
     let style = isSelectable ? 'min-content ' : '';
 
-    // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.
     for (let i = 0; i < columns.length; i++) {
       style += ` ${columns[i]!.appliedWidth}`;
     }

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -447,6 +447,14 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
   private _setUpScrollWrapper = modifier((element: HTMLDivElement) => {
     this._scrollWrapperElement = element;
 
+    const updateHorizontalScrollIndicators = () => {
+      if (element.clientWidth < element.scrollWidth) {
+        this.showScrollIndicatorRight = true;
+      } else {
+        this.showScrollIndicatorRight = false;
+      }
+    };
+
     this._scrollHandler = () => {
       this._updateScrollIndicators(element);
     };
@@ -482,6 +490,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     this._resizeObserver = new ResizeObserver((entries) => {
       entries.forEach(() => {
         updateMeasurements();
+        updateHorizontalScrollIndicators();
       });
     });
 
@@ -490,9 +499,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     updateMeasurements();
 
     // on render check if should show right scroll indicator
-    if (element.clientWidth < element.scrollWidth) {
-      this.showScrollIndicatorRight = true;
-    }
+    updateHorizontalScrollIndicators();
 
     // on render check if should show bottom scroll indicator
     if (element.clientHeight < element.scrollHeight) {

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -29,6 +29,7 @@ import type {
   HdsAdvancedTableModel,
   HdsAdvancedTableExpandState,
 } from './types.ts';
+import type HdsAdvancedTableColumnType from './models/column.ts';
 import type { HdsFormCheckboxBaseSignature } from '../form/checkbox/base.ts';
 import type HdsAdvancedTableTd from './td.ts';
 import type HdsAdvancedTableTh from './th.ts';
@@ -432,6 +433,16 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
 
     return classes.join(' ');
   }
+
+  private _registerThElement = modifier(
+    (element: HTMLDivElement, [column]: [HdsAdvancedTableColumnType]) => {
+      if (column === undefined) {
+        return;
+      }
+
+      column.thElement = element;
+    }
+  );
 
   private _setUpScrollWrapper = modifier((element: HTMLDivElement) => {
     this._scrollWrapperElement = element;

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -388,7 +388,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
 
     // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.
     for (let i = 0; i < columns.length; i++) {
-      style += ` ${columns[i]!.width}`;
+      style += ` ${columns[i]!.appliedWidth}`;
     }
 
     return style;

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -433,6 +433,10 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     return classes.join(' ');
   }
 
+  private _registerGridElement = modifier((element: HTMLDivElement) => {
+    this._tableModel.gridElement = element;
+  });
+
   private _registerThElement = modifier(
     (element: HTMLDivElement, [column]: [HdsAdvancedTableColumnType]) => {
       if (column === undefined) {

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -451,11 +451,7 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     this._scrollWrapperElement = element;
 
     const updateHorizontalScrollIndicators = () => {
-      if (element.clientWidth < element.scrollWidth) {
-        this.showScrollIndicatorRight = true;
-      } else {
-        this.showScrollIndicatorRight = false;
-      }
+      this.showScrollIndicatorRight = element.clientWidth < element.scrollWidth;
     };
 
     this._scrollHandler = () => {

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -434,6 +434,10 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     return classes.join(' ');
   }
 
+  private _registerTableElement = modifier((element: HTMLDivElement) => {
+    this._tableModel.tableElement = element;
+  });
+
   private _registerThElement = modifier(
     (element: HTMLDivElement, [column]: [HdsAdvancedTableColumnType]) => {
       if (column === undefined) {

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -11,7 +11,6 @@ import type { WithBoundArgs } from '@glint/template';
 import { guidFor } from '@ember/object/internals';
 import { modifier } from 'ember-modifier';
 import type Owner from '@ember/owner';
-import { schedule } from '@ember/runloop';
 
 import HdsAdvancedTableTableModel from './models/table.ts';
 
@@ -30,7 +29,6 @@ import type {
   HdsAdvancedTableModel,
   HdsAdvancedTableExpandState,
 } from './types.ts';
-import type HdsAdvancedTableColumnType from './models/column.ts';
 import type { HdsFormCheckboxBaseSignature } from '../form/checkbox/base.ts';
 import type HdsAdvancedTableTd from './td.ts';
 import type HdsAdvancedTableTh from './th.ts';
@@ -384,23 +382,12 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     const { isSelectable } = this.args;
     const { columns } = this._tableModel;
 
-    const DEFAULT_COLUMN_WIDTH = '1fr';
-
     // if there is a select checkbox, the first column has a 'min-content' width to hug the checkbox content
     let style = isSelectable ? 'min-content ' : '';
 
-    const hasCustomColumnWidths = columns.some(
-      (column) => column.width !== undefined
-    );
-
-    if (hasCustomColumnWidths) {
-      // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.
-      for (let i = 0; i < columns.length; i++) {
-        style += ` ${columns[i]!.width ?? DEFAULT_COLUMN_WIDTH}`;
-      }
-    } else {
-      // if there are no custom column widths, each column is the same width and they take up the available space
-      style += `repeat(${columns.length}, ${DEFAULT_COLUMN_WIDTH})`;
+    // check the custom column widths, if the current column has a custom width use the custom width. otherwise take the available space.
+    for (let i = 0; i < columns.length; i++) {
+      style += ` ${columns[i]!.width}`;
     }
 
     return style;
@@ -445,20 +432,6 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
 
     return classes.join(' ');
   }
-
-  private _setColumnWidth = modifier(
-    (element: HTMLDivElement, [column]: [HdsAdvancedTableColumnType]) => {
-      // eslint-disable-next-line ember/no-runloop
-      schedule('afterRender', () => {
-        const width = element.offsetWidth;
-
-        if (column.width === undefined) {
-          column.setPxWidth(width);
-          column.originalWidth = `${width}px`;
-        }
-      });
-    }
-  );
 
   private _setUpScrollWrapper = modifier((element: HTMLDivElement) => {
     this._scrollWrapperElement = element;

--- a/packages/components/src/components/hds/advanced-table/index.ts
+++ b/packages/components/src/components/hds/advanced-table/index.ts
@@ -434,10 +434,6 @@ export default class HdsAdvancedTable extends Component<HdsAdvancedTableSignatur
     return classes.join(' ');
   }
 
-  private _registerTableElement = modifier((element: HTMLDivElement) => {
-    this._tableModel.tableElement = element;
-  });
-
   private _registerThElement = modifier(
     (element: HTMLDivElement, [column]: [HdsAdvancedTableColumnType]) => {
       if (column === undefined) {

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -35,6 +35,7 @@ export default class HdsAdvancedTableColumn {
   @tracked isVisuallyHidden?: boolean = false;
   @tracked key?: string = undefined;
   @tracked tooltip?: string = undefined;
+  @tracked thElement?: HTMLDivElement = undefined;
 
   // width properties
   @tracked width?: string = '1fr'; // default to '1fr' to allow flexible width

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -165,27 +165,23 @@ export default class HdsAdvancedTableColumn {
   }
 
   private collectWidthDebts(): void {
-    const { key: thisKey, table } = this;
-
-    if (thisKey === undefined) {
-      return;
-    }
-
-    table.columns.forEach((otherColumn) => {
-      const debtToCollect = otherColumn.widthDebts[thisKey] ?? 0;
+    this.table.columns.forEach((otherColumn) => {
+      const debtToCollect = otherColumn.widthDebts[this.key] ?? 0;
 
       if (debtToCollect > 0) {
+        // otherColumn.collectWidthDebts();
+
         // Take the width back from the column that owes us
         otherColumn.pxWidth = (otherColumn.pxWidth ?? 0) - debtToCollect;
         // Clear the debt from their ledger
-        delete otherColumn.widthDebts[thisKey];
+        delete otherColumn.widthDebts[this.key];
       }
     });
   }
 
   private settleWidthDebts(): void {
-    this.payWidthDebts();
     this.collectWidthDebts();
+    this.payWidthDebts();
   }
 
   // set initial width values
@@ -220,8 +216,8 @@ export default class HdsAdvancedTableColumn {
 
   @action
   restoreWidth(): void {
-    this.width = this.originalWidth ?? this.width;
-
     this.settleWidthDebts();
+
+    this.width = this.originalWidth ?? this.width;
   }
 }

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -31,14 +31,15 @@ export default class HdsAdvancedTableColumn {
   @tracked label: string = '';
   @tracked align?: HdsAdvancedTableHorizontalAlignment = 'left';
   @tracked isExpandable?: boolean = false;
-  @tracked isReorderable?: boolean = false;
   @tracked isSortable?: boolean = false;
   @tracked isVisuallyHidden?: boolean = false;
   @tracked key?: string = undefined;
+  @tracked tooltip?: string = undefined;
+
+  // width properties
+  @tracked width?: string = '1fr'; // default to '1fr' to allow flexible width
   @tracked minWidth?: `${number}px` = DEFAULT_MIN_WIDTH;
   @tracked maxWidth?: `${number}px` = DEFAULT_MAX_WIDTH;
-  @tracked tooltip?: string = undefined;
-  @tracked width?: string = undefined;
   @tracked originalWidth?: string = undefined; // used to restore the width when resetting
   @tracked widthDebts: Record<string, number> = {}; // used to track width changes imposed by other columns
 
@@ -127,7 +128,7 @@ export default class HdsAdvancedTableColumn {
     Object.entries(this.widthDebts).forEach(([lenderKey, amount]) => {
       const lender = this.table.getColumnByKey(lenderKey);
 
-      if (lender) {
+      if (lender !== undefined) {
         // Give the width back to the column that lent it to us
         lender.setPxWidth((lender.pxWidth ?? 0) + amount);
       }
@@ -166,11 +167,7 @@ export default class HdsAdvancedTableColumn {
     minWidth,
     maxWidth,
   }: HdsAdvancedTableColumnType): void {
-    if (width === undefined) {
-      return;
-    }
-
-    this.width = width;
+    this.width = width ?? '1fr'; // default to '1fr' if not provided
 
     // capture the width at the time of instantiation so it can be restored
     this.originalWidth = width;

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -5,6 +5,7 @@
 
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 
 import type HdsAdvancedTableModel from './table.ts';
 import type {
@@ -34,7 +35,7 @@ export default class HdsAdvancedTableColumn {
   @tracked isExpandable?: boolean = false;
   @tracked isSortable?: boolean = false;
   @tracked isVisuallyHidden?: boolean = false;
-  @tracked key?: string = undefined;
+  @tracked key: string;
   @tracked tooltip?: string = undefined;
   @tracked thElement?: HTMLDivElement = undefined;
 
@@ -143,7 +144,7 @@ export default class HdsAdvancedTableColumn {
     this.isExpandable = 'isExpandable' in column ? column.isExpandable : false;
     this.isSortable = column.isSortable ?? false;
     this.isVisuallyHidden = column.isVisuallyHidden ?? false;
-    this.key = column.key;
+    this.key = column.key ?? guidFor(this);
     this.tooltip = column.tooltip;
     this._setWidthValues(column);
     this.sortingFunction = column.sortingFunction;

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -51,7 +51,7 @@ export default class HdsAdvancedTableColumn {
   table: HdsAdvancedTableModel;
 
   get appliedWidth(): string {
-    return this.transientWidth ?? this.width ?? '1fr';
+    return this.transientWidth ?? this.width;
   }
   get pxAppliedWidth(): number | undefined {
     if (isPxSize(this.appliedWidth)) {

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -40,7 +40,7 @@ export default class HdsAdvancedTableColumn {
   @tracked tooltip?: string = undefined;
   @tracked width?: string = undefined;
   @tracked originalWidth?: string = undefined; // used to restore the width when resetting
-  @tracked imposedWidthDelta: number = 0; // used to track the width change imposed by the previous column
+  @tracked widthDebts: Record<string, number> = {}; // used to track width changes imposed by other columns
 
   @tracked sortingFunction?: (a: unknown, b: unknown) => number = undefined;
 
@@ -123,6 +123,44 @@ export default class HdsAdvancedTableColumn {
     this.sortingFunction = column.sortingFunction;
   }
 
+  private payWidthDebts(): void {
+    Object.entries(this.widthDebts).forEach(([lenderKey, amount]) => {
+      const lender = this.table.getColumnByKey(lenderKey);
+
+      if (lender) {
+        // Give the width back to the column that lent it to us
+        lender.setPxWidth((lender.pxWidth ?? 0) + amount);
+      }
+    });
+
+    // Clear our own debt ledger, as we've paid everyone back
+    this.widthDebts = {};
+  }
+
+  private collectWidthDebts(): void {
+    const { key: thisKey, table } = this;
+
+    if (thisKey === undefined) {
+      return;
+    }
+
+    table.columns.forEach((otherColumn) => {
+      const debtToCollect = otherColumn.widthDebts[thisKey] ?? 0;
+
+      if (debtToCollect > 0) {
+        // Take the width back from the column that owes us
+        otherColumn.setPxWidth((otherColumn.pxWidth ?? 0) - debtToCollect);
+        // Clear the debt from their ledger
+        delete otherColumn.widthDebts[thisKey];
+      }
+    });
+  }
+
+  private settleWidthDebts(): void {
+    this.payWidthDebts();
+    this.collectWidthDebts();
+  }
+
   private _setWidthValues({
     width,
     minWidth,
@@ -157,29 +195,10 @@ export default class HdsAdvancedTableColumn {
     }
   }
 
-  // This method is called when the column width is changed by the previous column.
-  @action
-  onPreviousColumnWidthRestored(): void {
-    const restoredWidth = (this.pxWidth ?? 0) + this.imposedWidthDelta;
-
-    this.setPxWidth(restoredWidth);
-
-    this.imposedWidthDelta = 0;
-  }
-
-  // This method is called when the next column width is restored.
-  @action
-  onNextColumnWidthRestored(imposedWidthDelta: number): void {
-    this.setPxWidth((this.pxWidth ?? 0) - imposedWidthDelta);
-  }
-
   @action
   restoreWidth(): void {
     this.width = this.originalWidth;
-    this.imposedWidthDelta = 0;
 
-    if (this.key === undefined) {
-      return;
-    }
+    this.settleWidthDebts();
   }
 }

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -146,134 +146,82 @@ export default class HdsAdvancedTableColumn {
     this.sortingFunction = column.sortingFunction;
   }
 
-  // Collects debt from a debtor's surplus width
-  private _collectFromSurplus(
-    debtor: HdsAdvancedTableColumn,
-    debtToCollect: number
-  ): number {
-    // Calculate the debtor's available width above its minimum constraint
-    const surplus = Math.max(0, (debtor.pxWidth ?? 0) - debtor.pxMinWidth);
-    // The amount we can actually take is the smaller of the debt or the surplus
-    const paymentAmount = Math.min(debtToCollect, surplus);
-
-    if (paymentAmount > 0) {
-      debtor.pxWidth = (debtor.pxWidth ?? 0) - paymentAmount;
-
-      this.pxWidth = (this.pxWidth ?? 0) + paymentAmount;
-    }
-
-    return paymentAmount;
-  }
-
-  // Updates the ledger for a sub-debtor after it has made a payment
-  private _updateSubDebtLedger(
-    subDebtor: HdsAdvancedTableColumn,
-    creditorKey: string,
-    amountPaid: number
-  ) {
-    const originalDebt = subDebtor.widthDebts[creditorKey] ?? 0;
-    const remainingDebt = originalDebt - amountPaid;
-
-    if (remainingDebt > 0) {
-      subDebtor.widthDebts[creditorKey] = remainingDebt;
-    } else {
-      delete subDebtor.widthDebts[creditorKey];
-    }
-  }
-
-  // Facilitates a cascading collection from a debtor's own debtors if the debtor has a shortfall
-  private _collectFromSubDebtors(
-    debtor: HdsAdvancedTableColumn,
-    shortfall: number
-  ): number {
-    if (shortfall <= 0) {
-      return 0;
-    }
-
-    let totalCollected = 0;
-
-    const subDebtors = this.table.columns.filter(
-      (column) => column.widthDebts[debtor.key]
-    );
-
-    for (const subDebtor of subDebtors) {
-      const amountStillNeeded = shortfall - totalCollected;
-
-      if (amountStillNeeded <= 0) {
-        break;
-      }
-
-      const subDebtOwed = subDebtor.widthDebts[debtor.key] ?? 0;
-      const amountToRequest = Math.min(amountStillNeeded, subDebtOwed);
-
-      // The sub-debtor pays from its own surplus in a direct transfer to the original collector (`this`)
-      const paymentAmount = this._collectFromSurplus(
-        subDebtor,
-        amountToRequest
-      );
-
-      if (paymentAmount > 0) {
-        totalCollected = totalCollected + paymentAmount;
-        // Update the sub-debtor's ledger
-        this._updateSubDebtLedger(subDebtor, debtor.key, paymentAmount);
-      }
-    }
-
-    return totalCollected;
-  }
-
-  // Updates the primary debt ledger after all collection attempts are complete
-  private _updatePrimaryDebtLedger(
-    debtor: HdsAdvancedTableColumn,
-    remainingDebt: number
-  ) {
-    const originalDebt = debtor.widthDebts[this.key] ?? 0;
-
-    if (remainingDebt <= 0) {
-      delete debtor.widthDebts[this.key];
-    } else if (remainingDebt < originalDebt) {
-      debtor.widthDebts[this.key] = remainingDebt;
-    }
-  }
-
-  /*
-   * Collects all debts owed to this column. For each debtor, it first attempts a
-   * direct payment from the debtor's available surplus width (width above its
-   * minimum). If a shortfall remains, it triggers a cascading collection where
-   * the debtor facilitates a direct payment from its own sub-debtors to the
-   * original collector.
-   */
+  // main collection function
   private collectWidthDebts(): void {
-    const { key: thisKey, table } = this;
-
-    table.columns.forEach((debtor) => {
-      let debtToCollect = debtor.widthDebts[thisKey] ?? 0;
+    this.table.columns.forEach((debtor) => {
+      const debtToCollect = debtor.widthDebts[this.key] ?? 0;
 
       if (debtToCollect <= 0) {
         return;
       }
 
-      // Attempt a direct payment from the debtor's surplus
-      const paymentFromSurplus = this._collectFromSurplus(
-        debtor,
-        debtToCollect
+      const amountPaid = debtor._sourceFundsForPayment(debtToCollect);
+
+      if (amountPaid > 0) {
+        this.pxWidth = (this.pxWidth ?? 0) + amountPaid;
+
+        const remainingDebt = debtToCollect - amountPaid;
+
+        if (remainingDebt > 0) {
+          debtor.widthDebts[this.key] = remainingDebt;
+        } else {
+          delete debtor.widthDebts[this.key];
+        }
+      }
+    });
+  }
+
+  // function for recursively recovering width debts without ending up in a deficit
+  private _sourceFundsForPayment(amountNeeded: number): number {
+    let fundsSourced = 0;
+
+    // preferentially source width from our own surplus first
+    const surplus = Math.max(0, (this.pxWidth ?? 0) - this.pxMinWidth);
+    const paymentFromSurplus = Math.min(amountNeeded, surplus);
+
+    if (paymentFromSurplus > 0) {
+      this.pxWidth = (this.pxWidth ?? 0) - paymentFromSurplus;
+
+      fundsSourced = fundsSourced + paymentFromSurplus;
+    }
+
+    // if we dont have enough to cover, source from debtors recursively
+    const shortfall = amountNeeded - fundsSourced;
+
+    if (shortfall > 0) {
+      const ourDebtors = this.table.columns.filter(
+        (column) => column.widthDebts[this.key]
       );
 
-      // Reduce the amount we still need to collect
-      debtToCollect = debtToCollect - paymentFromSurplus;
+      for (const subDebtor of ourDebtors) {
+        const amountStillNeeded = amountNeeded - fundsSourced;
 
-      // If a shortfall remains, trigger the cascading collection
-      if (debtToCollect > 0) {
-        const paymentFromCascade = this._collectFromSubDebtors(
-          debtor,
-          debtToCollect
-        );
+        if (amountStillNeeded <= 0) {
+          break;
+        }
 
-        debtToCollect = debtToCollect - paymentFromCascade;
+        const subDebtOwed = subDebtor.widthDebts[this.key] ?? 0;
+        const amountToRequest = Math.min(amountStillNeeded, subDebtOwed);
+
+        const collectedFromSubDebtor =
+          subDebtor._sourceFundsForPayment(amountToRequest);
+
+        if (collectedFromSubDebtor > 0) {
+          fundsSourced = fundsSourced + collectedFromSubDebtor;
+
+          // Update the sub-debtor's ledger.
+          const remainingSubDebt = subDebtOwed - collectedFromSubDebtor;
+
+          if (remainingSubDebt > 0) {
+            subDebtor.widthDebts[this.key] = remainingSubDebt;
+          } else {
+            delete subDebtor.widthDebts[this.key];
+          }
+        }
       }
+    }
 
-      this._updatePrimaryDebtLedger(debtor, debtToCollect);
-    });
+    return fundsSourced;
   }
 
   private payWidthDebts(): void {

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -73,9 +73,11 @@ export default class HdsAdvancedTableColumn {
     }
   }
 
-  get pxWidth(): number | undefined {
+  get pxWidth(): number {
     if (isPxSize(this.width)) {
       return pxToNumber(this.width);
+    } else {
+      return this.thElement?.offsetWidth ?? 0;
     }
   }
   set pxWidth(value: number) {

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -151,9 +151,9 @@ export default class HdsAdvancedTableColumn {
     debtor: HdsAdvancedTableColumn,
     debtToCollect: number
   ): number {
-    // Calculate the debtor's available width above its minimum constraint.
+    // Calculate the debtor's available width above its minimum constraint
     const surplus = Math.max(0, (debtor.pxWidth ?? 0) - debtor.pxMinWidth);
-    // The amount we can actually take is the smaller of the debt or the surplus.
+    // The amount we can actually take is the smaller of the debt or the surplus
     const paymentAmount = Math.min(debtToCollect, surplus);
 
     if (paymentAmount > 0) {
@@ -206,14 +206,14 @@ export default class HdsAdvancedTableColumn {
       const subDebtOwed = subDebtor.widthDebts[debtor.key] ?? 0;
       const amountToRequest = Math.min(amountStillNeeded, subDebtOwed);
 
-      // The sub-debtor pays from its own surplus in a direct transfer to the original collector (`this`).
+      // The sub-debtor pays from its own surplus in a direct transfer to the original collector (`this`)
       const paymentAmount = this._collectFromSurplus(
         subDebtor,
         amountToRequest
       );
 
       if (paymentAmount > 0) {
-        totalCollected += paymentAmount;
+        totalCollected = totalCollected + paymentAmount;
         // Update the sub-debtor's ledger
         this._updateSubDebtLedger(subDebtor, debtor.key, paymentAmount);
       }

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -48,6 +48,7 @@ export default class HdsAdvancedTableTableModel {
   @tracked sortBy: HdsAdvancedTableTableArgs['sortBy'] = undefined;
   @tracked sortOrder: HdsAdvancedTableTableArgs['sortOrder'] =
     HdsAdvancedTableThSortOrderValues.Asc;
+  @tracked gridElement?: HTMLDivElement = undefined;
 
   childrenKey?: HdsAdvancedTableTableArgs['childrenKey'];
   hasResizableColumns?: HdsAdvancedTableTableArgs['hasResizableColumns'];

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -48,7 +48,6 @@ export default class HdsAdvancedTableTableModel {
   @tracked sortBy: HdsAdvancedTableTableArgs['sortBy'] = undefined;
   @tracked sortOrder: HdsAdvancedTableTableArgs['sortOrder'] =
     HdsAdvancedTableThSortOrderValues.Asc;
-  @tracked tableElement?: HTMLDivElement = undefined;
 
   childrenKey?: HdsAdvancedTableTableArgs['childrenKey'];
   hasResizableColumns?: HdsAdvancedTableTableArgs['hasResizableColumns'];

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -152,6 +152,19 @@ export default class HdsAdvancedTableTableModel {
     }
   }
 
+  onStartColumnResize(): void {
+    this.columns.forEach((column) => {
+      column.pxTransientWidth =
+        column.pxWidth ?? column.thElement?.offsetWidth ?? 0;
+    });
+  }
+
+  onStopColumnResize(): void {
+    this.columns.forEach((column) => {
+      column.pxTransientWidth = undefined;
+    });
+  }
+
   getColumnByKey(key: string): HdsAdvancedTableColumn | undefined {
     return this.columns.find((column) => column.key === key);
   }

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -152,6 +152,10 @@ export default class HdsAdvancedTableTableModel {
     }
   }
 
+  getColumnByKey(key: string): HdsAdvancedTableColumn | undefined {
+    return this.columns.find((column) => column.key === key);
+  }
+
   @action
   setupData(
     args: Pick<

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -155,8 +155,7 @@ export default class HdsAdvancedTableTableModel {
 
   onStartColumnResize(): void {
     this.columns.forEach((column) => {
-      const width =
-        column.pxWidth ?? column.thElement?.getBoundingClientRect().width ?? 0;
+      const width = column.pxWidth ?? column.thElement?.offsetWidth ?? 0;
 
       column.pxTransientWidth = width;
     });

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -163,7 +163,8 @@ export default class HdsAdvancedTableTableModel {
 
   setTransientColumnWidths(): void {
     this.columns.forEach((column) => {
-      column.pxTransientWidth = column.thElement?.offsetWidth ?? 0;
+      column.pxTransientWidth =
+        column.thElement?.getBoundingClientRect().width ?? 0;
     });
   }
 

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -48,6 +48,7 @@ export default class HdsAdvancedTableTableModel {
   @tracked sortBy: HdsAdvancedTableTableArgs['sortBy'] = undefined;
   @tracked sortOrder: HdsAdvancedTableTableArgs['sortOrder'] =
     HdsAdvancedTableThSortOrderValues.Asc;
+  @tracked tableElement?: HTMLDivElement = undefined;
 
   childrenKey?: HdsAdvancedTableTableArgs['childrenKey'];
   hasResizableColumns?: HdsAdvancedTableTableArgs['hasResizableColumns'];
@@ -154,8 +155,10 @@ export default class HdsAdvancedTableTableModel {
 
   onStartColumnResize(): void {
     this.columns.forEach((column) => {
-      column.pxTransientWidth =
-        column.pxWidth ?? column.thElement?.offsetWidth ?? 0;
+      const width =
+        column.pxWidth ?? column.thElement?.getBoundingClientRect().width ?? 0;
+
+      column.pxTransientWidth = width;
     });
   }
 

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -71,6 +71,15 @@ export default class HdsAdvancedTableTableModel {
     this.setupData({ model, columns, sortBy, sortOrder });
   }
 
+  get debug() {
+    return this.columns.map((column) => ({
+      key: column.key,
+      label: column.label,
+      appliedWidth: column.appliedWidth,
+      widthDebts: column.widthDebts,
+    }));
+  }
+
   get sortCriteria(): string | HdsAdvancedTableSortingFunction<unknown> {
     // get the current column
     const currentColumn = this.columns.find(

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -152,7 +152,7 @@ export default class HdsAdvancedTableTableModel {
     }
   }
 
-  onStartColumnResize(): void {
+  setTransientColumnWidths(): void {
     this.columns.forEach((column) => {
       const width = column.pxWidth ?? column.thElement?.offsetWidth ?? 0;
 
@@ -160,7 +160,7 @@ export default class HdsAdvancedTableTableModel {
     });
   }
 
-  onStopColumnResize(): void {
+  resetTransientColumnWidths(): void {
     this.columns.forEach((column) => {
       column.pxTransientWidth = undefined;
     });

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -72,15 +72,6 @@ export default class HdsAdvancedTableTableModel {
     this.setupData({ model, columns, sortBy, sortOrder });
   }
 
-  get debug() {
-    return this.columns.map((column) => ({
-      key: column.key,
-      label: column.label,
-      appliedWidth: column.appliedWidth,
-      widthDebts: column.widthDebts,
-    }));
-  }
-
   get sortCriteria(): string | HdsAdvancedTableSortingFunction<unknown> {
     // get the current column
     const currentColumn = this.columns.find(
@@ -162,10 +153,13 @@ export default class HdsAdvancedTableTableModel {
     }
   }
 
-  setTransientColumnWidths(): void {
+  setTransientColumnWidths(options: { roundValues?: boolean } = {}): void {
+    const roundValues = options.roundValues ?? false;
+
     this.columns.forEach((column) => {
-      column.pxTransientWidth =
-        column.thElement?.getBoundingClientRect().width ?? 0;
+      column.pxTransientWidth = roundValues
+        ? Math.round(column.pxWidth)
+        : column.pxWidth;
     });
   }
 

--- a/packages/components/src/components/hds/advanced-table/models/table.ts
+++ b/packages/components/src/components/hds/advanced-table/models/table.ts
@@ -154,9 +154,7 @@ export default class HdsAdvancedTableTableModel {
 
   setTransientColumnWidths(): void {
     this.columns.forEach((column) => {
-      const width = column.pxWidth ?? column.thElement?.offsetWidth ?? 0;
-
-      column.pxTransientWidth = width;
+      column.pxTransientWidth = column.thElement?.offsetWidth ?? 0;
     });
   }
 

--- a/packages/components/src/components/hds/advanced-table/th-context-menu.ts
+++ b/packages/components/src/components/hds/advanced-table/th-context-menu.ts
@@ -114,10 +114,6 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
   ): void {
     const { onColumnResize } = this.args;
 
-    const { previous: previousColumn, next: nextColumn } = column.siblings;
-
-    previousColumn?.onNextColumnWidthRestored(column.imposedWidthDelta);
-    nextColumn?.onPreviousColumnWidthRestored();
     column.restoreWidth();
 
     if (typeof onColumnResize === 'function' && column.key !== undefined) {

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.hbs
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.hbs
@@ -9,7 +9,7 @@
   draggable="false"
   role="slider"
   aria-orientation="horizontal"
-  aria-valuenow={{@column.pxAppliedWidth}}
+  aria-valuenow={{or @column.pxAppliedWidth @column.thElement.offsetWidth}}
   aria-valuemin={{@column.pxMinWidth}}
   aria-valuemax={{@column.pxMaxWidth}}
   tabindex="0"

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.hbs
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.hbs
@@ -9,7 +9,7 @@
   draggable="false"
   role="slider"
   aria-orientation="horizontal"
-  aria-valuenow={{@column.pxWidth}}
+  aria-valuenow={{@column.pxAppliedWidth}}
   aria-valuemin={{@column.pxMinWidth}}
   aria-valuemax={{@column.pxMaxWidth}}
   tabindex="0"

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
@@ -153,7 +153,7 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     const { column } = this.args;
     const { next: nextColumn } = column.siblings;
 
-    column.table.onStartColumnResize();
+    column.table.setTransientColumnWidths();
 
     const currentColumnPxWidth = column.pxAppliedWidth;
     const currentNextColumnPxWidth = nextColumn?.pxAppliedWidth;
@@ -181,7 +181,7 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     this._applyTransientWidths();
 
     // reset the transient width
-    column.table.onStopColumnResize();
+    column.table.resetTransientColumnWidths();
 
     // reset the resizing state
     this._transientDelta = 0;
@@ -197,7 +197,7 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     const { column } = this.args;
     const { next: nextColumn } = column.siblings;
 
-    column.table.onStartColumnResize();
+    column.table.setTransientColumnWidths();
 
     this.resizing = {
       startX: event.clientX,
@@ -284,7 +284,7 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     this._applyTransientWidths();
 
     // reset the transient width
-    column.table.onStopColumnResize();
+    column.table.resetTransientColumnWidths();
 
     // reset the resizing state
     this.resizing = null;

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
@@ -41,13 +41,10 @@ function calculateEffectiveDelta(
     const absDeltaX = -deltaX;
     const maxCanShrinkCol = startColW - colMin;
 
-    // For expanding neighbor: only clamp min width, allow shrinking from above max width
     let maxCanExpandNext: number;
     if (startNextColW > nextMax) {
-      // If neighbor is above max width, allow unlimited expansion until it reaches max width
       maxCanExpandNext = Infinity;
     } else {
-      // If neighbor is at or below max width, apply normal max width constraint
       maxCanExpandNext = nextMax - startNextColW;
     }
 

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
@@ -216,8 +216,8 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
 
     this.resizing = {
       startX: event.clientX,
-      startColumnPxWidth: column.pxAppliedWidth ?? 0,
-      startNextColumnPxWidth: nextColumn?.pxAppliedWidth ?? 0,
+      startColumnPxWidth: Math.round(column.pxAppliedWidth ?? 0),
+      startNextColumnPxWidth: Math.round(nextColumn?.pxAppliedWidth ?? 0),
     };
 
     window.addEventListener('pointermove', this._boundResize);

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
@@ -225,13 +225,17 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
         startNextColumnPxWidth
       );
 
-      column.setPxTransientWidth(startColumnPxWidth + effectiveDelta);
+      column.setPxTransientWidth(
+        Math.round(startColumnPxWidth + effectiveDelta)
+      );
 
       // the actual new column width may differ from the intended width due to min/max constraints.
       const actualNewColumnWidth = column.pxAppliedWidth ?? startColumnPxWidth;
       const actualAppliedDelta = actualNewColumnWidth - startColumnPxWidth;
 
-      const nextColumnNewWidth = startNextColumnPxWidth - actualAppliedDelta;
+      const nextColumnNewWidth = Math.round(
+        startNextColumnPxWidth - actualAppliedDelta
+      );
 
       // Check if the next column is outside its min/max bounds
       const nextMaxWidth = nextColumn.pxMaxWidth ?? Infinity;
@@ -244,7 +248,7 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
 
       this._transientDelta = actualAppliedDelta;
     } else {
-      column.setPxTransientWidth(startColumnPxWidth + deltaX);
+      column.setPxTransientWidth(Math.round(startColumnPxWidth + deltaX));
     }
   }
 

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
@@ -208,6 +208,14 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     window.addEventListener('pointerup', this._boundStopResize);
   }
 
+  private _setColumnWidth(column: HdsAdvancedTableColumn, width: number): void {
+    if (width > column.pxMaxWidth || width < column.pxMinWidth) {
+      column.pxTransientWidth = width;
+    } else {
+      column.setPxTransientWidth(width);
+    }
+  }
+
   private _applyResizeDelta(
     deltaX: number,
     column: HdsAdvancedTableColumn,
@@ -227,7 +235,8 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
         startNextColumnPxWidth
       );
 
-      column.setPxTransientWidth(
+      this._setColumnWidth(
+        column,
         Math.round(startColumnPxWidth + effectiveDelta)
       );
 
@@ -235,18 +244,10 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
       const actualNewColumnWidth = column.pxAppliedWidth ?? startColumnPxWidth;
       const actualAppliedDelta = actualNewColumnWidth - startColumnPxWidth;
 
-      const nextColumnNewWidth = Math.round(
-        startNextColumnPxWidth - actualAppliedDelta
+      this._setColumnWidth(
+        nextColumn,
+        Math.round(startNextColumnPxWidth - actualAppliedDelta)
       );
-
-      // check if the next column is outside its min/max bounds
-      const nextMaxWidth = nextColumn.pxMaxWidth ?? Infinity;
-      if (startNextColumnPxWidth > nextMaxWidth) {
-        // allow resizing if column is already above max width or below min width
-        nextColumn.pxTransientWidth = nextColumnNewWidth;
-      } else {
-        nextColumn.setPxTransientWidth(nextColumnNewWidth);
-      }
 
       this._transientDelta = actualAppliedDelta;
     } else {

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.ts
@@ -190,6 +190,10 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
 
   @action
   startResize(event: PointerEvent): void {
+    if (event.button !== 0) {
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
 
@@ -235,6 +239,7 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
         startNextColumnPxWidth
       );
 
+      // set the width for the current column
       this._setColumnWidth(
         column,
         Math.round(startColumnPxWidth + effectiveDelta)
@@ -244,6 +249,7 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
       const actualNewColumnWidth = column.pxAppliedWidth ?? startColumnPxWidth;
       const actualAppliedDelta = actualNewColumnWidth - startColumnPxWidth;
 
+      // set the width for the next sibling column
       this._setColumnWidth(
         nextColumn,
         Math.round(startNextColumnPxWidth - actualAppliedDelta)

--- a/showcase/tests/integration/components/hds/advanced-table/index-test.js
+++ b/showcase/tests/integration/components/hds/advanced-table/index-test.js
@@ -10,6 +10,7 @@ import {
   click,
   focus,
   setupOnerror,
+  settled,
   find,
   triggerEvent,
   triggerKeyEvent,
@@ -1927,5 +1928,70 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
     assert
       .dom('.hds-advanced-table__th.hds-advanced-table__th--is-sticky-column')
       .doesNotExist();
+  });
+
+  // Resize behavior tests
+  test('columns will grow to fill available space when width is not explicitly set', async function (assert) {
+    this.set('width', '300px');
+
+    await render(hbs`
+      <div id="resize-test-container" {{style width=this.width}}>
+        <Hds::AdvancedTable
+          id='data-test-advanced-table'
+          @columns={{array
+            (hash key='name' label='Name')
+            (hash key='biography' label='Biography')
+            (hash key='occupation' label='Occupation')
+            (hash key='age' label='Age')
+            (hash key='hair' label='Hair Color')
+            (hash key='eyes' label='Eye Color')
+            (hash key='salary' label='Salary')
+          }}
+          @model={{array
+            (hash
+              name="John Jacob Jingleheimer Schmidt"
+              biography="A long biography text that should cause overflow. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+              occupation="Professional Name Repeater"
+              age=42
+              hair="Brown"
+              eyes="Blue"
+              salary=1000000
+            )
+          }}
+        >
+          <:body as |B|>
+            <B.Tr>
+              <B.Td>{{B.data.name}}</B.Td>
+              <B.Td>{{B.data.biography}}</B.Td>
+              <B.Td>{{B.data.occupation}}</B.Td>
+              <B.Td>{{B.data.age}}</B.Td>
+              <B.Td>{{B.data.hair}}</B.Td>
+              <B.Td>{{B.data.eyes}}</B.Td>
+              <B.Td>{{B.data.salary}}</B.Td>
+            </B.Tr>
+          </:body>
+        </Hds::AdvancedTable>
+      </div>
+    `);
+
+    // eslint-disable-next-line ember/no-settled-after-test-helper
+    await settled();
+
+    const table = find('#data-test-advanced-table');
+    const container = find('#resize-test-container');
+
+    assert.ok(
+      table.offsetWidth >= container.offsetWidth,
+      'Table width is greater than the container width',
+    );
+
+    this.set('width', '100%');
+
+    await settled();
+
+    assert.ok(
+      table.offsetWidth === container.offsetWidth,
+      'Table width grows to fit container width',
+    );
   });
 });

--- a/showcase/tests/integration/components/hds/advanced-table/index-test.js
+++ b/showcase/tests/integration/components/hds/advanced-table/index-test.js
@@ -49,9 +49,9 @@ async function performContextMenuAction(th, key) {
 }
 
 async function simulateRightPointerDrag(handle) {
-  await triggerEvent(handle, 'pointerdown', { clientX: 100 });
-  await triggerEvent(handle, 'pointermove', { clientX: 130 });
-  await triggerEvent(window, 'pointerup');
+  await triggerEvent(handle, 'pointerdown', { clientX: 100, button: 0 });
+  await triggerEvent(handle, 'pointermove', { clientX: 130, buttons: 1 });
+  await triggerEvent(window, 'pointerup', { button: 0 });
 }
 
 // we're using this for multiple tests so we'll declare context once and use it when we need it.

--- a/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
+++ b/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
@@ -190,21 +190,21 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
 
     column.setPxTransientWidth(100);
     assert.strictEqual(
-      column.width,
+      column.transientWidth,
       '150px',
       'respects minimum width constraint',
     );
 
     column.setPxTransientWidth(300);
     assert.strictEqual(
-      column.width,
+      column.transientWidth,
       '250px',
       'respects maximum width constraint',
     );
 
     column.setPxTransientWidth(200);
     assert.strictEqual(
-      column.width,
+      column.transientWidth,
       '200px',
       'sets exact width when within constraints',
     );
@@ -220,7 +220,7 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
 
     assert.strictEqual(column.width, '200px', 'initial width is set');
 
-    column.setPxWidth(300);
+    column.pxWidth = 300;
     assert.strictEqual(column.width, '300px', 'width is updated');
 
     column.restoreWidth();

--- a/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
+++ b/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
@@ -29,10 +29,9 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
       false,
       'isVisuallyHidden is false when not provided',
     );
-    assert.strictEqual(
-      column.key,
-      undefined,
-      'key is undefined when not provided',
+    assert.ok(
+      typeof column.key === 'string',
+      'key defaults to a uuid when not provided',
     );
     assert.strictEqual(
       column.minWidth,
@@ -211,11 +210,30 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
   });
 
   test('restoreWidth sets width back to original value', function (assert) {
+    // Create mock table with multiple columns
+    const mockTable = {
+      columns: [
+        new HdsAdvancedTableColumn({
+          column: { label: 'First', key: 'first' },
+          table: null,
+        }),
+        new HdsAdvancedTableColumn({
+          column: { label: 'Second', key: 'second' },
+          table: null,
+        }),
+        new HdsAdvancedTableColumn({
+          column: { label: 'Third', key: 'third' },
+          table: null,
+        }),
+      ],
+    };
+
     const column = new HdsAdvancedTableColumn({
       column: {
         label: 'Restore Test',
         width: '200px',
       },
+      table: mockTable,
     });
 
     assert.strictEqual(column.width, '200px', 'initial width is set');

--- a/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
+++ b/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
@@ -133,9 +133,15 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
   });
 
   test('isPxSize utility function works correctly', function (assert) {
+    const thElement = document.createElement('div');
+    thElement.style.width = '100px';
+    document.body.appendChild(thElement);
+
     const column = new HdsAdvancedTableColumn({
       column: { label: 'Test' },
     });
+
+    column.thElement = thElement;
 
     // Setting valid px values
     column.width = '100px';
@@ -155,25 +161,29 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
     column.width = '100%';
     assert.strictEqual(
       column.pxWidth,
-      undefined,
-      'returns undefined for percentage values',
+      100,
+      'returns the width of the thElement',
     );
 
     column.width = '10em';
     assert.strictEqual(
       column.pxWidth,
-      undefined,
-      'returns undefined for em values',
+      100,
+      'returns the width of the thElement',
     );
 
     column.width = 'auto';
-    assert.strictEqual(column.pxWidth, undefined, 'returns undefined for auto');
+    assert.strictEqual(
+      column.pxWidth,
+      100,
+      'returns the width of the thElement',
+    );
 
     column.width = undefined;
     assert.strictEqual(
       column.pxWidth,
-      undefined,
-      'returns undefined when width is undefined',
+      100,
+      'returns the width of the thElement',
     );
   });
 

--- a/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
+++ b/showcase/tests/unit/components/hds/advanced-table/models/column-test.js
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import HdsAdvancedTableColumn, {
   DEFAULT_MAX_WIDTH,
   DEFAULT_MIN_WIDTH,
+  DEFAULT_WIDTH,
 } from '@hashicorp/design-system-components/components/hds/advanced-table/models/column';
 
 module('Unit | Component | hds/advanced-table/models/column', function () {
@@ -50,8 +51,8 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
     );
     assert.strictEqual(
       column.width,
-      undefined,
-      'width is undefined when not provided',
+      DEFAULT_WIDTH,
+      'width is set to the default when not provided',
     );
   });
 
@@ -177,7 +178,7 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
     );
   });
 
-  test('setPxWidth respects min/max constraints', function (assert) {
+  test('setPxTransientWidth respects min/max constraints', function (assert) {
     const column = new HdsAdvancedTableColumn({
       column: {
         label: 'Constrained Width',
@@ -187,21 +188,21 @@ module('Unit | Component | hds/advanced-table/models/column', function () {
       },
     });
 
-    column.setPxWidth(100);
+    column.setPxTransientWidth(100);
     assert.strictEqual(
       column.width,
       '150px',
       'respects minimum width constraint',
     );
 
-    column.setPxWidth(300);
+    column.setPxTransientWidth(300);
     assert.strictEqual(
       column.width,
       '250px',
       'respects maximum width constraint',
     );
 
-    column.setPxWidth(200);
+    column.setPxTransientWidth(200);
     assert.strictEqual(
       column.width,
       '200px',


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes a bug that was introduced by the column resize feature. The bug prevented the columns from expanding to fill available space if the viewport was expanded.

### :hammer_and_wrench: Detailed description

A key requirement of column resizing is that the columns being resized need to have an explicit pixel width in order to expand/contract with the cursor.

The previous implementation incorrectly applied the pixel width of the columns at render to the column configuration object. This prevented the table from filling the available space if the viewport was expanded.

The fix was to convert all column widths to pixels during the resizing process. Columns that were actively involved in resizing will have their new pixel widths "baked" into the column model after resizing is complete, whereas columns that were not involved will revert back to pre-resize values.

For example:

If I have a table with 4 columns and do not set any explicit width values on columns, each column will have an initial width of 1 fractional unit or `1fr`.

```
1fr 1fr 1fr 1fr
```

When I start to resize a column, each column will be assigned a transient width to be used during the resize. If the table is within a `1000px` container, each column will be assigned a width of `250px`.

```
250px 250px 250px 250px
```

If I expand the first column by `10px`, at the end of the resize event, the css grid values will be:

```
260px 240px 1fr 1fr
```

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5171](https://hashicorp.atlassian.net/browse/HDS-5171)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5171]: https://hashicorp.atlassian.net/browse/HDS-5171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ