### PR TITLE
`AppFrame` - Change media queries for sticky header to older syntax (HDS-5304)

### DIFF
--- a/.changeset/hungry-months-kick.md
+++ b/.changeset/hungry-months-kick.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppFrame` - Changed media query styles for frame header and sidebar containers to use level 3 vs level 4 CSS syntax

--- a/packages/components/src/styles/components/app-frame.scss
+++ b/packages/components/src/styles/components/app-frame.scss
@@ -25,7 +25,9 @@
   grid-area: header;
 
   // Make header position sticky/fixed if the viewport height is greater than 480px
-  @media (height >= 480px) {
+  // Note: HCP in prod doesn't support newer media queries, so we use the old syntax
+  // stylelint-disable-next-line media-feature-range-notation
+  @media (min-height: 480px) {
     position: sticky;
     top: 0;
     right: 0;
@@ -42,7 +44,9 @@
   min-height: 100vh;
 
   // Modify sidenav layout when used together with fixed app-header
-  @media (height >= 480px) {
+  // Note: HCP in prod doesn't support newer media queries, so we use the old syntax
+  // stylelint-disable-next-line media-feature-range-notation
+  @media (min-height: 480px) {
     .hds-app-frame--has-header-with-sidebar & {
       top: var(--token-app-header-height);
       height: calc(100vh - var(--token-app-header-height));


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR changes media queries in the `AppFrame` styles related to the sticky positioning of the `AppHeader` to use level 3 syntax instead of level 4 to be compatible with consumers using compilers not supporting the newer syntax.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-5304](https://hashicorp.atlassian.net/browse/HDS-5304)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>