### PR TITLE
HDS-5265: a11y guardrails for dropdown toggle icon

### DIFF
--- a/packages/components/src/components/hds/dropdown/toggle/icon.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.ts
@@ -7,7 +7,10 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
-import { HdsDropdownToggleIconSizeValues } from './types.ts';
+import {
+  HdsDropdownToggleIconSizeValues,
+  HdsDropdownToggleIconAllowedListValues,
+} from './types.ts';
 
 import type { HdsIconSignature } from '../../icon';
 import type { HdsDropdownToggleIconSizes } from './types';
@@ -17,6 +20,10 @@ import type Owner from '@ember/owner';
 
 export const DEFAULT_SIZE = HdsDropdownToggleIconSizeValues.Medium;
 export const SIZES: string[] = Object.values(HdsDropdownToggleIconSizeValues);
+
+export const ALLOWED_LIST: string[] = Object.values(
+  HdsDropdownToggleIconAllowedListValues
+);
 
 export interface HdsDropdownToggleIconSignature {
   Args: {
@@ -112,6 +119,17 @@ export default class HdsDropdownToggleIcon extends Component<HdsDropdownToggleIc
    * @default true
    */
   get hasChevron(): boolean {
+    const { icon, hasChevron } = this.args;
+
+    if (icon && !ALLOWED_LIST.includes(icon) && hasChevron === false) {
+      assert(
+        `@hasChevron for "Hds::Dropdown::Toggle::Icon" must be true unless the icon is one of the following: ${ALLOWED_LIST.join(
+          ', '
+        )}; received: ${icon}`,
+        ALLOWED_LIST.includes(icon)
+      );
+    }
+
     return this.args.hasChevron ?? true;
   }
 

--- a/packages/components/src/components/hds/dropdown/toggle/types.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/types.ts
@@ -22,3 +22,10 @@ export enum HdsDropdownToggleButtonColorValues {
 }
 export type HdsDropdownToggleButtonColors =
   `${HdsDropdownToggleButtonColorValues}`;
+
+export enum HdsDropdownToggleIconAllowedListValues {
+  MoreHorizontal = 'more-horizontal',
+  MoreVertical = 'more-vertical',
+}
+export type HdsDropdownToggleIconAllowedList =
+  `${HdsDropdownToggleIconAllowedListValues}`;

--- a/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.js
+++ b/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.js
@@ -155,4 +155,18 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
       throw new Error(errorMessage);
     });
   });
+  test('it should throw an assertion if an incorrect value for @icon is provided and @hasChevron is false', async function (assert) {
+    const errorMessage =
+      '@hasChevron for "Hds::Dropdown::Toggle::Icon" must be true unless the icon is one of the following: more-horizontal, more-vertical; received: user';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(
+      hbs`<Hds::Dropdown::Toggle::Icon @icon="user" @text="user menu" @hasChevron={{false}}/>`,
+    );
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
 });


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR should add a11y guardrails to the Dropdown Toggle Icon component where the consumer can only set `@hasChevron` to false if the icon is in a list of allowed values.

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

Test currently failing, unsure why
<img width="720" height="206" alt="image" src="https://github.com/user-attachments/assets/e069889c-65ce-4610-81aa-6e72150cf3f7" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5265](https://hashicorp.atlassian.net/browse/HDS-5265)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>