### PR TITLE
fix(components): add css output validation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -72,9 +72,9 @@
     "luxon": "^3.4.2",
     "prismjs": "^1.30.0",
     "sass": "^1.83.0",
-    "tracked-built-ins": "^4.0.0",
     "tabbable": "^6.2.0",
-    "tippy.js": "^6.3.7"
+    "tippy.js": "^6.3.7",
+    "tracked-built-ins": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.27.1",
@@ -107,12 +107,14 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-n": "^17.17.0",
     "globals": "^16.0.0",
+    "lightningcss": "^1.30.1",
     "postcss": "^8.5.3",
     "prettier": "^3.5.3",
     "prettier-plugin-ember-template-tag": "^2.0.5",
     "rollup": "^4.39.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-scss": "^4.0.1",
+    "source-map-js": "^1.2.1",
     "stylelint": "^16.17.0",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard-scss": "^14.0.0",

--- a/packages/components/rollup-plugin-lightningcss-validator.mjs
+++ b/packages/components/rollup-plugin-lightningcss-validator.mjs
@@ -1,0 +1,170 @@
+// rollup-plugin-lightningcss-validator.mjs
+import { transform } from 'lightningcss';
+import { SourceMapConsumer } from 'source-map-js';
+
+/**
+ * @typedef {Object} LightningCssValidatorOptions
+ * @property {(fileName: string) => boolean} [include]
+ *   Predicate to select which CSS files to validate. Defaults to all `.css` files.
+ * @property {boolean} [errorRecovery=true]
+ *   If true, collect all diagnostics instead of throwing on the first error.
+ * @property {boolean} [failOnWarning=true]
+ *   If true, fail the build on any diagnostics. If false, emit them as warnings.
+ */
+
+/** Safely parse JSON and warn on failure. */
+function safeJSONParse(jsonLike, context, warn) {
+  try {
+    return typeof jsonLike === 'string' ? JSON.parse(jsonLike) : jsonLike;
+  } catch (e) {
+    warn?.(
+      `(lightningcss-validator) invalid JSON in ${context}: ${e?.message || e}`
+    );
+    return null;
+  }
+}
+
+/** Try to load a sourcemap for the given asset. */
+function getSourceMap(bundle, fileName, asset, cssText, warn) {
+  // 1) asset.map
+  const fromAsset = safeJSONParse(asset.map, `${fileName} (asset.map)`, warn);
+  if (fromAsset) return fromAsset;
+
+  // 2) inline sourceMappingURL (data URL)
+  const m =
+    typeof cssText === 'string'
+      ? cssText.match(
+          /\/\*# sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)\s*\*\//
+        )
+      : null;
+  if (m) {
+    const inlineJson = Buffer.from(m[1], 'base64').toString('utf8');
+    const fromInline = safeJSONParse(
+      inlineJson,
+      `${fileName} (inline sourcemap)`,
+      warn
+    );
+    if (fromInline) return fromInline;
+  }
+
+  // 3) sibling .map asset
+  const siblingKey = `${fileName}.map`;
+  const altKey = fileName.replace(/\.css$/i, '.css.map');
+  const sibling = bundle[siblingKey] || bundle[altKey];
+  if (sibling?.type === 'asset' && sibling.source) {
+    const mapText =
+      typeof sibling.source === 'string'
+        ? sibling.source
+        : Buffer.from(sibling.source).toString('utf8');
+    const fromSibling = safeJSONParse(
+      mapText,
+      `${fileName} (sibling .map)`,
+      warn
+    );
+    if (fromSibling) return fromSibling;
+  }
+
+  warn?.(
+    `(lightningcss-validator) no sourcemap found for ${fileName}. Enable sourceMap/sourceMapEmbed/sourceMapContents in your SCSS step for better traces.`
+  );
+  return null;
+}
+
+/** Map generated position back to original (with column nudges). */
+function mapToOriginal(consumer, line, column) {
+  for (const col of [column, column - 1, column + 1]) {
+    const orig = consumer.originalPositionFor({
+      line,
+      column: Math.max(0, col ?? 0),
+    });
+    if (orig?.source && orig.line != null) return orig;
+  }
+  return null;
+}
+
+/**
+ * Rollup plugin to validate emitted CSS assets with Lightning CSS.
+ *
+ * It parses CSS, collects diagnostics, and reports them with optional source map
+ * tracebacks to the original SCSS. By default, the build fails if any issues are found.
+ *
+ * @param {LightningCssValidatorOptions} [opts]
+ * @returns {import('rollup').Plugin}
+ */
+export default function lightningCssValidator(opts = {}) {
+  const include = opts.include ?? ((f) => f.endsWith('.css'));
+  const errorRecovery = opts.errorRecovery ?? true;
+  const failOnWarning = opts.failOnWarning ?? true;
+
+  return {
+    name: 'rollup-plugin-lightningcss-validator',
+
+    async generateBundle(_out, bundle) {
+      const reports = [];
+
+      for (const [fileName, asset] of Object.entries(bundle)) {
+        if (asset.type !== 'asset' || !include(fileName)) continue;
+
+        const cssText =
+          typeof asset.source === 'string'
+            ? asset.source
+            : Buffer.from(asset.source || []).toString('utf8');
+
+        const res = transform({
+          code: Buffer.from(cssText, 'utf8'),
+          filename: fileName,
+          minify: false,
+          errorRecovery,
+        });
+
+        const diagnostics = [
+          ...(res.diagnostics ?? []),
+          ...(res.warnings ?? []),
+        ];
+        if (!diagnostics.length) continue;
+
+        const mapObj = getSourceMap(
+          bundle,
+          fileName,
+          asset,
+          cssText,
+          this.warn
+        );
+        let consumer = null;
+        if (mapObj) {
+          try {
+            consumer = await new SourceMapConsumer(mapObj);
+          } catch (e) {
+            this.warn(
+              `(lightningcss-validator) bad sourcemap for ${fileName}: ${e?.message || e}`
+            );
+          }
+        }
+
+        for (const d of diagnostics) {
+          const line = d.loc?.line ?? d.line;
+          const col = d.loc?.column ?? d.column;
+
+          let msg = `❌ CSS issue in ${fileName}`;
+          if (line != null) msg += `:${line}${col != null ? `:${col}` : ''}`;
+          msg += ` — ${d.message || 'invalid CSS'}`;
+
+          if (consumer && line != null && col != null) {
+            const orig = mapToOriginal(consumer, line, col);
+            msg += orig
+              ? `\n    ← ${orig.source}:${orig.line}:${orig.column ?? '?'}`
+              : `\n    (no original mapping found — embed SCSS sourcemaps)`;
+          }
+
+          reports.push(msg);
+        }
+      }
+
+      if (reports.length) {
+        const header = `\nCSS validation ${failOnWarning ? 'failed' : 'warnings'} — ${reports.length} issue(s):\n`;
+        const body = reports.join('\n') + '\n';
+        failOnWarning ? this.error(header + body) : this.warn(header + body);
+      }
+    },
+  };
+}

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -10,6 +10,8 @@ import scss from 'rollup-plugin-scss';
 import process from 'process';
 import path from 'node:path';
 
+import lightningCssValidator from './rollup-plugin-lightningcss-validator.mjs';
+
 const addon = new Addon({
   srcDir: 'src',
   destDir: 'dist',
@@ -55,11 +57,20 @@ const plugins = [
     includePaths: [
       'node_modules/@hashicorp/design-system-tokens/dist/products/css',
     ],
+    sourceMap: true,
+    sourceMapEmbed: true, // <-- embed map into CSS we can read later
+    sourceMapContents: true, // <-- include original sources in the map
   }),
 
   scss({
     fileName: 'styles/@hashicorp/design-system-power-select-overrides.css',
+    sourceMap: true,
+    sourceMapEmbed: true, // <-- embed map into CSS we can read later
+    sourceMapContents: true, // <-- include original sources in the map
   }),
+
+  // fail build if any invalid CSS is found in emitted .css files
+  lightningCssValidator(),
 
   // Ensure that standalone .hbs files are properly integrated as Javascript.
   addon.hbs(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       globals:
         specifier: ^16.0.0
         version: 16.3.0
+      lightningcss:
+        specifier: ^1.30.1
+        version: 1.30.1
       postcss:
         specifier: ^8.5.3
         version: 8.5.6
@@ -298,6 +301,9 @@ importers:
       rollup-plugin-scss:
         specifier: ^4.0.1
         version: 4.0.1
+      source-map-js:
+        specifier: ^1.2.1
+        version: 1.2.1
       stylelint:
         specifier: ^16.17.0
         version: 16.23.0(typescript@5.9.2)
@@ -5833,6 +5839,10 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
+  detect-libc@2.0.4:
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -8437,6 +8447,70 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lightningcss-darwin-arm64@1.30.1:
+    resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.1:
+    resolution: {integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.1:
+    resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    resolution: {integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.1:
+    resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    resolution: {integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.1:
+    resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
 
   line-column@1.0.2:
     resolution: {integrity: sha512-Ktrjk5noGYlHsVnYWh62FLVs4hTb8A3e+vucNZMgPeAOITdshMSgv4cCZQeRDjm7+goqmo6+liZwTXo+U3sVww==}
@@ -18187,6 +18261,8 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
+  detect-libc@2.0.4: {}
+
   detect-newline@3.1.0: {}
 
   detect-newline@4.0.1: {}
@@ -22593,6 +22669,51 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.1:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss@1.30.1:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.30.1
+      lightningcss-darwin-x64: 1.30.1
+      lightningcss-freebsd-x64: 1.30.1
+      lightningcss-linux-arm-gnueabihf: 1.30.1
+      lightningcss-linux-arm64-gnu: 1.30.1
+      lightningcss-linux-arm64-musl: 1.30.1
+      lightningcss-linux-x64-gnu: 1.30.1
+      lightningcss-linux-x64-musl: 1.30.1
+      lightningcss-win32-arm64-msvc: 1.30.1
+      lightningcss-win32-x64-msvc: 1.30.1
 
   line-column@1.0.2:
     dependencies:


### PR DESCRIPTION
# 📝 Summary of CSS Issues & Recommendations

## 🚨 What Happened
- While migrating Embroider’s CSS minification from **`csso`** to **Lightning CSS**, builds started failing.
- Error reported:
  ```
  SyntaxError: Invalid state
  data: { type: 'SelectorError', value: { type: 'InvalidState' } }
  ```
- Investigation showed the generated CSS contained selectors like:
  ```css
  .hds-form-file-input:disabled::file-selector-button::before { … }
  ```
- This is **invalid CSS** — spec forbids chaining two pseudo-elements (`::file-selector-button::before`).

## 🔍 Root Cause
- In SCSS, the **`hds-button-state-disabled()`** mixin includes:
  ```scss
  &::before {
    border-color: transparent;
  }
  ```
- When applied inside a `&::file-selector-button` block, it compiles to `::file-selector-button::before`.
- Browsers silently drop these rules, so the issue wasn’t obvious until a strict parser (Lightning CSS) enforced the spec.

## ⚡ Impact
- **Browsers:** Invalid rules are ignored, so styles may not apply as intended (e.g., `border-color: transparent` never hits).
- **Build tooling:** Strict parsers/minifiers (Lightning CSS, future PostCSS upgrades, etc.) **fail builds** instead of ignoring bad selectors.
- **Developer experience:** Downstream consumers (e.g. Embroider, Cloud UI) cannot adopt modern tooling unless this is fixed upstream.

## ✅ Recommendations

### 1. Fix the mixin
- **Option A:** Add a flag to disable pseudo-element emission.
  ```scss
  @mixin hds-button-state-disabled($include-before: true) {
    color: var(--token-color-foreground-disabled);
    background-color: var(--token-color-surface-faint);
    border-color: var(--token-color-border-primary);
    box-shadow: none;
    cursor: not-allowed;

    @if $include-before {
      &::before { border-color: transparent; }
    }
  }
  ```
  Use with `$include-before: false` for `::file-selector-button`.

- **Option B:** Split into two mixins (`*-base` and `*-decorators`) and include only what’s valid in each context.

### 2. Add validation in the build pipeline
Since the library uses **`rollup-plugin-scss`**, add strict CSS validation before publishing:

- **Lightning CSS parse check**  
  After SCSS compiles, run:
  ```js
  transform({
    code: Buffer.from(css, 'utf8'),
    filename: filePath,
    minify: false,        // parse-only
    errorRecovery: false, // fail on first invalid selector
  });
  ```
  This fails fast if invalid CSS is generated.

- **Stylelint rule for chained pseudo-elements**  
  Custom rule: flag any `::<something>::<something>` in selectors.  
  Catches misuse at the SCSS source before it compiles.

### 3. CI integration
- Run validation (Lightning CSS or Stylelint) in CI for **every SCSS change**.  
- Fail the build if invalid selectors appear in compiled CSS.  
- This prevents regressions and ensures library consumers don’t hit the same problem.

---

## 📌 Takeaway
- The **design system SCSS mixin** is generating **invalid CSS** when reused with pseudo-elements.  
- Browsers mask the issue, but modern tooling correctly enforces the spec and fails.  
- Fixing the mixin + adding **early validation (Rollup + Stylelint/Lightning CSS parse)** will make the library spec-compliant, robust, and unblock consumers moving to modern build pipelines.

## 🤔 Why `clean-css` and `csso` didn’t fail (but Lightning CSS does)

Older/legacy-focused minifiers like **clean-css** (and historically **csso**) primarily optimize for **byte reduction** and **throughput**, not strict standards enforcement. In practice this means:

- **Lenient parsing philosophy** – If something looks odd or unknown, they typically **don’t stop the build**. They either pass it through verbatim or quietly drop it, assuming browsers will ignore invalid bits anyway.
- **Back-compat with messy CSS** – The ecosystem used to tolerate “quirky” outputs from preprocessors (Sass/Less) and templating pipelines. Strict parsing would have broken lots of builds, so **forgiveness was a feature**.
- **No heavy transforms that require full correctness** – Since they aren’t doing modern syntax lowering/transpilation, they **don’t need a fully spec-valid AST** the way a modern transformer does.
- **Practical goal: keep shipping** – The cost of failing production builds on a questionable selector was considered higher than letting it through, because browsers already ignore invalid selectors.

By contrast, **Lightning CSS** is designed for **spec compliance** and **safe transforms** (e.g., prefixing, modern syntax → widely supported output). To guarantee correctness it **must trust the AST**, so it **throws** on invalid CSS, like a chained pseudo-element selector (`::file-selector-button::before`).

### Quick comparison

| Tool              | Default posture                 | What happens on invalid selector?                 |
|-------------------|----------------------------------|--------------------------------------------------|
| **clean-css**     | Lenient minifier                 | Usually passes through or drops silently         |
| **csso**          | Mostly lenient minifier          | Similar behavior; doesn’t typically hard-fail    |
| **Lightning CSS** | Spec‑strict transformer/minifier | **Errors** (or warns with `errorRecovery: true`) |

**Implication for us:** With Lightning CSS (and generally modern pipelines), invalid CSS should be **fixed at the source**. If we relied on lenient tools before, they may have masked issues that were *already ineffective in browsers*.


### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

<img width="2752" height="456" alt="Screenshot 2025-08-16 at 6 24 33 PM" src="https://github.com/user-attachments/assets/c853cc85-c927-49e6-b1ad-c7e0c20b99f6" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>