### PR TITLE
`Modal` docs - Add callout banners explaining visual focus (HDS-5423)

### DIFF
--- a/website/docs/components/modal/partials/accessibility/accessibility.md
+++ b/website/docs/components/modal/partials/accessibility/accessibility.md
@@ -6,7 +6,7 @@ The Modal component is conformant when used as directed.
 
 ## Focus and focus order
 
-!!! callout
+!!! info
 
 Browsers use a variety of heuristics to decide when to visually show focus state based on what is considered most useful to users. For that reason, even though the Modal’s dismiss button is focused by default, it may not visually appear to be focused.
 

--- a/website/docs/components/modal/partials/accessibility/accessibility.md
+++ b/website/docs/components/modal/partials/accessibility/accessibility.md
@@ -6,6 +6,12 @@ The Modal component is conformant when used as directed.
 
 ## Focus and focus order
 
+!!! callout
+
+Browsers use a variety of heuristics to decide when to visually show focus state based on what is considered most useful to users. For that reason, even though the Modal’s dismiss button is focused by default, it may not visually appear to be focused.
+
+!!!
+
 - When the modal is open, focus moves to the first interactive element within the modal and is trapped within the component.
 - Since a Modal is a complex pattern that can contain any combination of nested components and content, nested elements must adhere to their individual accessibility criteria.
 

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -12,6 +12,12 @@ As an overlaying component, the `Hds::Modal` is rendered on the [top layer](http
 
 ## Focus and focus trap
 
+!!! callout
+
+Browsers use a variety of heuristics to decide when to visually show focus state based on what is considered most useful to users. For that reason, even though the Modal’s dismiss button is focused by default, it may not visually appear to be focused.
+
+!!!
+
 This component uses [`ember-focus-trap`](https://github.com/josemarluedke/ember-focus-trap) to prevent the focus from going outside the Modal and to dismiss the Modal when clicking outside the Modal. This Ember modifier requires at least one interactive element to be present within the Modal, which is by default achieved by the dismiss button in the header.
 
 When a Modal is opened with the keyboard, the focus is automatically set to the first focusable element inside the Modal, which is the “Dismiss” button. The action of this button has no effect on the system, so focusing on it helps prevent users from accidentally confirming the Modal.

--- a/website/docs/components/modal/partials/code/how-to-use.md
+++ b/website/docs/components/modal/partials/code/how-to-use.md
@@ -12,7 +12,7 @@ As an overlaying component, the `Hds::Modal` is rendered on the [top layer](http
 
 ## Focus and focus trap
 
-!!! callout
+!!! info
 
 Browsers use a variety of heuristics to decide when to visually show focus state based on what is considered most useful to users. For that reason, even though the Modal’s dismiss button is focused by default, it may not visually appear to be focused.
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the Modal web docs to add callouts explaining that browsers may not visually show focus of the default-focused dismiss/close button.

**Previews**:
(Banner has been added within two relevant pages)

* https://hds-website-git-kristin-hds-5423-update-modal-docs-hashicorp.vercel.app/components/modal?tab=accessibility#focus-and-focus-order
* https://hds-website-git-kristin-hds-5423-update-modal-docs-hashicorp.vercel.app/components/modal?tab=code#focus-and-focus-trap

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<img width="854" height="194" alt="image" src="https://github.com/user-attachments/assets/fcd5151a-149f-45e4-a62a-d27d5bc2d5e7" />

### :link: External links

* Jira ticket: [HDS-5423](https://hashicorp.atlassian.net/browse/HDS-5423)

***

### :eyes: Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5423]: https://hashicorp.atlassian.net/browse/HDS-5423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ