### PR TITLE
Showcase: replace simple clone functions with `structuredClone`

### DIFF
--- a/showcase/app/controllers/page-components/stepper/list.ts
+++ b/showcase/app/controllers/page-components/stepper/list.ts
@@ -11,11 +11,6 @@ import { deepTracked } from 'ember-deep-tracked';
 import type { HdsStepperStatuses } from '@hashicorp/design-system-components/components/hds/stepper/types';
 import type { PageComponentsStepperListModel } from 'showcase/routes/page-components/stepper/list';
 
-// basic function that clones an array of objects (not deep)
-export const clone = <T>(arr: T[]): T[] => {
-  return arr.map((item) => ({ ...item }));
-};
-
 type ListData = {
   title: string;
   status: HdsStepperStatuses;
@@ -70,8 +65,8 @@ export default class PageComponentsStepperListController extends Controller {
   @tracked currentStep_demo1 = 1;
   @tracked currentStep_demo2 = 1;
 
-  @deepTracked steps_demo1 = clone(DEFAULT_DATA);
-  @deepTracked steps_demo2 = clone(DEFAULT_DATA);
+  @deepTracked steps_demo1 = structuredClone(DEFAULT_DATA);
+  @deepTracked steps_demo2 = structuredClone(DEFAULT_DATA);
 
   // =============================
   // DEMOS

--- a/showcase/app/routes/page-components/advanced-table.ts
+++ b/showcase/app/routes/page-components/advanced-table.ts
@@ -19,26 +19,21 @@ import users from 'showcase/mocks/user-data';
 export type PageComponentsAdvancedTableModel =
   ModelFrom<PageComponentsAdvancedTableRoute>;
 
-// basic function that clones an array of objects (not deep)
-export const clone = <T>(arr: T[]): T[] => {
-  return arr.map((item) => ({ ...item }));
-};
-
 const STATES = ['default', 'hover', 'active', 'focus'];
 
 export default class PageComponentsAdvancedTableRoute extends Route {
   model() {
     return {
       music: folkMusic,
-      userDataShort: clone(users.slice(0, 5)),
+      userDataShort: structuredClone(users.slice(0, 5)),
       clusters,
       spanningManualData: spanningCells,
       selectableData: selectableItems,
-      selectableDataDemo1: clone(selectableItems),
-      selectableDataDemo2: clone(selectableItems),
+      selectableDataDemo1: structuredClone(selectableItems),
+      selectableDataDemo2: structuredClone(selectableItems),
       userData: users,
-      userDataDemo3: clone(users.slice(0, 16)),
-      userDataDemo4: clone(
+      userDataDemo3: structuredClone(users.slice(0, 16)),
+      userDataDemo4: structuredClone(
         users.slice(0, 4).map((user) => ({ ...user, isAnimated: false })),
       ),
       nestedData: policies,

--- a/showcase/app/routes/page-components/table.ts
+++ b/showcase/app/routes/page-components/table.ts
@@ -16,11 +16,6 @@ import userWithMoreColumns from 'showcase/mocks/user-with-more-columns-data';
 
 export type PageComponentsTableModel = ModelFrom<PageComponentsTableRoute>;
 
-// basic function that clones an array of objects (not deep)
-export const clone = <T>(arr: T[]): T[] => {
-  return arr.map((item) => ({ ...item }));
-};
-
 const STATES = ['default', 'hover', 'active', 'focus'];
 
 export default class PageComponentsTableRoute extends Route {
@@ -28,14 +23,14 @@ export default class PageComponentsTableRoute extends Route {
     return {
       music: folkMusic,
       selectableData: selectableItems,
-      selectableDataDemo1: clone(selectableItems),
-      selectableDataDemo2: clone(selectableItems),
-      userDataDemo3: clone(users.slice(0, 16)),
-      userDataDemo4: clone(
+      selectableDataDemo1: structuredClone(selectableItems),
+      selectableDataDemo2: structuredClone(selectableItems),
+      userDataDemo3: structuredClone(users.slice(0, 16)),
+      userDataDemo4: structuredClone(
         users.slice(0, 4).map((user) => ({ ...user, isAnimated: false })),
       ),
-      selectableDataDemo5: clone(selectableItems),
-      selectableDataDemo6: clone(selectableItems),
+      selectableDataDemo5: structuredClone(selectableItems),
+      selectableDataDemo6: structuredClone(selectableItems),
       clusters,
       userMoreColumnsData: userWithMoreColumns,
       DENSITIES,


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would remove the custom clone functions from the showcase and replace them with `structuredClone`. This follows the pattern created in the KeyValueInputs showcase page:
* [example 1](https://github.com/hashicorp/design-system/blob/2fba699805545070adcec975850a22168463b5de/showcase/app/components/mock/components/form/key-value-inputs/with-validation-and-limit.gts#L70)
* [example 2](https://github.com/hashicorp/design-system/blob/2fba699805545070adcec975850a22168463b5de/showcase/app/components/mock/components/form/key-value-inputs/with-dynamic-inputs.gts#L61)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5174](https://hashicorp.atlassian.net/browse/HDS-5174)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5174]: https://hashicorp.atlassian.net/browse/HDS-5174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ