### PR TITLE
Showcase: fix examples of visually hidden header cells in AdvancedTable page

### DIFF
--- a/showcase/app/controllers/page-components/advanced-table.ts
+++ b/showcase/app/controllers/page-components/advanced-table.ts
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { deepTracked } from 'ember-deep-tracked';
 import { later } from '@ember/runloop';
+import type Owner from '@ember/owner';
 
 import type { PageComponentsAdvancedTableModel } from 'showcase/routes/page-components/advanced-table';
 
@@ -85,15 +86,30 @@ export default class PageComponentsAdvancedTableController extends Controller {
   // @ts-expect-error - we need to reevaluate how we get the data for the table demos when we break up the template files into sub components
   @deepTracked multiSelectUserData__demo4 = [...this.model.userDataDemo4];
   @tracked focusableElementsVisible = false;
-  @deepTracked thResizeHandleTable = new HdsAdvancedTableModel({
-    // @ts-expect-error - this will be fixed in HDS-5090
-    model: this.model.userDataShort,
-    columns: [
-      {
-        label: 'Label',
-      },
-    ],
-  });
+
+  sampleTableModel!: HdsAdvancedTableModel;
+
+  constructor(owner: Owner) {
+    super(owner);
+
+    this.sampleTableModel = new HdsAdvancedTableModel({
+      model: [
+        {
+          value: 'lorem',
+        },
+        {
+          value: 'ipsum',
+        },
+      ],
+      hasResizableColumns: true,
+      columns: [
+        {
+          label: 'Label',
+          isVisuallyHidden: true,
+        },
+      ],
+    });
+  }
 
   get clustersWithExtraData() {
     return this.model.clusters.map((record) => {

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -1689,7 +1689,7 @@
             <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Ipsum</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Dolor</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @isVisuallyHidden={{true}}>Sit amet</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @column={{get this.sampleTableModel.columns 0}}>Sit amet</Hds::AdvancedTable::Th>
           </div>
         </div>
       </div>
@@ -1704,7 +1704,7 @@
             <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Ipsum</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Dolor</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @isVisuallyHidden={{true}}>Sit amet</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @column={{get this.sampleTableModel.columns 0}}>Sit amet</Hds::AdvancedTable::Th>
           </div>
         </div>
       </div>
@@ -1719,7 +1719,7 @@
             <Hds::AdvancedTable::Th>Lorem</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Ipsum</Hds::AdvancedTable::Th>
             <Hds::AdvancedTable::Th>Dolor</Hds::AdvancedTable::Th>
-            <Hds::AdvancedTable::Th @isVisuallyHidden={{true}}>Sit amet</Hds::AdvancedTable::Th>
+            <Hds::AdvancedTable::Th @column={{get this.sampleTableModel.columns 0}}>Sit amet</Hds::AdvancedTable::Th>
           </div>
         </div>
       </div>
@@ -2258,7 +2258,7 @@
                   </div>
                   <Hds::AdvancedTable::ThResizeHandle
                     mock-state-value={{state}}
-                    @column={{get this.thResizeHandleTable.columns 0}}
+                    @column={{get this.sampleTableModel.columns 0}}
                     @hasResizableColumns={{true}}
                     aria-valuenow="200"
                   />


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the examples of visually hidden header cells in the Advanced Header showcase page. This is because the TH component no longer uses `@isVisuallyHidden` to hide cell content - it uses the `columns` model.

In a future PR, we should deprecate the `@isVisuallyHidden` argument because it doesn't do anything. This probably not have any affect on consumers, but we could do it in `5.0.0` to be safe.

### :camera_flash: Screenshots

**CURRENT SHOWCASE**
<img width="1261" height="157" alt="Screenshot 2025-08-06 at 6 30 14 PM" src="https://github.com/user-attachments/assets/47b4620e-7759-41e3-8e87-52e0c63f5c12" />

**AFTER FIX**
<img width="1277" height="122" alt="Screenshot 2025-08-06 at 6 30 33 PM" src="https://github.com/user-attachments/assets/60022c16-d687-46d8-9a06-52a22f3458bc" />

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>