### PR TITLE
Adding CSAT survey banner to website

### DIFF
--- a/website/app/components/doc/page/banner.hbs
+++ b/website/app/components/doc/page/banner.hbs
@@ -7,7 +7,7 @@
   <div class="doc-page-banner">
     <Hds::Icon class="doc-page-banner__icon" @name="message-circle-fill" @size={{24}} />
     <p class="doc-page-banner__text doc-text-body">Got a minute? We’d like your feedback!
-      <a href="https://forms.gle/N5ibgGF3zXFFm1Lj9" target="_blank" rel="noopener noreferrer">Take the survey</a></p>
+      <a href="https://forms.gle/TtEa9AwtoHH9VCJG8" target="_blank" rel="noopener noreferrer">Take the survey</a></p>
     <button type="button" class="doc-page-banner__close" aria-label="Close banner" {{on "click" this.onClose}}>
       <Hds::Icon @name="x" @size={{16}} />
     </button>

--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -14,7 +14,7 @@
   @routeChangeValidator={{this.transitionValidator}}
 />
 {{! uncomment this to turn the survey banner back on, but ensure survey link has been updated as well }}
-{{! <Doc::Page::Banner /> }}
+<Doc::Page::Banner />
 <Doc::Page::Sidebar
   {{! `this.model.toc` comes from `routes/application.js` }}
   @toc={{this.model.toc}}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will add a banner to the website for the CSAT survey that was sent out on Sept 10, 2025. This banner will be removed after the survey ends on Sept 24, 2025.

**Preview link:** https://hds-website-git-hl-add-survey-banner-hashicorp.vercel.app/

### :camera_flash: Screenshots

**Before**
<img width="1362" height="1071" alt="Screenshot 2025-09-10 at 11 46 13 AM" src="https://github.com/user-attachments/assets/f0559c1b-0067-4386-aad9-45fa1623181e" />

**After**
<img width="1359" height="1079" alt="Screenshot 2025-09-10 at 11 46 42 AM" src="https://github.com/user-attachments/assets/ac308b2c-0c52-4bff-bb15-c287f29881ce" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5478](https://hashicorp.atlassian.net/browse/HDS-5478)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

[HDS-5478]: https://hashicorp.atlassian.net/browse/HDS-5478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ