### PR TITLE
`PopoverPrimitive`, `RichTooltip`, `Dropdown`: add optional `event` argument to the close callback

### DIFF
--- a/.changeset/huge-buses-play.md
+++ b/.changeset/huge-buses-play.md
@@ -1,0 +1,15 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START utilities/popover-primitive -->
+`PopoverPrimitive` - Updated the type of the `hidePopover` callback to allow an optional event to be passed.
+<!-- END -->
+
+<!-- START components/rich-tooltip -->
+`RichToolip` - Updated the type of the `close` callback to allow an optional event to be passed.
+<!-- END -->
+
+<!-- START components/dropdown -->
+`Dropdown` - Updated the type of the `close` callback to allow an optional event to be passed and to make it always returned.
+<!-- END -->

--- a/packages/components/src/components/hds/advanced-table/th-context-menu.ts
+++ b/packages/components/src/components/hds/advanced-table/th-context-menu.ts
@@ -21,7 +21,7 @@ interface HdsAdvancedTableThContextMenuOption {
   icon: HdsDropdownToggleIconSignature['Args']['icon'];
   action: (
     column: HdsAdvancedTableColumn,
-    dropdownCloseCallback?: () => void
+    dropdownCloseCallback: () => void
   ) => void;
 }
 
@@ -110,7 +110,7 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
   @action
   resetColumnWidth(
     column: HdsAdvancedTableColumn,
-    dropdownCloseCallback?: () => void
+    dropdownCloseCallback: () => void
   ): void {
     const { onColumnResize } = this.args;
 
@@ -124,13 +124,13 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
       onColumnResize(column.key, column.width);
     }
 
-    dropdownCloseCallback?.();
+    dropdownCloseCallback();
   }
 
   @action
   pinFirstColumn(
     column: HdsAdvancedTableColumn,
-    dropdownCloseCallback?: () => void
+    dropdownCloseCallback: () => void
   ): void {
     const { onPinFirstColumn } = this.args;
 
@@ -138,6 +138,6 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
       onPinFirstColumn();
     }
 
-    dropdownCloseCallback?.();
+    dropdownCloseCallback();
   }
 }

--- a/packages/components/src/components/hds/dropdown/index.hbs
+++ b/packages/components/src/components/hds/dropdown/index.hbs
@@ -10,6 +10,7 @@
           "hds/dropdown/toggle/button" isOpen=PP.isOpen setupPrimitiveToggle=PP.setupPrimitiveToggle
         )
         ToggleIcon=(component "hds/dropdown/toggle/icon" isOpen=PP.isOpen setupPrimitiveToggle=PP.setupPrimitiveToggle)
+        close=PP.hidePopover
       )
     }}
     <div
@@ -19,7 +20,7 @@
       {{PP.setupPrimitivePopover anchoredPositionOptions=this.anchoredPositionOptions}}
     >
       {{#if (or PP.isOpen @preserveContentInDom)}}
-        {{yield (hash Header=(component "hds/dropdown/header"))}}
+        {{yield (hash Header=(component "hds/dropdown/header") close=PP.hidePopover)}}
         <ul class="hds-dropdown__list" {{did-insert this.didInsertList}}>
           {{yield
             (hash

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -65,7 +65,7 @@ export interface HdsDropdownSignature {
         Title?: ComponentLike<HdsDropdownListItemTitleSignature>;
         ToggleButton?: ComponentLike<HdsDropdownToggleButtonSignature>;
         ToggleIcon?: ComponentLike<HdsDropdownToggleIconSignature>;
-        close: (event?: PointerEvent) => void;
+        close: (event?: Event) => void;
       },
     ];
   };

--- a/packages/components/src/components/hds/dropdown/index.ts
+++ b/packages/components/src/components/hds/dropdown/index.ts
@@ -65,7 +65,7 @@ export interface HdsDropdownSignature {
         Title?: ComponentLike<HdsDropdownListItemTitleSignature>;
         ToggleButton?: ComponentLike<HdsDropdownToggleButtonSignature>;
         ToggleIcon?: ComponentLike<HdsDropdownToggleIconSignature>;
-        close?: () => void;
+        close: (event?: PointerEvent) => void;
       },
     ];
   };

--- a/packages/components/src/components/hds/popover-primitive/index.ts
+++ b/packages/components/src/components/hds/popover-primitive/index.ts
@@ -36,7 +36,7 @@ export interface HdsPopoverPrimitiveSignature {
         popoverElement?: HTMLElement;
         isOpen: boolean;
         showPopover: () => void;
-        hidePopover: () => void;
+        hidePopover: (event?: PointerEvent) => void;
         togglePopover: () => void;
       },
     ];
@@ -208,7 +208,9 @@ export default class HdsPopoverPrimitive extends Component<HdsPopoverPrimitiveSi
   }
 
   @action
-  hidePopover(): void {
+  // the event may be passed by the `on` modifier, so we need to keep it as an argument here
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  hidePopover(_event?: MouseEvent): void {
     try {
       if (this._popoverElement) {
         this._popoverElement.hidePopover();

--- a/packages/components/src/components/hds/popover-primitive/index.ts
+++ b/packages/components/src/components/hds/popover-primitive/index.ts
@@ -36,7 +36,7 @@ export interface HdsPopoverPrimitiveSignature {
         popoverElement?: HTMLElement;
         isOpen: boolean;
         showPopover: () => void;
-        hidePopover: (event?: PointerEvent) => void;
+        hidePopover: (event?: Event) => void;
         togglePopover: () => void;
       },
     ];
@@ -210,7 +210,7 @@ export default class HdsPopoverPrimitive extends Component<HdsPopoverPrimitiveSi
   @action
   // the event may be passed by the `on` modifier, so we need to keep it as an argument here
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  hidePopover(_event?: MouseEvent): void {
+  hidePopover(_event?: Event): void {
     try {
       if (this._popoverElement) {
         this._popoverElement.hidePopover();

--- a/packages/components/src/components/hds/rich-tooltip/index.ts
+++ b/packages/components/src/components/hds/rich-tooltip/index.ts
@@ -24,7 +24,7 @@ export interface HdsRichTooltipSignature {
           'arrowId' | 'popoverId' | 'setupPrimitivePopover' | 'isOpen'
         >;
         isOpen?: boolean;
-        close?: () => void;
+        close: (event?: PointerEvent) => void;
       },
     ];
   };

--- a/packages/components/src/components/hds/rich-tooltip/index.ts
+++ b/packages/components/src/components/hds/rich-tooltip/index.ts
@@ -24,7 +24,7 @@ export interface HdsRichTooltipSignature {
           'arrowId' | 'popoverId' | 'setupPrimitivePopover' | 'isOpen'
         >;
         isOpen?: boolean;
-        close: (event?: PointerEvent) => void;
+        close: (event?: Event) => void;
       },
     ];
   };

--- a/showcase/app/templates/page-components/app-footer.hbs
+++ b/showcase/app/templates/page-components/app-footer.hbs
@@ -80,11 +80,8 @@
           <AF.ExtraBefore>
             <Hds::Dropdown as |D|>
               <D.ToggleButton @text="Theme" @color="secondary" @size="small" />
-              {{! @glint-expect-error https://hashicorp.atlassian.net/browse/HDS-5170 }}
               <D.Interactive @icon="monitor" {{on "click" D.close}}>System</D.Interactive>
-              {{! @glint-expect-error https://hashicorp.atlassian.net/browse/HDS-5170 }}
               <D.Interactive @icon="moon" {{on "click" D.close}}>Dark</D.Interactive>
-              {{! @glint-expect-error https://hashicorp.atlassian.net/browse/HDS-5170 }}
               <D.Interactive @icon="sun" {{on "click" D.close}}>Light</D.Interactive>
             </Hds::Dropdown>
           </AF.ExtraBefore>

--- a/showcase/app/templates/page-components/rich-tooltip.hbs
+++ b/showcase/app/templates/page-components/rich-tooltip.hbs
@@ -1011,7 +1011,6 @@
           <RT.Bubble @placement="top-start">
             <Hds::Text::Body @size="200" @tag="p" {{style margin-bottom="12px"}}>Lorem ipsum dolor sit amet consectetur
               adipisicing elit.</Hds::Text::Body>
-            {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5170 }}
             <Hds::Button @text="Got it" @size="small" {{on "click" RT.close}} />
           </RT.Bubble>
         </Hds::RichTooltip>
@@ -1025,7 +1024,6 @@
           <RT.Bubble @placement="top-start">
             <Hds::Text::Body @size="200" @tag="p" {{style margin-bottom="12px"}}>Lorem ipsum dolor sit amet consectetur
               adipisicing elit.</Hds::Text::Body>
-            {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5170 }}
             <Hds::Button @text="Got it" @size="small" {{on "click" RT.close}} />
           </RT.Bubble>
         </Hds::RichTooltip>
@@ -1041,7 +1039,6 @@
         <RT.Toggle @text="Lorem ipsum dolor" @icon="info" @size="medium" />
         <RT.Bubble @placement="top">
           <div class="shw-component-rich-tooltip-content-interactive">
-            {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5170 }}
             <button type="button" {{on "click" RT.close}} title="Button that closes the popover on click">x</button>
             <ul>
               <li>
@@ -1057,7 +1054,6 @@
                 {{/let}}
               </li>
               <li>
-                {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5170 }}
                 <button type="button" {{on "click" RT.close}}>Got it!</button>
               </li>
             </ul>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the `PopoverPrimitive`, `RichTooltip`, and `Dropdown` components to allow an optional event argument to be passed to the close callback. This is because the callback can be used with the `on` modifier which always passes an event to the function.

This PR also makes it so the close callback always returned by the `Dropdown` component. This is because you can't pass undefined to the `on` modifier, and it seems logical for the consumer to always assume the `close` callback is defined (that is how it works for the `RichTooltip`).

_Side note: this wasn't caught in the Dropdown showcase page because it doesn't have any examples that use the close callback._

### :link: External links

Jira ticket: [HDS-5170](https://hashicorp.atlassian.net/browse/HDS-5170)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5170]: https://hashicorp.atlassian.net/browse/HDS-5170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ