### PR TITLE
[SPIKE] AdvancedTable Filtering - In-column

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -154,6 +154,7 @@
       "./components/hds/advanced-table/th-button-sort.js": "./dist/_app_/components/hds/advanced-table/th-button-sort.js",
       "./components/hds/advanced-table/th-button-tooltip.js": "./dist/_app_/components/hds/advanced-table/th-button-tooltip.js",
       "./components/hds/advanced-table/th-context-menu.js": "./dist/_app_/components/hds/advanced-table/th-context-menu.js",
+      "./components/hds/advanced-table/th-filter-menu.js": "./dist/_app_/components/hds/advanced-table/th-filter-menu.js",
       "./components/hds/advanced-table/th-reorder-drop-target.js": "./dist/_app_/components/hds/advanced-table/th-reorder-drop-target.js",
       "./components/hds/advanced-table/th-reorder-handle.js": "./dist/_app_/components/hds/advanced-table/th-reorder-handle.js",
       "./components/hds/advanced-table/th-resize-handle.js": "./dist/_app_/components/hds/advanced-table/th-resize-handle.js",

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -3,6 +3,16 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
+{{#if this.hasActiveFilters}}
+  <Hds::Button
+    @text="Clear all filters"
+    @color="tertiary"
+    @icon="x"
+    @size="small"
+    class="hds-advanced-table__clear-filters-button"
+    {{on "click" this.clearFilters}}
+  />
+{{/if}}
 <div
   class="hds-advanced-table__container
     {{(if this.isStickyHeaderPinned 'hds-advanced-table__container--header-is-pinned')}}"
@@ -63,11 +73,14 @@
               @isStickyColumn={{this._isStickyColumn column}}
               @isStickyColumnPinned={{this.isStickyColumnPinned}}
               @tableHeight={{this._tableHeight}}
+              @filters={{this.filters}}
+              @isLiveFilter={{@isLiveFilter}}
               @onColumnResize={{@onColumnResize}}
               @onPinFirstColumn={{this._onPinFirstColumn}}
               @onReorderDragEnd={{fn (mut this._tableModel.reorderDraggedColumn) null}}
               @onReorderDragStart={{fn (mut this._tableModel.reorderDraggedColumn)}}
               @onReorderDrop={{this._tableModel.moveColumnToDropTarget}}
+              @onFilter={{this.onFilter}}
               {{this._registerThElement column}}
             >
               {{column.label}}

--- a/packages/components/src/components/hds/advanced-table/models/column.ts
+++ b/packages/components/src/components/hds/advanced-table/models/column.ts
@@ -13,7 +13,9 @@ import type { HdsDropdownToggleButtonSignature } from '../../dropdown/toggle/but
 import type {
   HdsAdvancedTableCell,
   HdsAdvancedTableHorizontalAlignment,
+  HdsAdvancedTableFilterOption,
   HdsAdvancedTableColumn as HdsAdvancedTableColumnType,
+  HdsAdvancedTableFilterType,
 } from '../types';
 
 export const DEFAULT_WIDTH = '1fr'; // default to '1fr' to allow flexible width
@@ -51,6 +53,8 @@ export default class HdsAdvancedTableColumn {
   @tracked
   thContextMenuToggleElement?: HdsDropdownToggleButtonSignature['Element'] =
     undefined;
+  @tracked filterOptions?: HdsAdvancedTableFilterOption[] = undefined;
+  @tracked filterType?: HdsAdvancedTableFilterType = undefined;
 
   // width properties
   @tracked transientWidth?: `${number}px` = undefined; // used for transient width changes
@@ -165,6 +169,8 @@ export default class HdsAdvancedTableColumn {
     this.tooltip = column.tooltip;
     this._setWidthValues(column);
     this.sortingFunction = column.sortingFunction;
+    this.filterOptions = column.filterOptions;
+    this.filterType = column.filterType;
   }
 
   // main collection function

--- a/packages/components/src/components/hds/advanced-table/th-filter-menu.hbs
+++ b/packages/components/src/components/hds/advanced-table/th-filter-menu.hbs
@@ -1,0 +1,44 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+<Hds::Dropdown
+  class="hds-advanced-table__th-filter-menu {{if this.hasActiveFilters 'hds-advanced-table__th-filter-menu--active'}}"
+  @enableCollisionDetection={{true}}
+  @listPosition="bottom-right"
+  @height="210px"
+  {{this._updateInternalFilters}}
+  ...attributes
+  as |D|
+>
+  <D.ToggleIcon @icon="filter" @text="Filter for {{@column.label}}" @hasChevron={{false}} @size="small" />
+  {{#each @column.filterOptions as |option|}}
+    {{#if (eq @column.filterType "radio")}}
+      <D.Radio
+        @value={{option.value}}
+        checked={{(this._isChecked option.value)}}
+        data-test-filter-option-key={{option.value}}
+        {{on "change" this.onFilter}}
+      >
+        {{option.label}}
+      </D.Radio>
+    {{else}}
+      <D.Checkbox
+        @value={{option.value}}
+        checked={{(this._isChecked option.value)}}
+        data-test-filter-option-key={{option.value}}
+        {{on "change" this.onFilter}}
+      >
+        {{option.label}}
+      </D.Checkbox>
+    {{/if}}
+  {{/each}}
+  {{#unless @isLiveFilter}}
+    <D.Footer @hasDivider={{true}}>
+      <Hds::ButtonSet>
+        <Hds::Button @text="Apply filters" @isFullWidth={{true}} @size="small" {{on "click" this.onApply}} />
+        <Hds::Button @text="Clear" @color="secondary" @size="small" {{on "click" this.onClear}} />
+      </Hds::ButtonSet>
+    </D.Footer>
+  {{/unless}}
+</Hds::Dropdown>

--- a/packages/components/src/components/hds/advanced-table/th-filter-menu.ts
+++ b/packages/components/src/components/hds/advanced-table/th-filter-menu.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
+import type HdsAdvancedTableColumn from './models/column.ts';
+import type { HdsDropdownSignature } from '../dropdown/index.ts';
+import type {
+  HdsAdvancedTableFilter,
+  HdsAdvancedTableFilters,
+} from './types.ts';
+
+export interface HdsAdvancedTableThFilterMenuSignature {
+  Args: {
+    column: HdsAdvancedTableColumn;
+    filters?: HdsAdvancedTableFilters;
+    isLiveFilter?: boolean;
+    onFilter?: (
+      key: string,
+      keyFilter?: HdsAdvancedTableFilter | HdsAdvancedTableFilter[]
+    ) => void;
+  };
+  Element: HdsDropdownSignature['Element'];
+}
+
+export default class HdsAdvancedTableThFilterMenu extends Component<HdsAdvancedTableThFilterMenuSignature> {
+  @tracked internalFilters:
+    | HdsAdvancedTableFilter[]
+    | HdsAdvancedTableFilter
+    | undefined = [];
+  @tracked hasActiveFilters: boolean = this.keyFilter !== undefined;
+
+  private _updateInternalFilters = modifier(() => {
+    this.internalFilters = this.keyFilter;
+  });
+
+  get keyFilter():
+    | HdsAdvancedTableFilter[]
+    | HdsAdvancedTableFilter
+    | undefined {
+    const { filters, column } = this.args;
+
+    if (!filters || !column) {
+      return undefined;
+    }
+    return filters[column.key];
+  }
+
+  @action
+  onFilter(event: Event): void {
+    const addFilter = (value: unknown): HdsAdvancedTableFilter[] => {
+      const newFilter = {
+        text: value as string,
+        value: value,
+      };
+      if (
+        Array.isArray(this.internalFilters) &&
+        input.classList.contains('hds-form-checkbox')
+      ) {
+        this.internalFilters.push(newFilter);
+        return this.internalFilters;
+      } else {
+        return [newFilter];
+      }
+    };
+
+    const removeFilter = (value: string): HdsAdvancedTableFilter[] => {
+      const newFilter = [] as HdsAdvancedTableFilter[];
+      if (Array.isArray(this.internalFilters)) {
+        this.internalFilters.forEach((filter) => {
+          if (filter.value != value) {
+            newFilter.push(filter);
+          }
+        });
+      }
+      return newFilter;
+    };
+
+    const input = event.target as HTMLInputElement;
+
+    let newFilter = [] as HdsAdvancedTableFilter[];
+
+    if (input.checked) {
+      newFilter = addFilter(input.value);
+    } else {
+      newFilter = removeFilter(input.value);
+    }
+
+    this.internalFilters = newFilter;
+
+    if (this.args.isLiveFilter) {
+      const { onFilter, column } = this.args;
+      if (onFilter && typeof onFilter === 'function') {
+        if (newFilter.length === 0) {
+          onFilter(column?.key, undefined);
+        } else {
+          onFilter(column?.key, newFilter);
+        }
+        this.hasActiveFilters = newFilter != undefined && newFilter.length > 0;
+      }
+    }
+  }
+
+  @action
+  onApply(): void {
+    const { onFilter, column } = this.args;
+    if (onFilter && typeof onFilter === 'function') {
+      onFilter(column?.key, this.internalFilters);
+    }
+  }
+
+  @action
+  onClear(): void {
+    this.internalFilters = [];
+
+    const { onFilter, column } = this.args;
+    if (onFilter && typeof onFilter === 'function') {
+      onFilter(column?.key, this.internalFilters);
+    }
+  }
+
+  private _isChecked = (value: string): boolean => {
+    if (Array.isArray(this.internalFilters)) {
+      return this.internalFilters.some((filter) => filter.value === value);
+    } else if (this.internalFilters && value) {
+      return this.internalFilters.value === value;
+    }
+    return false;
+  };
+}

--- a/packages/components/src/components/hds/advanced-table/th-sort.hbs
+++ b/packages/components/src/components/hds/advanced-table/th-sort.hbs
@@ -34,6 +34,9 @@
       {{#if @tooltip}}
         <Hds::AdvancedTable::ThButtonTooltip @tooltip={{@tooltip}} @labelId={{this._labelId}} />
       {{/if}}
+      {{#if (gt this.numFilters 0)}}
+        <Hds::BadgeCount @text={{this.numFilters}} @type="outlined" @size="small" />
+      {{/if}}
     </div>
 
     <Hds::Layout::Flex class="hds-advanced-table__th-actions" @align="center" @gap="8">
@@ -44,6 +47,15 @@
       />
 
       {{#if @column}}
+        {{#if @column.filterOptions}}
+          <Hds::AdvancedTable::ThFilterMenu
+            @column={{@column}}
+            @filters={{@filters}}
+            @isLiveFilter={{@isLiveFilter}}
+            @onFilter={{@onFilter}}
+          />
+        {{/if}}
+
         <Hds::AdvancedTable::ThContextMenu
           @column={{@column}}
           @hasReorderableColumns={{@hasReorderableColumns}}

--- a/packages/components/src/components/hds/advanced-table/th-sort.ts
+++ b/packages/components/src/components/hds/advanced-table/th-sort.ts
@@ -22,6 +22,8 @@ import type {
   HdsAdvancedTableThSortOrder,
   HdsAdvancedTableThSortOrderLabels,
   HdsAdvancedTableColumnReorderSide,
+  HdsAdvancedTableFilter,
+  HdsAdvancedTableFilters,
 } from './types.ts';
 import type { HdsAdvancedTableThReorderHandleSignature } from './th-reorder-handle.ts';
 import type { HdsAdvancedTableThButtonSortSignature } from './th-button-sort.ts';
@@ -51,6 +53,8 @@ export interface HdsAdvancedTableThSortSignature {
     tableHeight?: number;
     isStickyColumn?: boolean;
     isStickyColumnPinned?: boolean;
+    filters?: HdsAdvancedTableFilters;
+    isLiveFilter?: boolean;
     onColumnResize?: HdsAdvancedTableSignature['Args']['onColumnResize'];
     onPinFirstColumn?: () => void;
     onReorderDragEnd?: () => void;
@@ -58,6 +62,10 @@ export interface HdsAdvancedTableThSortSignature {
     onReorderDrop?: (
       column: HdsAdvancedTableColumn,
       side: HdsAdvancedTableColumnReorderSide
+    ) => void;
+    onFilter?: (
+      key: string,
+      keyFilter?: HdsAdvancedTableFilter[] | HdsAdvancedTableFilter
     ) => void;
   };
   Blocks: {
@@ -111,6 +119,22 @@ export default class HdsAdvancedTableThSort extends Component<HdsAdvancedTableTh
       ALIGNMENTS.includes(align)
     );
     return align;
+  }
+
+  get numFilters(): number {
+    const { filters, column } = this.args;
+
+    if (!filters || !column) {
+      return 0;
+    }
+
+    const filterValue = filters[column.key];
+
+    if (Array.isArray(filterValue)) {
+      return filterValue.length;
+    }
+
+    return 0;
   }
 
   get classNames(): string {

--- a/packages/components/src/components/hds/advanced-table/types.ts
+++ b/packages/components/src/components/hds/advanced-table/types.ts
@@ -74,6 +74,27 @@ export type HdsAdvancedTableSelectableRow = {
 
 export type HdsAdvancedTableExpandState = boolean;
 
+export type HdsAdvancedTableFilterOption = {
+  value: string;
+  label: string;
+};
+
+export interface HdsAdvancedTableFilter {
+  text: string;
+  value: unknown;
+}
+
+export interface HdsAdvancedTableFilters {
+  [name: string]: HdsAdvancedTableFilter | HdsAdvancedTableFilter[] | undefined;
+}
+
+export enum HdsAdvancedTableFilterTypeValues {
+  Checkbox = 'checkbox',
+  Radio = 'radio',
+}
+
+export type HdsAdvancedTableFilterType = `${HdsAdvancedTableFilterTypeValues}`;
+
 interface BaseHdsAdvancedTableColumn {
   align?: HdsAdvancedTableHorizontalAlignment;
   isVisuallyHidden?: boolean;
@@ -83,6 +104,8 @@ interface BaseHdsAdvancedTableColumn {
   width?: string;
   minWidth?: `${number}px`;
   maxWidth?: `${number}px`;
+  filterOptions?: HdsAdvancedTableFilterOption[];
+  filterType?: HdsAdvancedTableFilterType;
 }
 
 interface SortableHdsAdvancedTableColumn extends BaseHdsAdvancedTableColumn {

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -415,7 +415,8 @@ $hds-advanced-table-drag-preview-background-color: rgba(204, 227, 254, 30%);
   }
 }
 
-.hds-advanced-table__th-context-menu .hds-dropdown-toggle-icon {
+.hds-advanced-table__th-context-menu .hds-dropdown-toggle-icon,
+.hds-advanced-table__th-filter-menu .hds-dropdown-toggle-icon {
   width: $hds-advanced-table-button-size;
   height: $hds-advanced-table-button-size;
   margin: -2px 0;
@@ -502,6 +503,25 @@ $hds-advanced-table-drag-preview-background-color: rgba(204, 227, 254, 30%);
 
 .hds-advanced-table__th-button--expand {
   align-self: flex-start;
+}
+
+.hds-advanced-table__th-filter-menu--active {
+  position: relative;
+
+  &::before {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    width: 6px;
+    height: 6px;
+    background-color: var(--token-color-foreground-action);
+    border-radius: 50%;
+    content: "";
+  }
+}
+
+.hds-advanced-table__clear-filters-button {
+  margin-bottom: 16px;
 }
 
 // ----------------------------------------------------------------

--- a/packages/components/src/template-registry.ts
+++ b/packages/components/src/template-registry.ts
@@ -16,6 +16,7 @@ import type HdsAdvancedTableThButtonTooltipComponent from './components/hds/adva
 import type HdsAdvancedTableThContextMenu from './components/hds/advanced-table/th-context-menu';
 import type HdsAdvancedTableThReorderDropTarget from './components/hds/advanced-table/th-reorder-drop-target';
 import type HdsAdvancedTableThReorderHandle from './components/hds/advanced-table/th-reorder-handle';
+import type HdsAdvancedTableThFilterMenu from './components/hds/advanced-table/th-filter-menu';
 import type HdsAdvancedTableThResizeHandle from './components/hds/advanced-table/th-resize-handle';
 import type HdsAdvancedTableThSortComponent from './components/hds/advanced-table/th-sort';
 import type HdsAdvancedTableThSelectableComponent from './components/hds/advanced-table/th-selectable';
@@ -285,6 +286,8 @@ export default interface HdsComponentsRegistry {
   'hds/advanced-table/th-reorder-drop-target': typeof HdsAdvancedTableThReorderDropTarget;
   'Hds::AdvancedTable::ThReorderHandle': typeof HdsAdvancedTableThReorderHandle;
   'hds/advanced-table/th-reorder-handle': typeof HdsAdvancedTableThReorderHandle;
+  'Hds::AdvancedTable::ThFilterMenu': typeof HdsAdvancedTableThFilterMenu;
+  'hds/advanced-table/th-filter-menu': typeof HdsAdvancedTableThFilterMenu;
   'Hds::AdvancedTable::ThResizeHandle': typeof HdsAdvancedTableThResizeHandle;
   'hds/advanced-table/th-resize-handle': typeof HdsAdvancedTableThResizeHandle;
   'hds/advanced-table/th-button-tooltip': typeof HdsAdvancedTableThButtonTooltipComponent;

--- a/showcase/app/components/mock/app/main/generic-advanced-table.gts
+++ b/showcase/app/components/mock/app/main/generic-advanced-table.gts
@@ -4,8 +4,11 @@
  */
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { deepTracked } from 'ember-deep-tracked';
 import { get } from '@ember/helper';
+import { on } from '@ember/modifier';
+import style from 'ember-style-modifier/modifiers/style';
 
 // HDS components
 import {
@@ -13,6 +16,7 @@ import {
   HdsLinkInline,
   HdsBadge,
   HdsBadgeColorValues,
+  HdsFormToggleField,
   type HdsAdvancedTableOnSelectionChangeSignature,
 } from '@hashicorp/design-system-components/components';
 
@@ -21,93 +25,6 @@ import type { HdsAdvancedTableSignature } from '@hashicorp/design-system-compone
 export interface MockAppMainGenericAdvancedTableSignature {
   Element: HTMLDivElement;
 }
-
-const SAMPLE_COLUMNS = [
-  {
-    isSortable: true,
-    label: 'Name',
-    key: 'name',
-    width: 'max-content',
-  },
-  {
-    label: 'Project name',
-    key: 'project-name',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Current run ID',
-    key: 'current-run-id',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Run status',
-    key: 'run-status',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Current run applied',
-    key: 'current-run-applied',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'VCS repo',
-    key: 'vcs-repo',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Module count',
-    key: 'module-count',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Modules',
-    key: 'modules',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Provider count',
-    key: 'provider-count',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Providers',
-    key: 'providers',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Terraform version',
-    key: 'terraform-version',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'State terraform version',
-    key: 'state-terraform-version',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Created',
-    key: 'created',
-    isSortable: true,
-    width: 'max-content',
-  },
-  {
-    label: 'Updated',
-    key: 'updated',
-    isSortable: true,
-    width: 'max-content',
-  },
-];
 
 const SAMPLE_MODEL = [
   {
@@ -151,7 +68,7 @@ const SAMPLE_MODEL = [
     'run-status': 'applied',
     'run-status-color': HdsBadgeColorValues.Success,
     'current-run-applied': 'Mar 06, 2025 09:08:14 am',
-    'vcs-repo': 'example/sClKKTBbyCIzf@d8NxH2',
+    'vcs-repo': 'example/a))!hzfpKcBl0',
     'module-count': 31,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 42,
@@ -168,7 +85,7 @@ const SAMPLE_MODEL = [
     'run-status': 'planned',
     'run-status-color': HdsBadgeColorValues.Warning,
     'current-run-applied': 'Mar 06, 2025 09:07:14 am',
-    'vcs-repo': 'example/y0^(Nm*63',
+    'vcs-repo': 'example/a))!hzfpKcBl0',
     'module-count': 58,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 140,
@@ -185,7 +102,7 @@ const SAMPLE_MODEL = [
     'run-status': 'applied',
     'run-status-color': HdsBadgeColorValues.Success,
     'current-run-applied': 'Mar 06, 2025 09:06:14 am',
-    'vcs-repo': 'example/ljPWe[4',
+    'vcs-repo': 'example/a))!hzfpKcBl0',
     'module-count': 32,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 50,
@@ -202,7 +119,7 @@ const SAMPLE_MODEL = [
     'run-status': 'errored',
     'run-status-color': HdsBadgeColorValues.Critical,
     'current-run-applied': 'Mar 06, 2025 09:05:14 am',
-    'vcs-repo': 'example/E*fcS4mn@BoDgZu0O5',
+    'vcs-repo': 'example/a))!hzfpKcBl0',
     'module-count': 94,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 113,
@@ -236,13 +153,13 @@ const SAMPLE_MODEL = [
     'run-status': 'errored',
     'run-status-color': HdsBadgeColorValues.Critical,
     'current-run-applied': 'Mar 06, 2025 09:03:14 am',
-    'vcs-repo': 'example/(DCFjSEKcBuU44J8AB87',
+    'vcs-repo': 'example/&j[RmmtjpQX6',
     'module-count': 114,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 107,
     providers: 'susnup-da-zuw',
     'terraform-version': '0.14.0',
-    'state-terraform-version': '0.15.0',
+    'state-terraform-version': '0.16.0',
     created: 'Feb 27 2025',
     updated: 'Feb 27 2025',
   },
@@ -253,13 +170,13 @@ const SAMPLE_MODEL = [
     'run-status': 'planned',
     'run-status-color': HdsBadgeColorValues.Warning,
     'current-run-applied': 'Mar 06, 2025 09:02:14 am',
-    'vcs-repo': 'example/9YURY8',
+    'vcs-repo': 'example/&j[RmmtjpQX6',
     'module-count': 106,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 185,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
-    'state-terraform-version': '0.15.0',
+    'terraform-version': '0.14.5',
+    'state-terraform-version': '0.16.0',
     created: 'Feb 26 2025',
     updated: 'Feb 26 2025',
   },
@@ -270,13 +187,13 @@ const SAMPLE_MODEL = [
     'run-status': 'errored',
     'run-status-color': HdsBadgeColorValues.Critical,
     'current-run-applied': 'Mar 06, 2025 09:01:14 am',
-    'vcs-repo': 'example/9YURY8',
+    'vcs-repo': 'example/&j[RmmtjpQX6',
     'module-count': 124,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 175,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
-    'state-terraform-version': '0.15.0',
+    'terraform-version': '0.14.5',
+    'state-terraform-version': '0.16.0',
     created: 'Feb 25 2025',
     updated: 'Feb 25 2025',
   },
@@ -287,13 +204,13 @@ const SAMPLE_MODEL = [
     'run-status': 'applied',
     'run-status-color': HdsBadgeColorValues.Success,
     'current-run-applied': 'Mar 06, 2025 09:00:14 am',
-    'vcs-repo': 'example/d2s3B46I10',
+    'vcs-repo': 'example/&j[RmmtjpQX6',
     'module-count': 70,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 168,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
-    'state-terraform-version': '0.15.0',
+    'terraform-version': '0.14.5',
+    'state-terraform-version': '0.16.0',
     created: 'Feb 24 2025',
     updated: 'Feb 24 2025',
   },
@@ -309,8 +226,8 @@ const SAMPLE_MODEL = [
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 168,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
-    'state-terraform-version': '0.15.0',
+    'terraform-version': '0.14.5',
+    'state-terraform-version': '0.16.0',
     created: 'Feb 23 2025',
     updated: 'Feb 23 2025',
   },
@@ -321,13 +238,13 @@ const SAMPLE_MODEL = [
     'run-status': 'errored',
     'run-status-color': HdsBadgeColorValues.Critical,
     'current-run-applied': 'Mar 06, 2025 08:59:14 am',
-    'vcs-repo': 'example/v@C6&hBTou11',
+    'vcs-repo': 'example/d2s3B46I10',
     'module-count': 106,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 61,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
-    'state-terraform-version': '0.15.0',
+    'terraform-version': '0.14.5',
+    'state-terraform-version': '0.16.0',
     created: 'Feb 22 2025',
     updated: 'Feb 22 2025',
   },
@@ -338,12 +255,12 @@ const SAMPLE_MODEL = [
     'run-status': 'applied',
     'run-status-color': HdsBadgeColorValues.Success,
     'current-run-applied': 'Mar 06, 2025 08:58:14 am',
-    'vcs-repo': 'example/@t23^12',
+    'vcs-repo': 'example/d2s3B46I10',
     'module-count': 14,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 143,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
+    'terraform-version': '0.14.5',
     'state-terraform-version': '0.15.0',
     created: 'Feb 21 2025',
     updated: 'Feb 21 2025',
@@ -355,12 +272,12 @@ const SAMPLE_MODEL = [
     'run-status': 'planned',
     'run-status-color': HdsBadgeColorValues.Warning,
     'current-run-applied': 'Mar 06, 2025 08:58:14 am',
-    'vcs-repo': 'example/@t23^12',
+    'vcs-repo': 'example/d2s3B46I10',
     'module-count': 14,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 143,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
+    'terraform-version': '0.14.5',
     'state-terraform-version': '0.15.0',
     created: 'Feb 20 2025',
     updated: 'Feb 20 2025',
@@ -377,7 +294,7 @@ const SAMPLE_MODEL = [
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 98,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
+    'terraform-version': '0.14.5',
     'state-terraform-version': '0.15.0',
     created: 'Feb 19 2025',
     updated: 'Feb 19 2025',
@@ -394,7 +311,7 @@ const SAMPLE_MODEL = [
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 170,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
+    'terraform-version': '0.14.5',
     'state-terraform-version': '0.15.0',
     created: 'Feb 18 2025',
     updated: 'Feb 18 2025',
@@ -406,12 +323,12 @@ const SAMPLE_MODEL = [
     'run-status': 'planned',
     'run-status-color': HdsBadgeColorValues.Warning,
     'current-run-applied': 'Mar 06, 2025 08:57:14 am',
-    'vcs-repo': 'example/t*vN3@*BxJnG116',
+    'vcs-repo': 'example/d2s3B46I10',
     'module-count': 139,
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 170,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
+    'terraform-version': '0.14.5',
     'state-terraform-version': '0.15.0',
     created: 'Feb 17 2025',
     updated: 'Feb 17 2025',
@@ -428,7 +345,7 @@ const SAMPLE_MODEL = [
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 83,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
+    'terraform-version': '0.14.5',
     'state-terraform-version': '0.15.0',
     created: 'Feb 16 2025',
     updated: 'Feb 16 2025',
@@ -445,7 +362,7 @@ const SAMPLE_MODEL = [
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 152,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
+    'terraform-version': '0.14.5',
     'state-terraform-version': '0.15.0',
     created: 'Feb 15 2025',
     updated: 'Feb 15 2025',
@@ -462,10 +379,126 @@ const SAMPLE_MODEL = [
     modules: 'wad-bedzeaje-rogmejca',
     'provider-count': 11,
     providers: 'susnup-da-zuw',
-    'terraform-version': '0.14.0',
+    'terraform-version': '0.14.5',
     'state-terraform-version': '0.15.0',
     created: 'Feb 14 2025',
     updated: 'Feb 14 2025',
+  },
+];
+
+
+const SAMPLE_MODEL_VALUES = {
+  'project-name': Array.from(
+    new Set(SAMPLE_MODEL.map((item) => item['project-name'])),
+  ).map((value) => ({ value, label: value })),
+  'run-status': Array.from(
+    new Set(SAMPLE_MODEL.map((item) => item['run-status'])),
+  ).map((value) => ({ value, label: value })),
+  'vcs-repo': Array.from(
+    new Set(SAMPLE_MODEL.map((item) => item['vcs-repo'])),
+  ).map((value) => ({ value, label: value })),
+  'terraform-version': Array.from(
+    new Set(SAMPLE_MODEL.map((item) => item['terraform-version'])),
+  ).map((value) => ({ value, label: value })),
+  'state-terraform-version': Array.from(
+    new Set(SAMPLE_MODEL.map((item) => item['state-terraform-version'])),
+  ).map((value) => ({ value, label: value })),
+};
+
+const SAMPLE_COLUMNS = [
+  {
+    isSortable: true,
+    label: 'Name',
+    key: 'name',
+    width: 'max-content',
+  },
+  {
+    label: 'Project name',
+    key: 'project-name',
+    isSortable: true,
+    width: 'max-content',
+    filterOptions: SAMPLE_MODEL_VALUES['project-name'],
+    filterType: 'checkbox',
+  },
+  {
+    label: 'Current run ID',
+    key: 'current-run-id',
+    isSortable: true,
+    width: 'max-content',
+  },
+  {
+    label: 'Run status',
+    key: 'run-status',
+    isSortable: true,
+    width: 'max-content',
+    filterOptions: SAMPLE_MODEL_VALUES['run-status'],
+    filterType: 'checkbox',
+  },
+  {
+    label: 'Current run applied',
+    key: 'current-run-applied',
+    isSortable: true,
+    width: 'max-content',
+  },
+  {
+    label: 'VCS repo',
+    key: 'vcs-repo',
+    isSortable: true,
+    width: 'max-content',
+    filterOptions: SAMPLE_MODEL_VALUES['vcs-repo'],
+    filterType: 'checkbox',
+  },
+  {
+    label: 'Module count',
+    key: 'module-count',
+    isSortable: true,
+    width: 'max-content',
+  },
+  {
+    label: 'Modules',
+    key: 'modules',
+    isSortable: true,
+    width: 'max-content',
+  },
+  {
+    label: 'Provider count',
+    key: 'provider-count',
+    isSortable: true,
+    width: 'max-content',
+  },
+  {
+    label: 'Providers',
+    key: 'providers',
+    isSortable: true,
+    width: 'max-content',
+  },
+  {
+    label: 'Terraform version',
+    key: 'terraform-version',
+    isSortable: true,
+    width: 'max-content',
+    filterOptions: SAMPLE_MODEL_VALUES['terraform-version'],
+    filterType: 'radio',
+  },
+  {
+    label: 'State terraform version',
+    key: 'state-terraform-version',
+    isSortable: true,
+    width: 'max-content',
+    filterOptions: SAMPLE_MODEL_VALUES['state-terraform-version'],
+    filterType: 'radio',
+  },
+  {
+    label: 'Created',
+    key: 'created',
+    isSortable: true,
+    width: 'max-content',
+  },
+  {
+    label: 'Updated',
+    key: 'updated',
+    isSortable: true,
+    width: 'max-content',
   },
 ];
 
@@ -499,6 +532,8 @@ export default class MockAppMainGenericAdvancedTable extends Component<MockAppMa
   @deepTracked demoModel: HdsAdvancedTableSignature['Args']['model'] = [
     ...SAMPLE_MODEL,
   ];
+  @deepTracked filters: HdsAdvancedTableSignature['Args']['filters'] = {};
+  @tracked isLiveFilter = false;
 
   @action onSelectionChange({
     selectionKey,
@@ -519,15 +554,70 @@ export default class MockAppMainGenericAdvancedTable extends Component<MockAppMa
     }
   }
 
+  valuesFromFilter = (filters: HdsAdvancedTableSignature['Args']['filters'], name: string) => {
+    const filter = filters[name];
+    if (!filter) return;
+
+    if (Array.isArray(filter)) {
+      if (filter.length === 1) return filter[0]?.value;
+      return filter.map((f: HdsAdvancedTableSignature['Args']['filters'][]) => f.value);
+    }
+    return filter.value;
+  };
+
+  @action
+  onFilter(filters: HdsAdvancedTableSignature['Args']['filters']) {
+    this.filters = filters;
+  }
+
+  get demoModelFilteredData() {
+    const filterItem = (item: HdsAdvancedTableSignature['Args']['filters']): boolean => {
+      if (Object.keys(this.filters).length === 0) return true;
+      let match = true;
+      Object.keys(this.filters).forEach((key) => {
+        const keyFilters = this.valuesFromFilter(this.filters, key);
+        if (Array.isArray(keyFilters)) {
+          if (!keyFilters.includes(item[key])) {
+            match = false;
+          }
+        } else if (item[key] !== keyFilters) {
+          match = false;
+        }
+      });
+      return match;
+    };
+
+    return this.demoModel.filter(filterItem);
+  }
+
+  @action
+  onLiveFilterToggle(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.isLiveFilter = target.checked;
+  }
+
   <template>
+    <div class="filters__toggle" {{style marginBottom="16px"}}>
+      <HdsFormToggleField
+        name="demo-live-filtering"
+        {{on "click" this.onLiveFilterToggle}}
+        checked={{this.isLiveFilter}}
+        as |F|
+      >
+        <F.Label>Live filtering</F.Label>
+      </HdsFormToggleField>
+    </div>
     <HdsAdvancedTable
       @columns={{this.demoColumns}}
-      @model={{this.demoModel}}
+      @model={{this.demoModelFilteredData}}
       @maxHeight="600px"
       @isSelectable={{true}}
       @isStriped={{true}}
       @onSelectionChange={{this.onSelectionChange}}
       @hasStickyFirstColumn={{true}}
+      @filters={{this.filters}}
+      @isLiveFilter={{this.isLiveFilter}}
+      @onFilter={{this.onFilter}}
     >
       <:body as |B|>
         {{! @glint-expect-error }}


### PR DESCRIPTION
### :pushpin: Summary

This spike explores implementing filtering in the AdvancedTable through an in-column approach. 

[Preview](https://hds-showcase-git-dchyun-spike-adv-table-in-col-8c31b8-hashicorp.vercel.app/layouts/app-frame/frameless/demo-full-app-frame-with-advanced-table)

### :hammer_and_wrench: Detailed description

#### Component API

There are two parts to the component API changes made here in the AdvancedTable. 

The `filters` argument sets the filters that are to be applied, and is what is used by consumers to filter their data. It takes the following format
```
{
  'column-key': [
    { value: 'filter1', label: 'Filter 1' }
  ]
}
```

The second part is how the consumer passes in what columns are filterable, and what are the values available for those filters that users can select.

Inside the column model there are new arguments `filterOptions` and `filterType`. `filterOptions` specifies what options are available for filtering, and `filterType` specifies if the options should be a checkbox group or radio group.

Example:
```
columns = [
  {
    label: 'Project name',
    key: 'project-name',
    filterOptions: [
      { value: 'filter1', label: 'Filter 1' },
      { value: 'filter2', label: 'Filter 2' },
      { value: 'filter3', label: 'Filter 3' },
    ],
    filterType: 'checkbox',
  },
]
```

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4380](https://hashicorp.atlassian.net/browse/HDS-4380)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-4380]: https://hashicorp.atlassian.net/browse/HDS-4380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ