### PR TITLE
`Accordion` - Add Showcase examples of flush variant within containers

### DIFF
--- a/showcase/app/styles/showcase-pages/accordion.scss
+++ b/showcase/app/styles/showcase-pages/accordion.scss
@@ -24,15 +24,13 @@ body.page-components-accordion {
   }
 
   .shw-component-flyout-sample-item {
+    // Note: Percy wasn't seeing the styles applied via selecting by the [open] attribute
+    // (which the Flyout showpage uses for similar examples)
     .hds-flyout {
-      &,
-      &[open] {
-        position: relative;
-        z-index: initial;
-        display: flex;
-        height: 40vh;
-        margin: 0;
-      }
+      position: relative;
+      z-index: initial;
+      display: flex;
+      height: 40vh;
     }
   }
 }

--- a/showcase/app/styles/showcase-pages/accordion.scss
+++ b/showcase/app/styles/showcase-pages/accordion.scss
@@ -24,12 +24,15 @@ body.page-components-accordion {
   }
 
   .shw-component-flyout-sample-item {
-    .hds-flyout[open] {
-      position: relative;
-      z-index: initial;
-      display: flex;
-      height: 40vh;
-      margin: 0;
+    .hds-flyout {
+      &,
+      &[open] {
+        position: relative;
+        z-index: initial;
+        display: flex;
+        height: 40vh;
+        margin: 0;
+      }
     }
   }
 }

--- a/showcase/app/styles/showcase-pages/accordion.scss
+++ b/showcase/app/styles/showcase-pages/accordion.scss
@@ -22,4 +22,14 @@ body.page-components-accordion {
     // this variable is set on the parent element
     --hds-accordion-item-focus-ring-offset: 0;
   }
+
+  .shw-component-flyout-sample-item {
+    .hds-flyout[open] {
+      position: relative;
+      z-index: initial;
+      display: flex;
+      height: 40vh;
+      margin: 0;
+    }
+  }
 }

--- a/showcase/app/templates/page-components/accordion.hbs
+++ b/showcase/app/templates/page-components/accordion.hbs
@@ -211,99 +211,6 @@
 
   <Shw::Divider @level={{2}} />
 
-  <Shw::Text::H3>Flush Accordion used within containers</Shw::Text::H3>
-
-  <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
-    <SG.Item @label="In a Card w/ no padding">
-      <Hds::Card::Container @hasBorder={{true}}>
-        <Hds::Accordion @type="flush" as |A|>
-          <A.Item>
-            <:toggle>Item one</:toggle>
-            <:content>
-              <Shw::Placeholder @text="generic content" @height="40" />
-            </:content>
-          </A.Item>
-
-          <A.Item @isStatic={{true}}>
-            <:toggle>Item two</:toggle>
-            <:content>
-              <Shw::Placeholder @text="generic content" @height="40" />
-            </:content>
-          </A.Item>
-
-          <A.Item @containsInteractive={{true}}>
-            <:toggle>Item three</:toggle>
-            <:content>
-              <Shw::Placeholder @text="generic content" @height="40" />
-            </:content>
-          </A.Item>
-        </Hds::Accordion>
-      </Hds::Card::Container>
-    </SG.Item>
-
-    <SG.Item @label="in a Card w/ padding">
-      <Hds::Card::Container @hasBorder={{true}} {{style padding="16px"}}>
-        <Hds::Accordion @type="flush" as |A|>
-          <A.Item>
-            <:toggle>Item one</:toggle>
-            <:content>
-              <Shw::Placeholder @text="generic content" @height="40" />
-            </:content>
-          </A.Item>
-
-          <A.Item @isStatic={{true}}>
-            <:toggle>Item two</:toggle>
-            <:content>
-              <Shw::Placeholder @text="generic content" @height="40" />
-            </:content>
-          </A.Item>
-
-          <A.Item @containsInteractive={{true}}>
-            <:toggle>Item three</:toggle>
-            <:content>
-              <Shw::Placeholder @text="generic content" @height="40" />
-            </:content>
-          </A.Item>
-        </Hds::Accordion>
-      </Hds::Card::Container>
-    </SG.Item>
-
-    <SG.Item @label="in a Flyout" class="shw-component-flyout-sample-item">
-      <Hds::Flyout open id="flyout-example-one-action" as |F|>
-        <F.Header>Title</F.Header>
-        <F.Body>
-          <Hds::Accordion @type="flush" as |A|>
-            <A.Item>
-              <:toggle>Item one</:toggle>
-              <:content>
-                <Shw::Placeholder @text="generic content" @height="40" />
-              </:content>
-            </A.Item>
-
-            <A.Item @isStatic={{true}}>
-              <:toggle>Item two</:toggle>
-              <:content>
-                <Shw::Placeholder @text="generic content" @height="40" />
-              </:content>
-            </A.Item>
-
-            <A.Item @containsInteractive={{true}}>
-              <:toggle>Item three</:toggle>
-              <:content>
-                <Shw::Placeholder @text="generic content" @height="40" />
-              </:content>
-            </A.Item>
-          </Hds::Accordion>
-        </F.Body>
-        <F.Footer>
-          <Hds::Button type="submit" @text="Primary" />
-        </F.Footer>
-      </Hds::Flyout>
-    </SG.Item>
-  </Shw::Grid>
-
-  <Shw::Divider @level={{2}} />
-
   <Shw::Text::H3>Nested Accordions</Shw::Text::H3>
 
   {{#each @model.TYPES as |type|}}
@@ -542,6 +449,101 @@
         </Hds::Accordion>
       </SG.Item>
     {{/each}}
+  </Shw::Grid>
+
+  <Shw::Divider />
+
+  <Shw::Text::H2>Context</Shw::Text::H2>
+
+  <Shw::Text::H3>Flush Accordion used within containers</Shw::Text::H3>
+
+  <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
+    <SG.Item @label="In a Card w/ no padding">
+      <Hds::Card::Container @hasBorder={{true}}>
+        <Hds::Accordion @type="flush" as |A|>
+          <A.Item>
+            <:toggle>Item one</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+
+          <A.Item @isStatic={{true}}>
+            <:toggle>Item two</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+
+          <A.Item @containsInteractive={{true}}>
+            <:toggle>Item three</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+        </Hds::Accordion>
+      </Hds::Card::Container>
+    </SG.Item>
+
+    <SG.Item @label="in a Card w/ padding">
+      <Hds::Card::Container @hasBorder={{true}} {{style padding="16px"}}>
+        <Hds::Accordion @type="flush" as |A|>
+          <A.Item>
+            <:toggle>Item one</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+
+          <A.Item @isStatic={{true}}>
+            <:toggle>Item two</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+
+          <A.Item @containsInteractive={{true}}>
+            <:toggle>Item three</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+        </Hds::Accordion>
+      </Hds::Card::Container>
+    </SG.Item>
+
+    <SG.Item @label="in a Flyout" class="shw-component-flyout-sample-item">
+      <Hds::Flyout open id="flyout-example-one-action" as |F|>
+        <F.Header>Title</F.Header>
+        <F.Body>
+          <Hds::Accordion @type="flush" as |A|>
+            <A.Item>
+              <:toggle>Item one</:toggle>
+              <:content>
+                <Shw::Placeholder @text="generic content" @height="40" />
+              </:content>
+            </A.Item>
+
+            <A.Item @isStatic={{true}}>
+              <:toggle>Item two</:toggle>
+              <:content>
+                <Shw::Placeholder @text="generic content" @height="40" />
+              </:content>
+            </A.Item>
+
+            <A.Item @containsInteractive={{true}}>
+              <:toggle>Item three</:toggle>
+              <:content>
+                <Shw::Placeholder @text="generic content" @height="40" />
+              </:content>
+            </A.Item>
+          </Hds::Accordion>
+        </F.Body>
+        <F.Footer>
+          <Hds::Button type="submit" @text="Primary" />
+        </F.Footer>
+      </Hds::Flyout>
+    </SG.Item>
   </Shw::Grid>
 
   <Shw::Divider />

--- a/showcase/app/templates/page-components/accordion.hbs
+++ b/showcase/app/templates/page-components/accordion.hbs
@@ -211,6 +211,99 @@
 
   <Shw::Divider @level={{2}} />
 
+  <Shw::Text::H3>Flush Accordion used within containers</Shw::Text::H3>
+
+  <Shw::Grid @columns={{2}} @gap="2rem" as |SG|>
+    <SG.Item @label="In a Card w/ no padding">
+      <Hds::Card::Container @hasBorder={{true}}>
+        <Hds::Accordion @type="flush" as |A|>
+          <A.Item>
+            <:toggle>Item one</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+
+          <A.Item @isStatic={{true}}>
+            <:toggle>Item two</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+
+          <A.Item @containsInteractive={{true}}>
+            <:toggle>Item three</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+        </Hds::Accordion>
+      </Hds::Card::Container>
+    </SG.Item>
+
+    <SG.Item @label="in a Card w/ padding">
+      <Hds::Card::Container @hasBorder={{true}} {{style padding="16px"}}>
+        <Hds::Accordion @type="flush" as |A|>
+          <A.Item>
+            <:toggle>Item one</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+
+          <A.Item @isStatic={{true}}>
+            <:toggle>Item two</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+
+          <A.Item @containsInteractive={{true}}>
+            <:toggle>Item three</:toggle>
+            <:content>
+              <Shw::Placeholder @text="generic content" @height="40" />
+            </:content>
+          </A.Item>
+        </Hds::Accordion>
+      </Hds::Card::Container>
+    </SG.Item>
+
+    <SG.Item @label="in a Flyout" class="shw-component-flyout-sample-item">
+      <Hds::Flyout open id="flyout-example-one-action" as |F|>
+        <F.Header>Title</F.Header>
+        <F.Body>
+          <Hds::Accordion @type="flush" as |A|>
+            <A.Item>
+              <:toggle>Item one</:toggle>
+              <:content>
+                <Shw::Placeholder @text="generic content" @height="40" />
+              </:content>
+            </A.Item>
+
+            <A.Item @isStatic={{true}}>
+              <:toggle>Item two</:toggle>
+              <:content>
+                <Shw::Placeholder @text="generic content" @height="40" />
+              </:content>
+            </A.Item>
+
+            <A.Item @containsInteractive={{true}}>
+              <:toggle>Item three</:toggle>
+              <:content>
+                <Shw::Placeholder @text="generic content" @height="40" />
+              </:content>
+            </A.Item>
+          </Hds::Accordion>
+        </F.Body>
+        <F.Footer>
+          <Hds::Button type="submit" @text="Primary" />
+        </F.Footer>
+      </Hds::Flyout>
+    </SG.Item>
+  </Shw::Grid>
+
+  <Shw::Divider @level={{2}} />
+
   <Shw::Text::H3>Nested Accordions</Shw::Text::H3>
 
   {{#each @model.TYPES as |type|}}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the `Accordion` Showcase page to add examples of the "flush" variant used inside containers, as recommended in Helios docs.

👉 **Preview**: https://hds-showcase-git-kristin-update-accordion-show-a8c4f9-hashicorp.vercel.app/components/accordion#flush-accordion-used-within-containers

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :link: External links

* [Related Slack discussion](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1755883439245599)
<!-- 
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)
-->

### :camera_flash: Screenshots

<img width="1110" height="822" alt="image" src="https://github.com/user-attachments/assets/12055f47-50c8-4016-b7f9-c89f09f297e1" />

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>