### PR TITLE
fix(components): remove deprecated `@task` decorator

### DIFF
--- a/packages/components/src/components/hds/time/index.ts
+++ b/packages/components/src/components/hds/time/index.ts
@@ -129,11 +129,11 @@ export default class HdsTime extends Component<HdsTimeSignature> {
   }
 
   @action
-  didInsertNode(): void {
+  async didInsertNode(): Promise<void> {
     const date = this.date;
 
     if (dateIsValid(date)) {
-      this.hdsTime.register(date);
+      await this.hdsTime.register(date);
     }
   }
 

--- a/packages/components/src/services/hds-time.ts
+++ b/packages/components/src/services/hds-time.ts
@@ -4,11 +4,10 @@
  */
 
 import Service from '@ember/service';
-import { task, timeout } from 'ember-concurrency';
+import { dropTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { DateTime } from 'luxon';
 import { isTesting } from '@embroider/macros';
-import type { TaskGenerator } from 'ember-concurrency';
 import type {
   DisplayType,
   DefaultDisplayType,
@@ -226,12 +225,11 @@ export default class TimeService extends Service {
   }
 
   // Subscribes a listener to the ticking task for time changes.
-  register(id: Date): () => void {
+  async register(id: Date): Promise<() => void> {
     this.#listeners.add(id);
-    // @ts-expect-error - TS2339: Property 'perform' does not exist on type '() => TaskGenerator<string | undefined>'
-    // note: we could potentially use taskFor via `ember-concurrency-ts` to avoid this exception
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    this.start.perform();
+
+    await this.start.perform();
+
     return (): void => {
       this.unregister(id);
     };
@@ -242,8 +240,7 @@ export default class TimeService extends Service {
     return this.#listeners.delete(id);
   }
 
-  @task({ drop: true })
-  *start(): TaskGenerator<string | undefined> {
+  start = dropTask(async () => {
     while (this.listeners.size) {
       this.now = Date.now();
       // When testing and canceling a EC task, a timer will never resolve and
@@ -251,9 +248,9 @@ export default class TimeService extends Service {
       // This condition breaks the test out of that.
       // via: http://ember-concurrency.com/docs/testing-debugging/
       if (isTesting()) return;
-      yield timeout(SECOND_IN_MS);
+      await timeout(SECOND_IN_MS);
     }
-  }
+  });
 
   // Transforms a JS date to a string representing the UTC ISO date.
   toIsoUtcString(date: Date): string | undefined {

--- a/showcase/tests/unit/services/hds-time-test.js
+++ b/showcase/tests/unit/services/hds-time-test.js
@@ -112,7 +112,7 @@ module('Unit | Service | time', function (hooks) {
     );
   });
 
-  test(`it can register and unregister listeners`, function (assert) {
+  test(`it can register and unregister listeners`, async function (assert) {
     let id = Date.now();
     assert.strictEqual(
       this.service.listeners.size,
@@ -123,7 +123,7 @@ module('Unit | Service | time', function (hooks) {
       this.service.listeners.has(id),
       'the registered id does not exist yet',
     );
-    let unregister = this.service.register(id);
+    let unregister = await this.service.register(id);
     assert.ok(this.service.listeners.has(id), 'the registered id exists');
     assert.strictEqual(
       this.service.listeners.size,


### PR DESCRIPTION
### :pushpin: Summary

<!-- If merged, this PR....
This should be a short TL;DR that includes the purpose of the PR.
-->

remove deprecated @task decorator

### :hammer_and_wrench: Detailed description

<!-- If more details are appropriate, add them here. What code changed, and why? -->

`@task` decorator has advised against since v3 and in v5 it's removed
task arrow function are much much better for typescript as you can see I was able to remove multiple comments and add correct types. https://ember-concurrency.com/docs/task-concurrency

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>