### PR TITLE
Add `cspNonce` argument to `Hds::CodeEditor` component

### DIFF
--- a/.changeset/brown-ways-invite.md
+++ b/.changeset/brown-ways-invite.md
@@ -1,0 +1,9 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+<!-- START components/code-editor -->
+
+`CodeEditor` - Added a `cspNonce` argument which passes a value of the same name to the `hds-code-editor` modifier. `cspNonce` is used to add a nonce value to the style tag
+
+<!-- END -->

--- a/packages/components/src/components/hds/code-editor/index.hbs
+++ b/packages/components/src/components/hds/code-editor/index.hbs
@@ -55,6 +55,7 @@
       ariaDescribedBy=this.ariaDescribedBy
       ariaLabel=@ariaLabel
       ariaLabelledBy=this.ariaLabelledBy
+      cspNonce=@cspNonce
       extraKeys=@extraKeys
       hasLineWrapping=@hasLineWrapping
       isLintingEnabled=@isLintingEnabled

--- a/showcase/tests/integration/components/hds/code-editor/index-test.js
+++ b/showcase/tests/integration/components/hds/code-editor/index-test.js
@@ -24,6 +24,20 @@ module('Integration | Component | hds/code-editor/index', function (hooks) {
     assert.dom('#test-code-editor').hasClass('hds-code-editor');
   });
 
+  // cspNonce
+  test('it should render the injected style tag with the provided `@cspNonce` value', async function (assert) {
+    const cspNonce = 'csp-nonce-123';
+
+    this.set('cspNonce', cspNonce);
+
+    await setupCodeEditor(
+      hbs`<Hds::CodeEditor @cspNonce={{this.cspNonce}} as |CE|><CE.Title>Test Title</CE.Title></Hds::CodeEditor>`,
+    );
+
+    // can't use assert.dom to access elements in head
+    assert.ok(document.querySelector(`style[nonce="${cspNonce}"]`));
+  });
+
   // title
   test('it should render the component with a title using the default tag', async function (assert) {
     await setupCodeEditor(


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds support for a `cspNonce` argument to the `Hds::CodeEditor` component.

### :hammer_and_wrench: Detailed description

The `hds-code-editor` modifier already supports this nonce attribute, but it wasn't being passed from the component to the modifier.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5444](https://hashicorp.atlassian.net/browse/HDS-5444)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5444]: https://hashicorp.atlassian.net/browse/HDS-5444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ