### PR TITLE
`CodeEditor` - React to `@value` changes

### DIFF
--- a/packages/components/src/components/hds/code-editor/index.ts
+++ b/packages/components/src/components/hds/code-editor/index.ts
@@ -14,9 +14,9 @@ import { StateEffect } from '@codemirror/state';
 import HdsCodeEditorDescription from './description.ts';
 import HdsCodeEditorTitle from './title.ts';
 
+import type Owner from '@ember/owner';
 import type { ViewUpdate } from '@codemirror/view';
 import type { WithBoundArgs } from '@glint/template';
-import type Owner from '@ember/owner';
 import type { ComponentLike } from '@glint/template';
 import type { HdsCodeEditorSignature as HdsCodeEditorModifierSignature } from '../../../modifiers/hds-code-editor.ts';
 import type { HdsCodeEditorDescriptionSignature } from './description';
@@ -154,14 +154,17 @@ export default class HdsCodeEditor extends Component<HdsCodeEditorSignature> {
   @action
   onSetup(editorView: EditorView): void {
     this._isSetupComplete = true;
-    const valUpdateExtension = EditorView.updateListener.of(
+
+    const valueUpdateExtension = EditorView.updateListener.of(
       (update: ViewUpdate) => {
         this._value = update.state.doc.toString();
       }
     );
+
     editorView.dispatch({
-      effects: StateEffect.appendConfig.of([valUpdateExtension]),
+      effects: StateEffect.appendConfig.of([valueUpdateExtension]),
     });
+
     this.args.onSetup?.(editorView);
   }
 }

--- a/packages/components/src/components/hds/code-editor/index.ts
+++ b/packages/components/src/components/hds/code-editor/index.ts
@@ -8,10 +8,13 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { modifier } from 'ember-modifier';
 import { guidFor } from '@ember/object/internals';
+import { EditorView } from '@codemirror/view';
+import { StateEffect } from '@codemirror/state';
 
 import HdsCodeEditorDescription from './description.ts';
 import HdsCodeEditorTitle from './title.ts';
 
+import type { ViewUpdate } from '@codemirror/view';
 import type { WithBoundArgs } from '@glint/template';
 import type Owner from '@ember/owner';
 import type { ComponentLike } from '@glint/template';
@@ -19,7 +22,6 @@ import type { HdsCodeEditorSignature as HdsCodeEditorModifierSignature } from '.
 import type { HdsCodeEditorDescriptionSignature } from './description';
 import type { HdsCodeEditorTitleSignature } from './title';
 import type { HdsCodeEditorGenericSignature } from './generic';
-import type { EditorView } from '@codemirror/view';
 import type { HdsCopyButtonSignature } from '../copy/button/index.ts';
 
 export interface HdsCodeEditorSignature {
@@ -139,7 +141,6 @@ export default class HdsCodeEditor extends Component<HdsCodeEditorSignature> {
 
   @action
   onInput(newValue: string, editorView: EditorView): void {
-    this._value = newValue;
     this.args.onInput?.(newValue, editorView);
   }
 
@@ -153,6 +154,13 @@ export default class HdsCodeEditor extends Component<HdsCodeEditorSignature> {
   @action
   onSetup(editorView: EditorView): void {
     this._isSetupComplete = true;
+    const valUpdateExtension = EditorView.updateListener.of(
+        (update: ViewUpdate) => {
+    this._value = update.state.doc.toString();
+        });
+    editorView.dispatch({
+      effects: StateEffect.appendConfig.of([valUpdateExtension])
+    });
     this.args.onSetup?.(editorView);
   }
 }

--- a/packages/components/src/components/hds/code-editor/index.ts
+++ b/packages/components/src/components/hds/code-editor/index.ts
@@ -155,11 +155,12 @@ export default class HdsCodeEditor extends Component<HdsCodeEditorSignature> {
   onSetup(editorView: EditorView): void {
     this._isSetupComplete = true;
     const valUpdateExtension = EditorView.updateListener.of(
-        (update: ViewUpdate) => {
-    this._value = update.state.doc.toString();
-        });
+      (update: ViewUpdate) => {
+        this._value = update.state.doc.toString();
+      }
+    );
     editorView.dispatch({
-      effects: StateEffect.appendConfig.of([valUpdateExtension])
+      effects: StateEffect.appendConfig.of([valUpdateExtension]),
     });
     this.args.onSetup?.(editorView);
   }

--- a/packages/components/src/modifiers/hds-code-editor.ts
+++ b/packages/components/src/modifiers/hds-code-editor.ts
@@ -13,6 +13,7 @@ import { EditorView } from '@codemirror/view';
 import { guidFor } from '@ember/object/internals';
 import { isEmpty } from '@ember/utils';
 import { service } from '@ember/service';
+import { buildWaiter } from '@ember/test-waiters';
 
 // hds-dark theme
 import hdsDarkTheme from './hds-code-editor/themes/hds-dark-theme.ts';
@@ -45,6 +46,8 @@ type HdsCodeEditorBlurHandler = (
 interface HdsCodeEditorExtraKeys {
   [key: string]: () => void;
 }
+
+const waiter = buildWaiter('hds-code-editor');
 
 export interface HdsCodeEditorSignature {
   Args: {
@@ -450,6 +453,7 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
 
       const handleUpdateExtension = EditorView.updateListener.of(
         (update: ViewUpdate) => {
+          const token = waiter.beginAsync();
           // toggle a class if the update has/does not have a selection
           if (update.selectionSet) {
             update.view.dom.classList.toggle(
@@ -472,9 +476,11 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
             this.onInput === undefined ||
             !isUserUpdate
           ) {
+            waiter.endAsync(token);
             return;
           }
           this.onInput(update.state.doc.toString(), update.view);
+          waiter.endAsync(token);
         }
       );
 

--- a/packages/components/src/modifiers/hds-code-editor.ts
+++ b/packages/components/src/modifiers/hds-code-editor.ts
@@ -467,7 +467,11 @@ export default class HdsCodeEditorModifier extends Modifier<HdsCodeEditorSignatu
             return false;
           });
           // call the onInput callback if the document has changed
-          if (!update.docChanged || this.onInput === undefined || !isUserUpdate) {
+          if (
+            !update.docChanged ||
+            this.onInput === undefined ||
+            !isUserUpdate
+          ) {
             return;
           }
           this.onInput(update.state.doc.toString(), update.view);

--- a/showcase/app/controllers/page-components/code-editor.ts
+++ b/showcase/app/controllers/page-components/code-editor.ts
@@ -16,7 +16,8 @@ export default class PageComponentsCodeEditorController extends Controller {
   declare model: PageComponentsCodeEditorModel;
 
   @tracked hasLineWrapping = true;
-
+  @tracked externalUpdateDemo =
+    'This value can be changed by clicking the "Change value" button.';
   @tracked demoCode =
     `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
 
@@ -180,5 +181,10 @@ SELECT 'Enjoy coding!';`,
     console.log('Diagnostics:', diagnostics);
     console.log('Value:', value);
     console.groupEnd();
+  }
+
+  @action
+  setExternalUpdateDemo(value: string) {
+    this.externalUpdateDemo = value;
   }
 }

--- a/showcase/app/styles/showcase-pages/code-editor.scss
+++ b/showcase/app/styles/showcase-pages/code-editor.scss
@@ -5,12 +5,12 @@
 
 // CODE-EDITOR
 
-.my-code-editor-custom-content {
+.hds-code-editor-custom-content {
   display: flex;
   gap: 8px;
   align-items: center;
 }
 
-.hds-code-editor-line-wrapper-controls {
+.hds-code-editor-controls {
   margin-bottom: 8px;
 }

--- a/showcase/app/templates/page-components/code-editor.hbs
+++ b/showcase/app/templates/page-components/code-editor.hbs
@@ -109,7 +109,7 @@
       <Hds::CodeEditor @hasFullScreenButton={{true}} @hasCopyButton={{true}} as |CE|>
         <CE.Title>Code editor with title</CE.Title>
         <CE.Description>This is a code editor with a description</CE.Description>
-        <CE.Generic class="my-code-editor-custom-content">
+        <CE.Generic class="hds-code-editor-custom-content">
           <Hds::Button @text="Custom action" @size="small" />
           <Hds::Button @text="Search" @icon="search" @isIconOnly={{true}} @size="small" />
         </CE.Generic>
@@ -152,11 +152,11 @@
   </Shw::Flex>
 
   <Shw::Flex @direction="column" as |SF|>
-    <SF.Item @label="toggle line wrapping">
+    <SF.Item @label="Toggle line wrapping">
       <Hds::Form::Checkbox::Field
         name="enable-line-wrapping"
         checked={{this.hasLineWrapping}}
-        class="hds-code-editor-line-wrapper-controls"
+        class="hds-code-editor-controls"
         {{on "change" this.toggleLineWrapping}}
         as |F|
       >
@@ -168,6 +168,24 @@
           value=this.demoCode
           hasLineWrapping=this.hasLineWrapping
           onInput=this.setDemoCode
+        }}
+      />
+    </SF.Item>
+  </Shw::Flex>
+
+  <Shw::Flex @direction="column" as |SF|>
+    <SF.Item @label="Update value externally">
+      <Hds::Button
+        @text="Change value"
+        class="hds-code-editor-controls"
+        {{on "click" (fn this.setExternalUpdateDemo "New value")}}
+      />
+
+      <div
+        {{hds-code-editor
+          ariaLabel="Standalone modifier usage"
+          value=this.externalUpdateDemo
+          onInput=this.setExternalUpdateDemo
         }}
       />
     </SF.Item>

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -8,7 +8,6 @@ import { setupRenderingTest } from 'showcase/tests/helpers';
 import {
   click,
   render,
-  rerender,
   fillIn,
   triggerEvent,
   waitFor,
@@ -240,7 +239,6 @@ module('Integration | Component | hds/code-editor/index', function (hooks) {
 
       Test Code`;
     this.set('value', newValue);
-    await rerender();
 
     await click('.hds-code-editor__copy-button');
     assert.true(clipboardStub.calledWith(newValue));

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -5,7 +5,14 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'showcase/tests/helpers';
-import { click, render, rerender, fillIn, triggerEvent, waitFor } from '@ember/test-helpers';
+import {
+  click,
+  render,
+  rerender,
+  fillIn,
+  triggerEvent,
+  waitFor,
+} from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -330,6 +330,7 @@ module('Integration | Component | hds/code-editor/index', function (hooks) {
     );
 
     // simulate user input
+    await click('.cm-content');
     await fillIn('.cm-content', 'Test string');
     await triggerEvent('.cm-content', 'input');
 

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -119,8 +119,7 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
     );
     this.editorView.dispatch({
       changes: {
-        from: 0,
-        to: this.editorView.state.selection.main.from,
+        from: this.editorView.state.selection.main.from,
         insert: 'Test string',
       },
     });

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -11,6 +11,7 @@ import {
   setupOnerror,
   focus,
   blur,
+  settled,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
@@ -60,7 +61,7 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
     assert.dom('#code-editor-wrapper .cm-editor').includesText(initialValue);
 
     this.set('val', updatedValue);
-    console.log('Updated value:', updatedValue);
+    await settled();
 
     assert.dom('#code-editor-wrapper .cm-editor').includesText(updatedValue);
   });
@@ -172,6 +173,7 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
       .hasClass('cm-lineWrapping');
 
     this.set('hasLineWrapping', false);
+    await settled();
     assert
       .dom('#code-editor-wrapper .cm-editor .cm-content')
       .doesNotHaveClass('cm-lineWrapping');

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -12,6 +12,7 @@ import {
   fillIn,
   triggerEvent,
   focus,
+  click,
   blur,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -97,6 +98,7 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
       hbs`<div id="code-editor-wrapper" {{hds-code-editor ariaLabel="test" onInput=this.handleInput onSetup=this.handleSetup}} />`,
     );
     // simulate user input
+    await click('.cm-content');
     await fillIn('.cm-content', 'Test string');
     await triggerEvent('.cm-content', 'input');
 

--- a/showcase/tests/integration/modifiers/hds-code-editor-test.js
+++ b/showcase/tests/integration/modifiers/hds-code-editor-test.js
@@ -48,6 +48,23 @@ module('Integration | Modifier | hds-code-editor', function (hooks) {
     assert.dom('#code-editor-wrapper .cm-editor').includesText(val);
   });
 
+  test('it should update the editor value when the value changes', async function (assert) {
+    const initialValue = 'Initial Value';
+    const updatedValue = 'Updated Value';
+
+    this.set('val', initialValue);
+    await setupCodeEditor(
+      hbs`<div id="code-editor-wrapper" {{hds-code-editor ariaLabel="test" value=this.val}} />`,
+    );
+
+    assert.dom('#code-editor-wrapper .cm-editor').includesText(initialValue);
+
+    this.set('val', updatedValue);
+    console.log('Updated value:', updatedValue);
+
+    assert.dom('#code-editor-wrapper .cm-editor').includesText(updatedValue);
+  });
+
   // onBlur
   test('it should call the onBlur action when the code editor loses focus', async function (assert) {
     const blurSpy = sinon.spy();


### PR DESCRIPTION
### :pushpin: Summary

Before, if the value for `value` was updated externally, the component/modifier would not update to the newly provided value. This fixes that.

### :hammer_and_wrench: Detailed description

- Update Codemirror editor value when the `value` argument on the `hds-code-editor` modifier changes.
- Use `ember-concurrency` to make sure that tests wait for the updates correctly

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5451](https://hashicorp.atlassian.net/browse/HDS-5451)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5451]: https://hashicorp.atlassian.net/browse/HDS-5451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ