### PR TITLE
Showcase: switch `deepTracked` out for `TrackedObject` and `TrackedArray`

### DIFF
--- a/showcase/app/components/mock/app/main/generic-advanced-table.gts
+++ b/showcase/app/components/mock/app/main/generic-advanced-table.gts
@@ -4,7 +4,7 @@
  */
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { deepTracked } from 'ember-deep-tracked';
+import { TrackedArray, TrackedObject } from 'tracked-built-ins';
 import { get } from '@ember/helper';
 
 // HDS components
@@ -17,8 +17,11 @@ import {
 } from '@hashicorp/design-system-components/components';
 
 import type { HdsAdvancedTableSignature } from '@hashicorp/design-system-components/components/hds/advanced-table/index';
+import type Owner from '@ember/owner';
 
 export interface MockAppMainGenericAdvancedTableSignature {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  Args: {};
   Element: HTMLDivElement;
 }
 
@@ -496,17 +499,28 @@ const updateModelWithSelectableRowsStates = (
 
 export default class MockAppMainGenericAdvancedTable extends Component<MockAppMainGenericAdvancedTableSignature> {
   demoColumns = SAMPLE_COLUMNS;
-  @deepTracked demoModel: HdsAdvancedTableSignature['Args']['model'] = [
-    ...SAMPLE_MODEL,
-  ];
+  demoModel: typeof SAMPLE_MODEL = new TrackedArray([]);
+
+  constructor(
+    owner: Owner,
+    args: MockAppMainGenericAdvancedTableSignature['Args'],
+  ) {
+    super(owner, args);
+    SAMPLE_MODEL.forEach((item) => {
+      this.demoModel.push(new TrackedObject(item));
+    });
+  }
 
   @action onSelectionChange({
     selectionKey,
     selectionCheckboxElement,
     selectableRowsStates,
   }: HdsAdvancedTableOnSelectionChangeSignature) {
-    // eslint-disable-next-line prefer-rest-params
-    console.log(...arguments);
+    console.group('Selection change arguments');
+    console.log('selectionKey:', selectionKey);
+    console.log('selectionCheckboxElement:', selectionCheckboxElement);
+    console.log('selectableRowsStates:', selectableRowsStates);
+    console.groupEnd();
 
     if (selectionKey === 'all' && this.demoModel) {
       const state = selectionCheckboxElement

--- a/showcase/app/components/mock/components/form/key-value-inputs/with-dynamic-inputs.gts
+++ b/showcase/app/components/mock/components/form/key-value-inputs/with-dynamic-inputs.gts
@@ -6,7 +6,8 @@
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
 import { tracked } from '@glimmer/tracking';
-import { deepTracked } from 'ember-deep-tracked';
+import { TrackedArray, TrackedObject } from 'tracked-built-ins';
+
 import { eq, or } from 'ember-truth-helpers';
 import style from 'ember-style-modifier/modifiers/style';
 
@@ -40,7 +41,7 @@ interface KvpItem {
   value: string | string[];
 }
 
-interface FormModel {
+interface FormModel extends Record<PropertyKey, unknown> {
   'thing-name': string;
   'thing-description': string;
   'kvp-list': KvpItem[];
@@ -99,7 +100,11 @@ export default class MockComponentsFormKeyValueInputsWithDynamicInputs extends C
   // Some examples of how the key-value pattern is implemented in the consumers' codebases:
   // - https://github.com/hashicorp/cloud-ui/blob/main/engines/iam/addon/components/groups/form.gts
   // - https://github.com/hashicorp/cloud-ui/blob/main/engines/role-assignments/addon/components/page/create.gts
-  @deepTracked model: FormModel = structuredClone(EMPTY_MODEL);
+  model = new TrackedObject<FormModel>({
+    'thing-name': '',
+    'thing-description': '',
+    'kvp-list': new TrackedArray([EMPTY_KVP_ITEM]),
+  });
 
   // we use the same function on all the different kind of inputs
   // except the SuperSelect, which returns a special set of arguments

--- a/showcase/app/components/mock/components/form/key-value-inputs/with-dynamic-inputs.gts
+++ b/showcase/app/components/mock/components/form/key-value-inputs/with-dynamic-inputs.gts
@@ -50,18 +50,6 @@ interface FormModel extends Record<PropertyKey, unknown> {
 
 const SUPERSELECT_OPTIONS = ['Option 1', 'Option 2', 'Option 3'];
 
-const EMPTY_KVP_ITEM: KvpItem = {
-  id: 0,
-  key: '',
-  value: '',
-};
-
-const EMPTY_MODEL: FormModel = {
-  'thing-name': '',
-  'thing-description': '',
-  'kvp-list': [structuredClone(EMPTY_KVP_ITEM)],
-};
-
 const Instructions = <template>
   <ShwTextH4 @tag="h3">Instructions</ShwTextH4>
   <ShwLabel {{style margin-bottom="32px"}}>
@@ -103,7 +91,13 @@ export default class MockComponentsFormKeyValueInputsWithDynamicInputs extends C
   model = new TrackedObject<FormModel>({
     'thing-name': '',
     'thing-description': '',
-    'kvp-list': new TrackedArray([EMPTY_KVP_ITEM]),
+    'kvp-list': new TrackedArray([
+      new TrackedObject({
+        id: 0,
+        key: '',
+        value: '',
+      }),
+    ]),
   });
 
   // we use the same function on all the different kind of inputs
@@ -167,11 +161,13 @@ export default class MockComponentsFormKeyValueInputsWithDynamicInputs extends C
   };
 
   onAddRowClick = () => {
-    this.model['kvp-list'].push({
-      id: this.model['kvp-list'].length + 1,
-      key: '',
-      value: '',
-    });
+    this.model['kvp-list'].push(
+      new TrackedObject({
+        id: this.model['kvp-list'].length + 1,
+        key: '',
+        value: '',
+      }),
+    );
   };
 
   get canDeleteRow() {
@@ -196,7 +192,7 @@ export default class MockComponentsFormKeyValueInputsWithDynamicInputs extends C
         'Trying to delete a row with index out of boundaries of the `@data` array',
       );
     } else if (rowIndex === 0 && this.model['kvp-list'].length === 1) {
-      this.model['kvp-list'] = [structuredClone(EMPTY_KVP_ITEM)];
+      this.model['kvp-list'].splice(rowIndex, this.model['kvp-list'].length);
     } else {
       // Remove the item at the specific index
       this.model['kvp-list'].splice(rowIndex, 1);
@@ -231,7 +227,16 @@ export default class MockComponentsFormKeyValueInputsWithDynamicInputs extends C
   };
 
   onResetButtonClick = () => {
-    this.model = structuredClone(EMPTY_MODEL);
+    this.model['thing-name'] = '';
+    this.model['thing-description'] = '';
+    this.model['kvp-list'].splice(0, this.model['kvp-list'].length);
+    this.model['kvp-list'].push(
+      new TrackedObject({
+        id: 0,
+        key: '',
+        value: '',
+      }),
+    );
   };
 
   onToggleAlwaysShowDeleteButtonClick = () => {

--- a/showcase/app/controllers/page-components/flyout.ts
+++ b/showcase/app/controllers/page-components/flyout.ts
@@ -5,7 +5,7 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { deepTracked } from 'ember-deep-tracked';
+import { TrackedObject } from 'tracked-built-ins';
 import { tracked } from '@glimmer/tracking';
 
 import type { PageComponentsFlyoutModel } from 'showcase/routes/page-components/flyout';
@@ -13,7 +13,7 @@ import type { PageComponentsFlyoutModel } from 'showcase/routes/page-components/
 export default class PageComponentsFlyoutController extends Controller {
   declare model: PageComponentsFlyoutModel;
 
-  @deepTracked flyouts = {
+  flyouts = new TrackedObject({
     mediumFlyoutActive: false,
     largeFlyoutActive: false,
     dropdownInitiatedFlyoutActive: false,
@@ -21,7 +21,7 @@ export default class PageComponentsFlyoutController extends Controller {
     deactivateFlyoutOnCloseActive: false,
     deactivateFlyoutOnDestroyActive: false,
     deactivateFlyoutOnSubmitActive: false,
-  };
+  });
 
   @tracked deactivateFlyoutOnSubmitValidationError = false;
 

--- a/showcase/app/controllers/page-components/form/base-elements.ts
+++ b/showcase/app/controllers/page-components/form/base-elements.ts
@@ -6,7 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { deepTracked } from 'ember-deep-tracked';
+import { TrackedObject } from 'tracked-built-ins';
 
 import type { PageComponentsFormBaseElementsModel } from 'showcase/routes/page-components/form/base-elements';
 
@@ -14,7 +14,7 @@ export default class PageComponentsFormBaseElementsController extends Controller
   declare model: PageComponentsFormBaseElementsModel;
 
   @tracked showHighlight = false;
-  @deepTracked values = {
+  values = new TrackedObject({
     value1: '',
     value2: 'cl',
     value3: '',
@@ -29,7 +29,7 @@ export default class PageComponentsFormBaseElementsController extends Controller
     value12: 'cluster',
     value13: 'cluster-length-is-longer-than',
     value14: 'Lorem ipsum dolor',
-  };
+  });
 
   @action
   toggleHighlight() {

--- a/showcase/app/controllers/page-components/form/masked-input.ts
+++ b/showcase/app/controllers/page-components/form/masked-input.ts
@@ -6,21 +6,21 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { deepTracked } from 'ember-deep-tracked';
+import { TrackedObject } from 'tracked-built-ins';
 
 import type { PageComponentsFormMaskedInputModel } from 'showcase/routes/page-components/form/masked-input';
 
 export default class PageComponentsFormMaskedInputController extends Controller {
   declare model: PageComponentsFormMaskedInputModel;
 
-  @deepTracked fieldValues = {
+  fieldValues = new TrackedObject({
     defaultText: 'Lorem ipsum dolor',
     customText: 'Lorem ipsum dolor',
     withErrorMessage: 'Lorem ipsum dolor sit amet',
     multilineDefaultText: 'Lorem ipsum dolor',
     multilineCustomText: 'Lorem ipsum dolor',
     multilineWithErrorMessage: 'Lorem ipsum dolor sit amet',
-  };
+  });
 
   @tracked isContentMasked = true;
 

--- a/showcase/app/controllers/page-components/form/text-input.ts
+++ b/showcase/app/controllers/page-components/form/text-input.ts
@@ -5,18 +5,18 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { deepTracked } from 'ember-deep-tracked';
+import { TrackedObject } from 'tracked-built-ins';
 
 import type { PageComponentsFormTextInputModel } from 'showcase/routes/page-components/form/text-input';
 
 export default class PageComponentsFormTextInputController extends Controller {
   declare model: PageComponentsFormTextInputModel;
 
-  @deepTracked fieldValues = {
+  fieldValues = new TrackedObject({
     defaultText: 'Lorem ipsum dolor',
     customText: 'Lorem ipsum dolor',
     withHelperText: 'Lorem ipsum dolor sit amet',
-  };
+  });
 
   maxLength = 20;
 

--- a/showcase/app/controllers/page-components/form/textarea.ts
+++ b/showcase/app/controllers/page-components/form/textarea.ts
@@ -5,19 +5,19 @@
 
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { deepTracked } from 'ember-deep-tracked';
+import { TrackedObject } from 'tracked-built-ins';
 
 import type { PageComponentsFormTextareaModel } from 'showcase/routes/page-components/form/textarea';
 
 export default class PageComponentsFormTextareaController extends Controller {
   declare model: PageComponentsFormTextareaModel;
 
-  @deepTracked values = {
+  values = new TrackedObject({
     defaultText: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco',
     customText: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco',
     withErrorMessage:
       'Ut enim ad minim veniam, quis nostrud exercitation ullamco',
-  };
+  });
 
   maxLength = 50;
 

--- a/showcase/app/controllers/page-components/modal.ts
+++ b/showcase/app/controllers/page-components/modal.ts
@@ -6,7 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { deepTracked } from 'ember-deep-tracked';
+import { TrackedObject } from 'tracked-built-ins';
 
 import { COLORS } from '@hashicorp/design-system-components/components/hds/modal/index';
 import { NAMES as ICON_NAMES } from '@hashicorp/design-system-components/components/hds/icon/index';
@@ -16,7 +16,7 @@ import type { PageComponentsModalModel } from 'showcase/routes/page-components/m
 export default class PageComponentsModalController extends Controller {
   declare model: PageComponentsModalModel;
 
-  @deepTracked modals = {
+  modals = new TrackedObject({
     basicModalActive: false,
     longModalActive: false,
     formModalActive: false,
@@ -31,7 +31,7 @@ export default class PageComponentsModalController extends Controller {
     deactivateModalOnCloseActive: false,
     deactivateModalOnDestroyActive: false,
     deactivateModalOnSubmitActive: false,
-  };
+  });
 
   @tracked isDismissDisabled: boolean | undefined = undefined;
   @tracked deactivateModalOnSubmitValidationError = false;

--- a/showcase/app/controllers/page-components/stepper/list.ts
+++ b/showcase/app/controllers/page-components/stepper/list.ts
@@ -6,7 +6,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { deepTracked } from 'ember-deep-tracked';
+import { TrackedArray, TrackedObject } from 'tracked-built-ins';
 
 import type { HdsStepperStatuses } from '@hashicorp/design-system-components/components/hds/stepper/types';
 import type { PageComponentsStepperListModel } from 'showcase/routes/page-components/stepper/list';
@@ -16,24 +16,6 @@ type ListData = {
   status: HdsStepperStatuses;
   description: string;
 };
-
-const DEFAULT_DATA: ListData[] = [
-  {
-    title: 'Step 1',
-    status: 'complete',
-    description: 'Description for Step 1',
-  },
-  {
-    title: 'Step 2',
-    status: 'progress',
-    description: 'Description for Step 2',
-  },
-  {
-    title: 'Step 3',
-    status: 'incomplete',
-    description: 'Description for Step 3',
-  },
-];
 
 const updateSteps = (steps: ListData[], stepNumber: number) => {
   steps.forEach((step, index) => {
@@ -65,8 +47,41 @@ export default class PageComponentsStepperListController extends Controller {
   @tracked currentStep_demo1 = 1;
   @tracked currentStep_demo2 = 1;
 
-  @deepTracked steps_demo1 = structuredClone(DEFAULT_DATA);
-  @deepTracked steps_demo2 = structuredClone(DEFAULT_DATA);
+  steps_demo1: ListData[] = new TrackedArray([
+    new TrackedObject({
+      title: 'Step 1',
+      status: 'complete',
+      description: 'Description for Step 1',
+    }),
+    new TrackedObject({
+      title: 'Step 2',
+      status: 'progress',
+      description: 'Description for Step 2',
+    }),
+    new TrackedObject({
+      title: 'Step 3',
+      status: 'incomplete',
+      description: 'Description for Step 3',
+    }),
+  ]);
+
+  steps_demo2: ListData[] = new TrackedArray([
+    new TrackedObject({
+      title: 'Step 1',
+      status: 'complete',
+      description: 'Description for Step 1',
+    }),
+    new TrackedObject({
+      title: 'Step 2',
+      status: 'progress',
+      description: 'Description for Step 2',
+    }),
+    new TrackedObject({
+      title: 'Step 3',
+      status: 'incomplete',
+      description: 'Description for Step 3',
+    }),
+  ]);
 
   // =============================
   // DEMOS

--- a/showcase/app/controllers/page-components/table.ts
+++ b/showcase/app/controllers/page-components/table.ts
@@ -290,12 +290,31 @@ export default class PageComponentsTableController extends Controller {
       if (this.customSortBy_demo6) {
         const v1 = s1[this.customSortBy_demo6];
         const v2 = s2[this.customSortBy_demo6];
-        if (v1 < v2) {
-          return this.customSortOrder_demo6 === 'asc' ? -1 : 1;
+
+        // Handle different value types for comparison
+        if (typeof v1 === 'string' && typeof v2 === 'string') {
+          const comparison = v1.localeCompare(v2);
+          return this.customSortOrder_demo6 === 'asc'
+            ? comparison
+            : -comparison;
         }
-        if (v1 > v2) {
-          return this.customSortOrder_demo6 === 'asc' ? 1 : -1;
+
+        if (typeof v1 === 'number' && typeof v2 === 'number') {
+          return this.customSortOrder_demo6 === 'asc' ? v1 - v2 : v2 - v1;
         }
+
+        if (typeof v1 === 'boolean' && typeof v2 === 'boolean') {
+          const comparison = Number(v1) - Number(v2);
+          return this.customSortOrder_demo6 === 'asc'
+            ? comparison
+            : -comparison;
+        }
+
+        // Fallback: convert to string for comparison
+        const str1 = String(v1);
+        const str2 = String(v2);
+        const comparison = str1.localeCompare(str2);
+        return this.customSortOrder_demo6 === 'asc' ? comparison : -comparison;
       }
       return 0;
     });

--- a/showcase/app/mocks/selectable-item-data.ts
+++ b/showcase/app/mocks/selectable-item-data.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-export interface SelectableItem {
+export interface SelectableItem extends Record<PropertyKey, unknown> {
   id: number;
   lorem: string;
   ipsum: string;

--- a/showcase/app/mocks/user-data.ts
+++ b/showcase/app/mocks/user-data.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-export interface User {
+export interface User extends Record<PropertyKey, unknown> {
   id: number;
   name: string;
   email: string;

--- a/showcase/app/templates/page-components/advanced-table.hbs
+++ b/showcase/app/templates/page-components/advanced-table.hbs
@@ -175,7 +175,6 @@
   <Hds::AdvancedTable
     @isSelectable={{true}}
     @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
-    {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
     @model={{this.model.userData}}
     @columns={{array
       (hash key="id" label="ID" width="auto")
@@ -213,7 +212,6 @@
     <Hds::AdvancedTable
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
-      {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
       @model={{this.model.userData}}
       @maxHeight="400px"
       @hasStickyHeader={{false}}
@@ -252,7 +250,6 @@
 
   <div class="shw-component-advanced-table-fixed-width-wrapper">
     <Hds::AdvancedTable
-      {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
       @model={{this.model.userData}}
       @columns={{array
         (hash key="id" label="ID" width="auto")
@@ -286,7 +283,6 @@
     <Hds::AdvancedTable
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
-      {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
       @model={{this.model.userData}}
       @columns={{array
         (hash key="id" label="ID" width="auto")
@@ -560,7 +556,6 @@
   <Hds::AdvancedTable
     @isSelectable={{true}}
     @onSelectionChange={{this.onSelectionChangeLogArguments}}
-    {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
     @model={{this.model.selectableData}}
     @columns={{array
       (hash key="lorem" label="Row #")
@@ -592,7 +587,6 @@
   <Hds::AdvancedTable
     @isSelectable={{true}}
     @onSelectionChange={{this.onMultiSelectSelectionChange}}
-    {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
     @model={{this.multiSelectSelectableData}}
     @columns={{array
       (hash key="lorem" label="Row #" isSortable=true)
@@ -812,7 +806,6 @@
   <Hds::AdvancedTable
     @isSelectable={{true}}
     @onSelectionChange={{this.onSelectionChangeWithModel__demo1}}
-    {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
     @model={{this.multiSelectFilteredData__demo1}}
     @columns={{array
       (hash key="lorem" label="Row #")
@@ -871,7 +864,6 @@
     <Hds::AdvancedTable
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectPaginatedSelectionChange__demo2}}
-      {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
       @model={{this.multiSelectPaginatedData_demo2}}
       @columns={{array
         (hash key="lorem" label="Row #")
@@ -945,7 +937,6 @@
     <Hds::AdvancedTable
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
-      {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
       @model={{this.multiSelectUsersData_demo3}}
       @columns={{array
         (hash key="id" label="ID")
@@ -1050,7 +1041,6 @@
                 <Hds::AdvancedTable
                   @isSelectable={{bool}}
                   @density={{if (not (eq density "default")) density}}
-                  {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
                   @model={{this.model.userDataShort}}
                   @columns={{array
                     (hash key="id" label="ID")
@@ -1092,7 +1082,6 @@
           <Hds::AdvancedTable
             @isStriped={{true}}
             @isSelectable={{bool}}
-            {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
             @model={{this.model.userDataShort}}
             @columns={{array
               (hash key="id" label="ID")
@@ -1237,7 +1226,6 @@
   <Shw::Text::H3>Selectable AdvancedTable with custom column widths</Shw::Text::H3>
   <Hds::AdvancedTable
     @isSelectable={{true}}
-    {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
     @model={{this.model.userDataShort}}
     @columns={{array
       (hash key="id" label="ID (120px)" width="120px")
@@ -1269,7 +1257,6 @@
     <Hds::AdvancedTable
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
-      {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
       @model={{this.model.userDataShort}}
       @columns={{array (hash key="id" label="ID" width="150px") (hash key="name" label="Name" width="150px")}}
     >

--- a/showcase/app/templates/page-components/form/key-value-inputs/frameless/demo-in-form.hbs
+++ b/showcase/app/templates/page-components/form/key-value-inputs/frameless/demo-in-form.hbs
@@ -84,37 +84,32 @@
               </:header>
 
               <:row as |R|>
-                {{#if (not-eq R.rowIndex undefined)}}
-                  {{! @glint-expect-error - with the if statement above, we know R.rowIndex is defined }}
-                  {{#let (get this.formErrors R.rowIndex) as |rowErrors|}}
-                    <R.Field as |F|>
-                      <F.Label>OS and architecture</F.Label>
-                      <F.Select name="plugin-os">
-                        <option></option>
-                        {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5090 }}
-                        <option selected={{if (eq "darwin - arm64" R.rowData.os) true}}>darwin - arm64</option>
-                        {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5090 }}
-                        <option selected={{if (eq "linux - 386" R.rowData.os) true}}>linux - 386</option>
-                        {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5090 }}
-                        <option selected={{if (eq "windows - amd64" R.rowData.os) true}}>windows - amd64</option>
-                      </F.Select>
-                    </R.Field>
+                <R.Field as |F|>
+                  <F.Label>OS and architecture</F.Label>
+                  <F.Select name="plugin-os">
+                    <option></option>
+                    {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5090 }}
+                    <option selected={{if (eq "darwin - arm64" R.rowData.os) true}}>darwin - arm64</option>
+                    {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5090 }}
+                    <option selected={{if (eq "linux - 386" R.rowData.os) true}}>linux - 386</option>
+                    {{! @glint-expect-error - https://hashicorp.atlassian.net/browse/HDS-5090 }}
+                    <option selected={{if (eq "windows - amd64" R.rowData.os) true}}>windows - amd64</option>
+                  </F.Select>
+                </R.Field>
 
-                    {{#let (get rowErrors "pluginFile") as |fileError|}}
-                      <R.Field @isInvalid={{(if (not-eq fileError undefined) true)}} as |F|>
-                        <F.Label>File</F.Label>
-                        <F.FileInput name="plugin-file" />
-                        {{#if (not-eq fileError undefined)}}
-                          <F.Error>
-                            {{! @glint-expect-error - file error is unknown type for some reason }}
-                            {{fileError}}
-                          </F.Error>
-                        {{/if}}
-                      </R.Field>
-                    {{/let}}
-                    <R.DeleteRowButton @onClick={{this.onDeleteRowClick}} />
-                  {{/let}}
-                {{/if}}
+                {{#let (get R.rowData "validationMessage") as |fileError|}}
+                  <R.Field @isInvalid={{(if (not-eq fileError undefined) true)}} as |F|>
+                    <F.Label>File</F.Label>
+                    <F.FileInput name="plugin-file" />
+                    {{#if (not-eq fileError undefined)}}
+                      <F.Error>
+                        {{! @glint-expect-error - file error is unknown type for some reason }}
+                        {{fileError}}
+                      </F.Error>
+                    {{/if}}
+                  </R.Field>
+                {{/let}}
+                <R.DeleteRowButton @onClick={{this.onDeleteRowClick}} />
               </:row>
 
               <:footer as |F|>

--- a/showcase/app/templates/page-components/pagination/index.hbs
+++ b/showcase/app/templates/page-components/pagination/index.hbs
@@ -292,7 +292,6 @@
 
   <div class="shw-component-pagination-table-demo" id="demo1-numbered-with-events">
     <Hds::Table
-      {{! @glint-expect-error - the Table doesn't have a generic type for the model argument / rowData (https://hashicorp.atlassian.net/browse/HDS-5090)  }}
       @model={{this.paginatedData_demo1}}
       @columns={{array
         (hash key="id" label="ID")
@@ -335,7 +334,6 @@
 
   <div class="shw-component-pagination-table-demo" id="demo2-numbered-with-routing">
     <Hds::Table
-      {{! @glint-expect-error - the Table doesn't have a generic type for the model argument / rowData (https://hashicorp.atlassian.net/browse/HDS-5090)  }}
       @model={{this.paginatedData_demo2}}
       @columns={{array
         (hash key="id" label="ID" isSortable=true)
@@ -384,7 +382,6 @@
 
   <div class="shw-component-pagination-table-demo" id="demo3-compact-with-events">
     <Hds::Table
-      {{! @glint-expect-error - the Table doesn't have a generic type for the model argument / rowData (https://hashicorp.atlassian.net/browse/HDS-5090)  }}
       @model={{this.paginatedData_demo3}}
       @columns={{array
         (hash key="id" label="ID")
@@ -426,7 +423,6 @@
 
   <div class="shw-component-pagination-table-demo" id="demo4-compact-with-routing">
     <Hds::Table
-      {{! @glint-expect-error - the Table doesn't have a generic type for the model argument / rowData (https://hashicorp.atlassian.net/browse/HDS-5090)  }}
       @model={{this.paginatedData_demo4}}
       @columns={{array
         (hash key="id" label="ID")

--- a/showcase/app/templates/page-components/table.hbs
+++ b/showcase/app/templates/page-components/table.hbs
@@ -476,7 +476,6 @@
   <Hds::Table
     @isSelectable={{true}}
     @onSelectionChange={{this.onSelectionChangeLogArguments}}
-    {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
     @model={{this.model.selectableData}}
     @columns={{array
       (hash key="lorem" label="Row #")
@@ -548,7 +547,6 @@
     @isSelectable={{true}}
     @selectableColumnKey="isSelected"
     @onSelectionChange={{this.onMultiSelectSelectionChange__demo5}}
-    {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
     @model={{this.multiSelectSelectableData__demo5}}
     @columns={{array
       (hash key="lorem" label="Row #" isSortable=true)
@@ -666,7 +664,6 @@
       <Hds::Table
         @isSelectable={{true}}
         @onSelectionChange={{this.onSelectionChangeWithModel__demo1}}
-        {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
         @model={{this.multiSelectFilteredData__demo1}}
         @columns={{array
           (hash key="lorem" label="Row #")
@@ -780,7 +777,6 @@
     <Hds::Table
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectPaginatedSelectionChange__demo2}}
-      {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
       @model={{this.multiSelectPaginatedData_demo2}}
       @columns={{array
         (hash key="lorem" label="Row #")
@@ -859,7 +855,6 @@
     <Hds::Table
       @isSelectable={{true}}
       @onSelectionChange={{this.onMultiSelectUsersSelectionChange__demo3}}
-      {{! @glint-expect-error - will be fixed by https://hashicorp.atlassian.net/browse/HDS-5090}}
       @model={{this.multiSelectUsersData_demo3}}
       @columns={{array
         (hash key="id" label="ID")


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would remove _most_ of the instances of `@deepTracked` in the showcase. `@deepTracked` is not the best practice to use anymore, we should use `TrackedObject` and `TrackedArray` instead.

`TrackedObject` and `TrackedArray` do not catch changes nested within the array or object (unlike `@deepTracked`), so thats why I have to nest them within each other. Ex:

```
  model = new TrackedObject<FormModel>({
    'thing-name': '',
    'thing-description': '',
    'kvp-list': new TrackedArray([
      new TrackedObject({
        id: 0,
        key: '',
        value: '',
      }),
    ]),
  });
```

I did not change the usage of `@deepTracked` in the Table and AdvancedTable showcase pages because it would be a lot easier to change it when we break up the pages into sub components + simplify how the data is fetched.

**NOTE: I am not sure why the linter is failing, I can not reproduce the failure locally.**

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5172](https://hashicorp.atlassian.net/browse/HDS-5172)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5172]: https://hashicorp.atlassian.net/browse/HDS-5172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ