### PR TITLE
Fix invalid generated CSS (HDS-5314)

### DIFF
--- a/.changeset/mighty-masks-wave.md
+++ b/.changeset/mighty-masks-wave.md
@@ -2,4 +2,14 @@
 "@hashicorp/design-system-components": patch
 ---
 
+<!-- START {components/button} -->
 `Button` - Fixed broken CSS included in hover state styles
+<!-- END -->
+
+<!-- START {components/dropdown} -->
+`Dropdown` - Fixed broken CSS included in hover state styles
+<!-- END -->
+
+<!-- START {components/form/file-input} -->
+`FileInput` - Fixed broken CSS included in hover state styles
+<!-- END -->

--- a/.changeset/mighty-masks-wave.md
+++ b/.changeset/mighty-masks-wave.md
@@ -3,13 +3,13 @@
 ---
 
 <!-- START {components/button} -->
-`Button` - Fixed broken CSS included in hover state styles
+`Button` - Fixed broken CSS included in disabled state styles
 <!-- END -->
 
 <!-- START {components/dropdown} -->
-`Dropdown` - Fixed broken CSS included in hover state styles
+`Dropdown` - Fixed broken CSS included in disabled state styles
 <!-- END -->
 
 <!-- START {components/form/file-input} -->
-`FileInput` - Fixed broken CSS included in hover state styles
+`FileInput` - Fixed broken CSS included in disabled state styles
 <!-- END -->

--- a/.changeset/mighty-masks-wave.md
+++ b/.changeset/mighty-masks-wave.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Button` - Fixed broken CSS included in hover state styles

--- a/.changeset/mighty-masks-wave.md
+++ b/.changeset/mighty-masks-wave.md
@@ -3,13 +3,13 @@
 ---
 
 <!-- START {components/button} -->
-`Button` - Fixed broken CSS included in disabled state styles
+`Button` - Removed CSS declaration for pseudo element in disabled state
 <!-- END -->
 
 <!-- START {components/dropdown} -->
-`Dropdown` - Fixed broken CSS included in disabled state styles
+`Dropdown` - Removed CSS declaration for pseudo element in disabled state
 <!-- END -->
 
 <!-- START {components/form/file-input} -->
-`FileInput` - Fixed broken CSS included in disabled state styles
+`FileInput` - Removed CSS declaration for pseudo element in disabled state that led to invalid CSS (ignored by browsers)
 <!-- END -->

--- a/.changeset/mighty-masks-wave.md
+++ b/.changeset/mighty-masks-wave.md
@@ -2,14 +2,14 @@
 "@hashicorp/design-system-components": patch
 ---
 
-<!-- START {components/button} -->
+<!-- START components/button -->
 `Button` - Removed CSS declaration for pseudo element in disabled state
 <!-- END -->
 
-<!-- START {components/dropdown} -->
+<!-- START components/dropdown -->
 `Dropdown` - Removed CSS declaration for pseudo element in disabled state
 <!-- END -->
 
-<!-- START {components/form/file-input} -->
+<!-- START components/form/file-input -->
 `FileInput` - Removed CSS declaration for pseudo element in disabled state that led to invalid CSS (ignored by browsers)
 <!-- END -->

--- a/packages/components/src/styles/mixins/_button.scss
+++ b/packages/components/src/styles/mixins/_button.scss
@@ -84,10 +84,6 @@ $hds-button-size-props: (
   border-color: var(--token-color-border-primary);
   box-shadow: none;
   cursor: not-allowed;
-
-  &::before {
-    border-color: transparent;
-  }
 }
 
 @mixin hds-button-state-focus() {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR removes/fixes SCSS styles which compile to invalid CSS.

#### Previews of affected component Showcases:
(_See disabled states, **no visible changes should be observed**_)

* `Button`: https://hds-showcase-git-kristin-hds-5314-fix-invalid-css-hashicorp.vercel.app/components/button#states
* `Dropdown`: https://hds-showcase-git-kristin-hds-5314-fix-invalid-css-hashicorp.vercel.app/components/dropdown#states
* `FileInput`: https://hds-showcase-git-kristin-hds-5314-fix-invalid-css-hashicorp.vercel.app/components/form/file-input#states

### :hammer_and_wrench: Detailed description

Where `hds-button-state-disabled` mixin is used:

* button.scss
  - one usage:
  ```
  .hds-button {
    // ...
    &:disabled,
    &[disabled],
    &.mock-disabled,
    &:disabled:focus,
    &[disabled]:focus,
    &.mock-disabled:focus,
    &:disabled:hover,
    &[disabled]:hover,
    &.mock-disabled:hover {
      @include hds-button-state-disabled();
    }
    // ...
  }
  ```
* dropdown.scss
  - two usages:
  ```
  .hds-dropdown-toggle-icon {
    // ...
    &:disabled,
    &.mock-disabled {
      @include hds-button-state-disabled();
    }
  }
  ```	
  ```
  .hds-dropdown-toggle-button {
    // ...
    &:disabled,
    &.mock-disabled,
    &:disabled:focus,
    &.mock-disabled:focus,
    &:disabled:hover,
    &.mock-disabled:hover {
      @include hds-button-state-disabled();
      // ...
    }
  }
  ```
* file-input.scss
  - one usage:
  ```
  .hds-form-file-input {
    &:disabled,
    &[disabled],
    &.mock-disabled,
    &:disabled:focus,
    &[disabled]:focus,
    &.mock-disabled:focus,
    &:disabled:hover,
    &[disabled]:hover,
    &.mock-disabled:hover {
      // ...
      &::file-selector-button {
        @include hds-button-state-disabled();
        // ...
      }
    }
  }
  ```

<!--
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-5314](https://hashicorp.atlassian.net/browse/HDS-5314)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-314]: https://hashicorp.atlassian.net/browse/HDS-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HDS-5314]: https://hashicorp.atlassian.net/browse/HDS-5314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ