### PR TITLE
Time - Fix error with start task

### DIFF
--- a/packages/components/src/components/hds/time/index.ts
+++ b/packages/components/src/components/hds/time/index.ts
@@ -129,11 +129,11 @@ export default class HdsTime extends Component<HdsTimeSignature> {
   }
 
   @action
-  async didInsertNode(): Promise<void> {
+  didInsertNode(): void {
     const date = this.date;
 
     if (dateIsValid(date)) {
-      await this.hdsTime.register(date);
+      this.hdsTime.register(date);
     }
   }
 

--- a/packages/components/src/services/hds-time.ts
+++ b/packages/components/src/services/hds-time.ts
@@ -228,7 +228,9 @@ export default class TimeService extends Service {
   async register(id: Date): Promise<() => void> {
     this.#listeners.add(id);
 
-    await this.start.perform();
+    if (!this.start.isRunning) {
+      await this.start.perform();
+    }
 
     return (): void => {
       this.unregister(id);

--- a/packages/components/src/services/hds-time.ts
+++ b/packages/components/src/services/hds-time.ts
@@ -225,12 +225,10 @@ export default class TimeService extends Service {
   }
 
   // Subscribes a listener to the ticking task for time changes.
-  async register(id: Date): Promise<() => void> {
+  register(id: Date): () => void {
     this.#listeners.add(id);
 
-    if (!this.start.isRunning) {
-      await this.start.perform();
-    }
+    void this.start.perform();
 
     return (): void => {
       this.unregister(id);


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue with the `Time` service where there are errors thrown in the showcase and website for the start task.

This issue is currently causing the website test suite to fail.

### :hammer_and_wrench: Detailed description

Error can be seen in the production [showcase](https://hds-showcase.vercel.app/components/time) and [website](https://helios.hashicorp.design/components/time) pages console. 

<img width="548" height="193" alt="Screenshot 2025-08-22 at 4 09 57 PM" src="https://github.com/user-attachments/assets/5142a177-0cc9-4bb2-a150-447da94ba9de" />


***

### :eyes: Component checklist
- [ ] Percy was checked for any visual regression


:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>