### PR TITLE
Enforce immutable updates to `AdvancedTable` `@model`

### DIFF
--- a/showcase/app/controllers/page-components/advanced-table.ts
+++ b/showcase/app/controllers/page-components/advanced-table.ts
@@ -424,16 +424,23 @@ export default class PageComponentsAdvancedTableController extends Controller {
     console.group('onMultiSelectSelectionChange__demo4');
     console.log('Selected Rows Keys:', selectedRowsKeys);
     console.groupEnd();
-    this.multiSelectUserData__demo4.forEach((user) => {
-      user.isSelected = selectedRowsKeys.includes(String(user.id));
-    });
+    this.multiSelectUserData__demo4 = this.multiSelectUserData__demo4.map(
+      (user) => {
+        user.isSelected = selectedRowsKeys.includes(String(user.id));
+        return user;
+      },
+    );
   }
 
   @action
   multiSelectAnimateSelectedUsers_demo4() {
-    this.multiSelectUserData__demo4.forEach((user) => {
-      user.isAnimated = user.isSelected ? user.isSelected : false;
-    });
+    this.multiSelectUserData__demo4 = this.multiSelectUserData__demo4.map(
+      (user) => {
+        user.isAnimated = user.isSelected ? user.isSelected : false;
+
+        return user;
+      },
+    );
 
     // eslint-disable-next-line ember/no-runloop
     later(() => {
@@ -443,9 +450,12 @@ export default class PageComponentsAdvancedTableController extends Controller {
 
   @action
   multiSelectResetUserAnimation_demo4() {
-    this.multiSelectUserData__demo4.forEach((user) => {
-      user.isAnimated = false;
-    });
+    this.multiSelectUserData__demo4 = this.multiSelectUserData__demo4.map(
+      (user) => {
+        user.isAnimated = false;
+        return user;
+      },
+    );
   }
 
   // Example where dynamically add more focusable elements to a cell

--- a/website/docs/components/table/advanced-table/partials/code/component-api.md
+++ b/website/docs/components/table/advanced-table/partials/code/component-api.md
@@ -23,7 +23,7 @@ The Advanced Table component itself is where most of the options will be applied
     </Doc::ComponentApi>
   </C.Property>
   <C.Property @name="model" @type="array">
-    The data model to be used by the Advanced Table. The model can have any shape, but for nested rows there are two expected keys.
+    The data model to be used by the Advanced Table. **This array should be treated as immutable. Any updates must be made by passing a new array.** The model can have any shape, but for nested rows there are two expected keys.
     <Doc::ComponentApi as |C|>
       <C.Property @name="children" @type="array">
         If there are nested rows, the Advanced Table will use the `children` key in the model to render the child content. The key can be changed by setting `childrenKey` argument on the `Hds::AdvancedTable`.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will update the showcase examples that rely on mutations to the `AdvancedTable` `@model` to be immutable.

Enforcing that updates to the model be immutable is more performant, and the only way to ensure that the data in the internal `HdsAdvancedTableTableModel` instance is up-to-date.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5236](https://hashicorp.atlassian.net/browse/HDS-5236)

<img width="837" height="464" alt="Screenshot 2025-08-25 at 2 17 40 PM" src="https://github.com/user-attachments/assets/c4330659-73de-4212-8655-85a35836eb25" />

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5236]: https://hashicorp.atlassian.net/browse/HDS-5236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ