### PR TITLE
AdvancedTable - Set mock-active styles for ThResizeHandle

### DIFF
--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -139,7 +139,8 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
       &.mock-focus::after,
       &:hover::after,
       &.mock-hover::after,
-      &.hds-advanced-table__th-resize-handle--resizing::after {
+      &.hds-advanced-table__th-resize-handle--resizing::after,
+      &.mock-active::after {
         width: 3px;
         transform: translateX(-10.5px); // (width of the handle (24px) - width of the visual handle (3px)) / 2 == 10.5px
       }
@@ -151,7 +152,8 @@ $hds-advanced-table-button-size: 24px; // the size of the buttons and dropdown t
 
       &:focus::after,
       &.mock-focus::after,
-      &.hds-advanced-table__th-resize-handle--resizing::after {
+      &.hds-advanced-table__th-resize-handle--resizing::after,
+      &.mock-active::after {
         background-color: var(--token-color-palette-blue-300);
       }
     }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the `mock-active` styles in the `AdvancedTable` `ThResizeHandle`.

[Preview page](https://hds-showcase-git-dchyun-adv-table-resize-mock-892097-hashicorp.vercel.app/components/advanced-table#thresizehandle)

### :camera_flash: Screenshots

**Before**
<img width="1124" height="149" alt="Screenshot 2025-08-08 at 11 11 16 AM" src="https://github.com/user-attachments/assets/e22d92d7-8a44-4603-b678-6cf2020fbb11" />

**After**
<img width="1124" height="154" alt="Screenshot 2025-08-08 at 11 11 06 AM" src="https://github.com/user-attachments/assets/e2c87fdf-d31e-4a15-8bc9-9ff8def8dfd3" />

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>