### PR TITLE
`AdvancedTable`: fix styles for right/center aligned cells

### DIFF
--- a/.changeset/bitter-knives-call.md
+++ b/.changeset/bitter-knives-call.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/table/advanced-table -->
+`AdvancedTable` - Fixed styles for right and center aligned cells.
+<!-- END -->

--- a/packages/components/src/components/hds/advanced-table/th.hbs
+++ b/packages/components/src/components/hds/advanced-table/th.hbs
@@ -23,7 +23,7 @@
   }}
   ...attributes
 >
-  <Hds::Layout::Flex @justify="space-between" @align="center" @gap="8" {{style flex-grow="1"}}>
+  <Hds::Layout::Flex @justify="space-between" @align="center" @gap="8">
     {{#if @column.isVisuallyHidden}}
       <span class="sr-only">{{yield}}</span>
     {{else}}

--- a/packages/components/src/components/hds/advanced-table/th.hbs
+++ b/packages/components/src/components/hds/advanced-table/th.hbs
@@ -28,16 +28,16 @@
       <span class="sr-only">{{yield}}</span>
     {{else}}
       {{#if @tooltip}}
+        {{#if @isExpandable}}
+          <Hds::AdvancedTable::ThButtonExpand
+            @labelId={{this._labelId}}
+            @onToggle={{@onClickToggle}}
+            @isExpanded={{@isExpanded}}
+            @isExpandAll={{@hasExpandAllButton}}
+            {{this._manageExpandButton}}
+          />
+        {{/if}}
         <div class="hds-advanced-table__th-content">
-          {{#if @isExpandable}}
-            <Hds::AdvancedTable::ThButtonExpand
-              @labelId={{this._labelId}}
-              @onToggle={{@onClickToggle}}
-              @isExpanded={{@isExpanded}}
-              @isExpandAll={{@hasExpandAllButton}}
-              {{this._manageExpandButton}}
-            />
-          {{/if}}
           <span
             id={{this._labelId}}
             class="hds-advanced-table__th-content-text hds-typography-body-200 hds-font-weight-semibold"
@@ -47,16 +47,16 @@
           <Hds::AdvancedTable::ThButtonTooltip @tooltip={{@tooltip}} @labelId={{this._labelId}} />
         </div>
       {{else}}
+        {{#if @isExpandable}}
+          <Hds::AdvancedTable::ThButtonExpand
+            @labelId={{this._labelId}}
+            @onToggle={{@onClickToggle}}
+            @isExpanded={{@isExpanded}}
+            @isExpandAll={{@hasExpandAllButton}}
+            {{this._manageExpandButton}}
+          />
+        {{/if}}
         <div class="hds-advanced-table__th-content">
-          {{#if @isExpandable}}
-            <Hds::AdvancedTable::ThButtonExpand
-              @labelId={{this._labelId}}
-              @onToggle={{@onClickToggle}}
-              @isExpanded={{@isExpanded}}
-              @isExpandAll={{@hasExpandAllButton}}
-              {{this._manageExpandButton}}
-            />
-          {{/if}}
           <span
             class="hds-advanced-table__th-content-text hds-typography-body-200 hds-font-weight-semibold"
             id={{this._labelId}}

--- a/packages/components/src/components/hds/advanced-table/th.hbs
+++ b/packages/components/src/components/hds/advanced-table/th.hbs
@@ -23,7 +23,7 @@
   }}
   ...attributes
 >
-  <Hds::Layout::Flex @justify="space-between" @align="center" @gap="8">
+  <Hds::Layout::Flex @justify="space-between" @align="center" @gap="8" {{style flex-grow="1"}}>
     {{#if @column.isVisuallyHidden}}
       <span class="sr-only">{{yield}}</span>
     {{else}}

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -165,6 +165,7 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
       text-align: center;
 
       .hds-advanced-table__th-content {
+        flex-grow: 1;
         justify-content: center;
       }
     }
@@ -174,6 +175,7 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
       text-align: right;
 
       .hds-advanced-table__th-content {
+        flex-grow: 1;
         justify-content: flex-end;
       }
     }
@@ -472,20 +474,14 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
 
   .hds-advanced-table__th--align-center,
   .hds-advanced-table__td--align-center {
+    justify-content: center;
     text-align: center;
-
-    .hds-advanced-table__th-content {
-      justify-content: center;
-    }
   }
 
   .hds-advanced-table__th--align-right,
   .hds-advanced-table__td--align-right {
+    justify-content: flex-end;
     text-align: right;
-
-    .hds-advanced-table__th-content {
-      justify-content: flex-end;
-    }
   }
 
   // vertical alignment (applied at table level)

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -471,16 +471,30 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
 
   // horizontal alignment
 
-  .hds-advanced-table__th--align-center,
   .hds-advanced-table__td--align-center {
     justify-content: center;
     text-align: center;
   }
 
-  .hds-advanced-table__th--align-right,
+  .hds-advanced-table__th--align-center {
+    text-align: center;
+
+    .hds-advanced-table__th-content {
+      justify-content: center;
+    }
+  }
+
   .hds-advanced-table__td--align-right {
     justify-content: flex-end;
     text-align: right;
+  }
+
+  .hds-advanced-table__th--align-right {
+    text-align: right;
+
+    .hds-advanced-table__th-content {
+      justify-content: flex-end;
+    }
   }
 
   // vertical alignment (applied at table level)

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -165,7 +165,6 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
       text-align: center;
 
       .hds-advanced-table__th-content {
-        flex-grow: 1;
         justify-content: center;
       }
     }
@@ -175,7 +174,6 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
       text-align: right;
 
       .hds-advanced-table__th-content {
-        flex-grow: 1;
         justify-content: flex-end;
       }
     }
@@ -265,6 +263,7 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
 // multi-select (isSelectable=true)
 .hds-advanced-table__th-content {
   display: flex;
+  flex-grow: 1;
   flex-shrink: 1;
   gap: 8px;
   align-items: center;

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -222,7 +222,6 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
   &.hds-advanced-table__thead--has-resizable-columns {
     .hds-advanced-table__th .hds-advanced-table__th-content-text {
       display: block;
-      width: 100%;
       min-width: 30px;
       overflow: hidden;
       white-space: nowrap;

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -397,13 +397,16 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
     }
   }
 
-  .hds-advanced-table__th,
   .hds-advanced-table__td {
     display: flex;
     gap: 8px;
     align-content: center;
     align-items: flex-start;
     justify-content: flex-start;
+  }
+
+  .hds-advanced-table__th,
+  .hds-advanced-table__td {
     height: 100%;
     font-weight: var(--token-typography-font-weight-regular);
     font-size: var(--token-typography-body-200-font-size);

--- a/showcase/app/controllers/page-components/advanced-table.ts
+++ b/showcase/app/controllers/page-components/advanced-table.ts
@@ -98,9 +98,11 @@ export default class PageComponentsAdvancedTableController extends Controller {
       model: [
         {
           value: 'lorem',
+          status: 'active',
         },
         {
           value: 'ipsum',
+          status: 'active',
         },
       ],
       hasResizableColumns: true,
@@ -108,6 +110,9 @@ export default class PageComponentsAdvancedTableController extends Controller {
         {
           label: 'Label',
           isVisuallyHidden: true,
+        },
+        {
+          label: 'Status',
         },
       ],
     });

--- a/showcase/app/controllers/page-components/advanced-table.ts
+++ b/showcase/app/controllers/page-components/advanced-table.ts
@@ -110,9 +110,11 @@ export default class PageComponentsAdvancedTableController extends Controller {
         {
           label: 'Label',
           isVisuallyHidden: true,
+          width: '200px',
         },
         {
           label: 'Status',
+          width: '200px',
         },
       ],
     });

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -411,7 +411,7 @@
     @columns={{array
       (hash key="artist" label="Artist" isSortable=true)
       (hash key="album" label="Album" isSortable=true)
-      (hash key="year" label="Release Year")
+      (hash key="year" label="Release Year" align="right")
     }}
     @sortBy="artist"
   >

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -1555,7 +1555,7 @@
       <div
         class="hds-advanced-table hds-advanced-table--density-medium"
         role="grid"
-        {{style gridTemplateColumns="repeat(3, 1fr)"}}
+        {{style gridTemplateColumns="repeat(4, 1fr)"}}
       >
         <div class="hds-advanced-table__thead hds-advanced-table__thead--has-resizable-columns" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
@@ -1576,6 +1576,8 @@
               @column={{get this.sampleTableModel.columns 1}}
               @hasResizableColumns={{true}}
             >Right</Hds::AdvancedTable::ThSort>
+            {{! Note: need a last column to avoid a scrollbar}}
+            <Hds::AdvancedTable::ThSort>Last column</Hds::AdvancedTable::ThSort>
           </div>
         </div>
       </div>
@@ -1735,7 +1737,7 @@
       <div
         class="hds-advanced-table hds-advanced-table--density-medium"
         role="grid"
-        {{style gridTemplateColumns="repeat(3, 1fr)"}}
+        {{style gridTemplateColumns="repeat(4, 1fr)"}}
       >
         <div class="hds-advanced-table__thead hds-advanced-table__thead--has-resizable-columns" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
@@ -1759,6 +1761,8 @@
               @column={{get this.sampleTableModel.columns 1}}
               @hasResizableColumns={{true}}
             >Right</Hds::AdvancedTable::Th>
+            {{! Note: need a last column to avoid a scrollbar}}
+            <Hds::AdvancedTable::Th>Last column</Hds::AdvancedTable::Th>
           </div>
         </div>
         <div class="hds-advanced-table__tbody" role="rowgroup">
@@ -1777,6 +1781,8 @@
               @isExpandable={{true}}
               @tooltip="Here is more information"
             >Right</Hds::AdvancedTable::Th>
+            {{! Note: need a last column to avoid a scrollbar}}
+            <Hds::AdvancedTable::Th>Last column</Hds::AdvancedTable::Th>
           </div>
         </div>
       </div>

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -1680,8 +1680,33 @@
 
   <Shw::Flex @label="Alignment" as |SF|>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(6, 1fr)"}}>
+      <div
+        class="hds-advanced-table hds-advanced-table--density-medium"
+        role="grid"
+        {{style gridTemplateColumns="repeat(6, 1fr)"}}
+      >
         <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
+            <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th
+              @isExpandable={{true}}
+              @tooltip="Here is more information"
+            >Left</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th
+              @align="center"
+              @isExpandable={{true}}
+              @tooltip="Here is more information"
+            >Center</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th
+              @align="right"
+              @isExpandable={{true}}
+              @tooltip="Here is more information"
+            >Right</Hds::AdvancedTable::Th>
+          </div>
+        </div>
+        <div class="hds-advanced-table__tbody" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -1534,17 +1534,64 @@
 
   <Shw::Flex @label="Alignment" as |SF|>
     <SF.Item @grow={{true}}>
-      <div class="hds-advanced-table" role="grid" {{style gridTemplateColumns="repeat(6, 1fr)"}}>
+      <div
+        class="hds-advanced-table hds-advanced-table--density-medium"
+        role="grid"
+        {{style gridTemplateColumns="repeat(3, 1fr)"}}
+      >
         <div class="hds-advanced-table__thead" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
-            <Hds::AdvancedTable::ThSort>Left</Hds::AdvancedTable::ThSort>
+            <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
+          </div>
+        </div>
+        <div class="hds-advanced-table__tbody" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
+            <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
+          </div>
+        </div>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex @label="Alignment with all interactive elements" as |SF|>
+    <SF.Item @grow={{true}}>
+      <div
+        class="hds-advanced-table hds-advanced-table--density-medium"
+        role="grid"
+        {{style gridTemplateColumns="repeat(3, 1fr)"}}
+      >
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
+            <Hds::AdvancedTable::ThSort
+              @tooltip="Here is more information"
+              @column={{get this.sampleTableModel.columns 1}}
+              @hasResizableColumns={{true}}
+            >Left</Hds::AdvancedTable::ThSort>
+            <Hds::AdvancedTable::ThSort
+              @align="center"
+              @tooltip="Here is more information"
+              @column={{get this.sampleTableModel.columns 1}}
+              @hasResizableColumns={{true}}
+            >Center</Hds::AdvancedTable::ThSort>
+            <Hds::AdvancedTable::ThSort
+              @align="right"
+              @tooltip="Here is more information"
+              @column={{get this.sampleTableModel.columns 1}}
+              @hasResizableColumns={{true}}
+            >Right</Hds::AdvancedTable::ThSort>
+          </div>
+        </div>
+        <div class="hds-advanced-table__tbody" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::ThSort @tooltip="Here is more information">Left</Hds::AdvancedTable::ThSort>
-            <Hds::AdvancedTable::ThSort @align="center">Center</Hds::AdvancedTable::ThSort>
             <Hds::AdvancedTable::ThSort
               @align="center"
               @tooltip="Here is more information"
             >Center</Hds::AdvancedTable::ThSort>
-            <Hds::AdvancedTable::ThSort @align="right">Right</Hds::AdvancedTable::ThSort>
             <Hds::AdvancedTable::ThSort
               @align="right"
               @tooltip="Here is more information"
@@ -1683,46 +1730,68 @@
       <div
         class="hds-advanced-table hds-advanced-table--density-medium"
         role="grid"
-        {{style gridTemplateColumns="repeat(6, 1fr)"}}
+        {{style gridTemplateColumns="repeat(3, 1fr)"}}
       >
         <div class="hds-advanced-table__thead" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
+          </div>
+        </div>
+        <div class="hds-advanced-table__tbody" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
+            <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
+          </div>
+        </div>
+      </div>
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex @label="Alignment with all interactive elements" as |SF|>
+    <SF.Item @grow={{true}}>
+      <div
+        class="hds-advanced-table hds-advanced-table--density-medium"
+        role="grid"
+        {{style gridTemplateColumns="repeat(3, 1fr)"}}
+      >
+        <div class="hds-advanced-table__thead" role="rowgroup">
+          <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th
               @isExpandable={{true}}
               @tooltip="Here is more information"
+              @column={{get this.sampleTableModel.columns 1}}
               @hasResizableColumns={{true}}
             >Left</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th
               @align="center"
               @isExpandable={{true}}
               @tooltip="Here is more information"
+              @column={{get this.sampleTableModel.columns 1}}
               @hasResizableColumns={{true}}
             >Center</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th
               @align="right"
               @isExpandable={{true}}
               @tooltip="Here is more information"
+              @column={{get this.sampleTableModel.columns 1}}
               @hasResizableColumns={{true}}
             >Right</Hds::AdvancedTable::Th>
           </div>
         </div>
         <div class="hds-advanced-table__tbody" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
-            <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th
               @isExpandable={{true}}
               @tooltip="Here is more information"
             >Left</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th
               @align="center"
               @isExpandable={{true}}
               @tooltip="Here is more information"
             >Center</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th
               @align="right"
               @isExpandable={{true}}

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -1691,18 +1691,21 @@
             <Hds::AdvancedTable::Th
               @isExpandable={{true}}
               @tooltip="Here is more information"
+              @hasResizableColumns={{true}}
             >Left</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th
               @align="center"
               @isExpandable={{true}}
               @tooltip="Here is more information"
+              @hasResizableColumns={{true}}
             >Center</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th
               @align="right"
               @isExpandable={{true}}
               @tooltip="Here is more information"
+              @hasResizableColumns={{true}}
             >Right</Hds::AdvancedTable::Th>
           </div>
         </div>

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -2382,7 +2382,6 @@
                     mock-state-value={{state}}
                     @column={{get this.sampleTableModel.columns 0}}
                     @hasResizableColumns={{true}}
-                    aria-valuenow="200"
                   />
                 </Hds::Layout::Flex>
               </div>

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -1684,11 +1684,22 @@
         <div class="hds-advanced-table__thead" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @tooltip="Here is more information">Left</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th
+              @isExpandable={{true}}
+              @tooltip="Here is more information"
+            >Left</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="center" @tooltip="Here is more information">Center</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th
+              @align="center"
+              @isExpandable={{true}}
+              @tooltip="Here is more information"
+            >Center</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="right" @tooltip="Here is more information">Right</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th
+              @align="right"
+              @isExpandable={{true}}
+              @tooltip="Here is more information"
+            >Right</Hds::AdvancedTable::Th>
           </div>
         </div>
       </div>

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -1541,16 +1541,9 @@
       >
         <div class="hds-advanced-table__thead" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
-            <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
-          </div>
-        </div>
-        <div class="hds-advanced-table__tbody" role="rowgroup">
-          <div class="hds-advanced-table__tr" role="row">
-            <Hds::AdvancedTable::Th>Left</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="center">Center</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @align="right">Right</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::ThSort>Left</Hds::AdvancedTable::ThSort>
+            <Hds::AdvancedTable::ThSort @align="center">Center</Hds::AdvancedTable::ThSort>
+            <Hds::AdvancedTable::ThSort @align="right">Right</Hds::AdvancedTable::ThSort>
           </div>
         </div>
       </div>
@@ -1564,7 +1557,7 @@
         role="grid"
         {{style gridTemplateColumns="repeat(3, 1fr)"}}
       >
-        <div class="hds-advanced-table__thead" role="rowgroup">
+        <div class="hds-advanced-table__thead hds-advanced-table__thead--has-resizable-columns" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::ThSort
               @tooltip="Here is more information"
@@ -1582,19 +1575,6 @@
               @tooltip="Here is more information"
               @column={{get this.sampleTableModel.columns 1}}
               @hasResizableColumns={{true}}
-            >Right</Hds::AdvancedTable::ThSort>
-          </div>
-        </div>
-        <div class="hds-advanced-table__tbody" role="rowgroup">
-          <div class="hds-advanced-table__tr" role="row">
-            <Hds::AdvancedTable::ThSort @tooltip="Here is more information">Left</Hds::AdvancedTable::ThSort>
-            <Hds::AdvancedTable::ThSort
-              @align="center"
-              @tooltip="Here is more information"
-            >Center</Hds::AdvancedTable::ThSort>
-            <Hds::AdvancedTable::ThSort
-              @align="right"
-              @tooltip="Here is more information"
             >Right</Hds::AdvancedTable::ThSort>
           </div>
         </div>
@@ -1757,7 +1737,7 @@
         role="grid"
         {{style gridTemplateColumns="repeat(3, 1fr)"}}
       >
-        <div class="hds-advanced-table__thead" role="rowgroup">
+        <div class="hds-advanced-table__thead hds-advanced-table__thead--has-resizable-columns" role="rowgroup">
           <div class="hds-advanced-table__tr" role="row">
             <Hds::AdvancedTable::Th
               @isExpandable={{true}}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the styles when the user sets `@align` to `"right"` or `"center"`. 

**[PREVIEW](https://hds-showcase-git-hds-5254-advanced-table-align-hashicorp.vercel.app/components/advanced-table#thsort)**

### :camera_flash: Screenshots

**CURRENT PRODUCTION SHOWCASE**
<img width="1227" height="103" alt="Screenshot 2025-08-06 at 6 00 58 PM" src="https://github.com/user-attachments/assets/453fa50a-a887-4a04-af28-765b6d17fd6f" />
<img width="1222" height="109" alt="Screenshot 2025-08-06 at 6 01 04 PM" src="https://github.com/user-attachments/assets/cc0e8c58-763a-4a76-a81c-5d72d06cbd6d" />
<img width="1263" height="568" alt="Screenshot 2025-08-06 at 6 01 59 PM" src="https://github.com/user-attachments/assets/26c05fbb-6094-42d0-a527-eb803daea31f" />

**AFTER PROPOSED FIX**
<img width="1230" height="105" alt="Screenshot 2025-08-06 at 6 02 29 PM" src="https://github.com/user-attachments/assets/f3c3ddf5-6ecb-4a39-99e4-fdce134b0e21" />
<img width="1230" height="103" alt="Screenshot 2025-08-07 at 8 00 10 AM" src="https://github.com/user-attachments/assets/c27f083b-3f7c-4785-a0f2-7c05b79a0ddc" />
<img width="1250" height="598" alt="Screenshot 2025-08-06 at 6 02 51 PM" src="https://github.com/user-attachments/assets/330d7961-ecbf-41ce-8c04-8751612f9567" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5254](https://hashicorp.atlassian.net/browse/HDS-5254)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5254]: https://hashicorp.atlassian.net/browse/HDS-5254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ