### PR TITLE
`AppHeader` - fix styling of non interactive actions (buttons) to look disabled (HDS-5303)

### DIFF
--- a/.changeset/light-facts-fall.md
+++ b/.changeset/light-facts-fall.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppHeader` - Fixed classname so that non-active controls in the AppHeader will be styled as disabled in small screens when the side nav is expanded

--- a/.changeset/light-facts-fall.md
+++ b/.changeset/light-facts-fall.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/app-header -->
-`AppHeader` - Fixed classname so that non-active controls in the AppHeader will be styled as disabled in small screens when the side nav is expanded
+`AppHeader` - Fixed classname so that non-active controls in the `AppHeader` will be styled as disabled when the `AppSideNav` is expanded and in overlay mode
 <!-- END -->

--- a/.changeset/light-facts-fall.md
+++ b/.changeset/light-facts-fall.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
+<!-- START components/app-header -->
 `AppHeader` - Fixed classname so that non-active controls in the AppHeader will be styled as disabled in small screens when the side nav is expanded
+<!-- END -->

--- a/packages/components/src/components/hds/app-side-nav/index.ts
+++ b/packages/components/src/components/hds/app-side-nav/index.ts
@@ -50,7 +50,7 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
     });
   }
 
-  private _setUpBodyElement = modifier(() => {
+  private _setUpBodyElement = modifier((): void => {
     this._body = document.body;
     // Store the initial `overflow` value of `<body>` so we can reset to it
     this._bodyInitialOverflowValue =
@@ -102,6 +102,7 @@ export default class HdsAppSideNav extends Component<HdsAppSideNavSignature> {
     return this.args.isCollapsible ?? false;
   }
 
+  // traps focus if isResponsive is enabled and it's in mobile view with side nav expanded (overlaying content)
   get shouldTrapFocus(): boolean {
     return this.isResponsive && !this._isDesktop && !this._isMinimized;
   }

--- a/packages/components/src/styles/components/app-header.scss
+++ b/packages/components/src/styles/components/app-header.scss
@@ -130,7 +130,8 @@
 }
 
 // prevent interaction with AppHeader when SideNav is open/expanded
-.hds-app-frame:has(.hds-side-nav--is-not-minimized) .hds-app-header--is-mobile {
+.hds-app-frame:has(.hds-side-nav--is-not-minimized) .hds-app-header--is-mobile,
+.hds-app-frame:has(.hds-app-side-nav--is-not-minimized) .hds-app-header--is-mobile {
   .hds-button,
   .hds-dropdown-toggle-button,
   .hds-dropdown-toggle-icon,

--- a/packages/components/src/styles/components/app-header.scss
+++ b/packages/components/src/styles/components/app-header.scss
@@ -130,6 +130,7 @@
 }
 
 // prevent interaction with AppHeader when SideNav is open/expanded
+// Note: ".hds-side-nav--is-not-minimized" references the old SideNav. Delete once SideNav code is fully removed.
 .hds-app-frame:has(.hds-side-nav--is-not-minimized) .hds-app-header--is-mobile,
 .hds-app-frame:has(.hds-app-side-nav--is-not-minimized) .hds-app-header--is-mobile {
   .hds-button,

--- a/packages/components/src/styles/components/app-header.scss
+++ b/packages/components/src/styles/components/app-header.scss
@@ -129,10 +129,14 @@
   }
 }
 
-// prevent interaction with AppHeader when SideNav is open/expanded
-// Note: ".hds-side-nav--is-not-minimized" references the old SideNav. Delete once SideNav code is fully removed.
-.hds-app-frame:has(.hds-side-nav--is-not-minimized) .hds-app-header--is-mobile,
-.hds-app-frame:has(.hds-app-side-nav--is-not-minimized) .hds-app-header--is-mobile {
+// Prevent interaction with AppHeader when SideNav is open/expanded
+
+// Logic: if the AppSideNav is "mobile" (operates in overlay mode) - AND - it is expanded (not minimized),
+// we disable interactions in the AppHeader
+
+// Note: ".hds-side-nav--BLAH" references the old SideNav. Delete once SideNav code is fully removed.
+.hds-app-frame:has(.hds-app-side-nav--is-mobile.hds-app-side-nav--is-not-minimized),
+.hds-app-frame:has(.hds-side-nav--is-mobile.hds-side-nav--is-not-minimized) {
   .hds-button,
   .hds-dropdown-toggle-button,
   .hds-dropdown-toggle-icon,


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes a class name so that non-interactive Buttons & actions within the `AppHeader` will be visually styled as disabled. (In small/mobile view when AppSideMenu is expanded)

👉 **Preview**: https://hds-showcase-git-kristin-hds-5303-app-header-m-5268b2-hashicorp.vercel.app/layouts/app-frame/frameless/demo-full-app-frame-with-app-header-and-app-side-nav

**To test**:

1. Narrow browser window to trigger small/mobile view
2. Expand/open `AppSideNav`

Expected: The Menu button and logo buttons within the AppHeader should become visually disabled looking ("grayed out") & should not change visually when hovered.

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

BEFORE:
<img width="726" height="359" alt="image" src="https://github.com/user-attachments/assets/4e2c167d-dcf1-4bbd-aaae-cdfcf74dd942" />

AFTER (fixed):
<img width="723" height="221" alt="image" src="https://github.com/user-attachments/assets/b617be0a-dd55-4cc7-814e-32477093b356" />


### :link: External links

* Jira ticket: [HDS-5303](https://hashicorp.atlassian.net/browse/HDS-5303)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5303]: https://hashicorp.atlassian.net/browse/HDS-5303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ