### PR TITLE
`AppHeader` - Add close callback to "logo" yielded block (HDS-5390)

### DIFF
--- a/packages/components/src/components/hds/app-header/index.hbs
+++ b/packages/components/src/components/hds/app-header/index.hbs
@@ -20,7 +20,7 @@
     />
   {{/if}}
 
-  {{yield to="logo"}}
+  {{yield (hash close=this.close) to="logo"}}
 
   {{#if (not this._isDesktop)}}
     <Hds::AppHeader::MenuButton

--- a/packages/components/src/components/hds/app-header/index.ts
+++ b/packages/components/src/components/hds/app-header/index.ts
@@ -23,7 +23,11 @@ export interface HdsAppHeaderSignature {
     a11yRefocusExcludeAllQueryParams?: boolean;
   };
   Blocks: {
-    logo?: [];
+    logo?: [
+      {
+        close: () => void;
+      },
+    ];
     globalActions?: [
       {
         close: () => void;

--- a/showcase/app/components/mock/app/header/app-header.gts
+++ b/showcase/app/components/mock/app/header/app-header.gts
@@ -44,14 +44,17 @@ export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHe
 
   <template>
     <HdsAppHeader>
-      <:logo>
+      <:logo as |actions|>
         <HdsAppHeaderHomeLink
           @icon="hashicorp"
           @text="HashiCorp home menu"
           @isIconOnly={{true}}
           @href="#"
+          @isHrefExternal={{false}}
+          {{on "click" actions.close}}
         />
       </:logo>
+
       <:globalActions as |actions|>
         {{#if this.showOrgPicker}}
           <HdsDropdown @enableCollisionDetection={{true}} as |dd|>
@@ -62,6 +65,7 @@ export default class MockAppHeaderAppHeader extends Component<MockAppHeaderAppHe
           </HdsDropdown>
         {{/if}}
       </:globalActions>
+
       <:utilityActions as |actions|>
         {{#if this.showRegionPicker}}
           <HdsDropdown @enableCollisionDetection={{true}} as |dd|>

--- a/showcase/tests/integration/components/hds/app-header/index-test.js
+++ b/showcase/tests/integration/components/hds/app-header/index-test.js
@@ -87,13 +87,27 @@ module('Integration | Component | hds/app-header/index', function (hooks) {
   test('it should hide the actions when the "close" function is called in mobile view', async function (assert) {
     await render(hbs`
 <Hds::AppHeader id='test-app-header' @breakpoint='10000px'>
-    <:globalActions as |actions|>
+  <:logo as |actions|>
+    <Hds::AppHeader::HomeLink
+      @icon="hashicorp"
+      @text="HashiCorp"
+      id="test-home-link"
+      {{on "click" actions.close}}
+    />
+  </:logo>
+  <:globalActions as |actions|>
     <Hds::Button id='test-global-action' {{on 'click' actions.close}} @text="Global action" />
   </:globalActions>
-    <:utilityActions as |actions|>
-        <Hds::Button id='test-utility-action' {{on 'click' actions.close}} @text="Utility action" />
+  <:utilityActions as |actions|>
+    <Hds::Button id='test-utility-action' {{on 'click' actions.close}} @text="Utility action" />
   </:utilityActions>
 </Hds::AppHeader>`);
+
+    // test logo actions close
+    await click('.hds-app-header__menu-button');
+    assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-open');
+    await click('#test-home-link');
+    assert.dom('#test-app-header').hasClass('hds-app-header--menu-is-closed');
 
     // test global actions close
     await click('.hds-app-header__menu-button');


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a close callback to the yielded :logo block.

Preview: coming up...

To test:
1. Narrow browser window until "Menu" button appears in `AppHeader` bar ("mobile" view)
2. Click "Menu" button to open the mobile menu
3. Click `HomeLink` logo in the `AppHeader`
Expected: The open menu should close.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-5390](https://hashicorp.atlassian.net/browse/HDS-5390)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>