### PR TITLE
AdvancedTable - Use `pin-off` icon in ThContextMenu

### DIFF
--- a/packages/components/src/components/hds/advanced-table/th-context-menu.ts
+++ b/packages/components/src/components/hds/advanced-table/th-context-menu.ts
@@ -93,7 +93,7 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
         {
           key: 'pin-first-column',
           label: isStickyColumn ? translatedUnpinLabel : translatedPinLabel,
-          icon: 'pin',
+          icon: isStickyColumn ? 'pin-off' : 'pin',
           action: this.pinFirstColumn.bind(this),
         },
       ];


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the icon used in the `AdvancedTable` `ThContextMenu` for the control to unpin a column from `pin` to `pin-off`.

[Preview page](https://hds-showcase-git-dchyun-adv-table-pin-off-icon-hashicorp.vercel.app/components/advanced-table#pinnable-first-column)

### :camera_flash: Screenshots

**Before**
<img width="272" height="124" alt="Screenshot 2025-08-21 at 1 15 16 PM" src="https://github.com/user-attachments/assets/1a7d634c-af6d-48cc-a973-2bcdd6186303" />

**After**
<img width="246" height="121" alt="Screenshot 2025-08-21 at 1 13 38 PM" src="https://github.com/user-attachments/assets/82ab9965-3f2c-401e-91eb-5714ec62771d" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5391](https://hashicorp.atlassian.net/browse/HDS-5391)

***

### :eyes: Component checklist
- [x] Percy was checked for any visual regression


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5237]: https://hashicorp.atlassian.net/browse/HDS-5237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HDS-5391]: https://hashicorp.atlassian.net/browse/HDS-5391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ