### PR TITLE
`AppSideNav` - manually add missed changelog entry

### DIFF
--- a/website/docs/components/app-side-nav/partials/version-history/version-history.md
+++ b/website/docs/components/app-side-nav/partials/version-history/version-history.md
@@ -2,8 +2,9 @@
 
 Translated template strings
 
-
 ## 4.21.1
+
+Fixed issue causing the focus ring of the first and last items within the Panel to be cut off
 
 Removed extra transparent border and background when rendered as a `<button>` element
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR manually adds a changelog entry that had been skipped over dues to a typo in the surrounding comment tag enclosing the entry.

**Preview**: https://hds-website-git-hds-fix-app-side-nav-change-log-hashicorp.vercel.app/components/app-side-nav?tab=version%20history

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?
-->

### :camera_flash: Screenshots

_Added text is highlighted:_

<img width="645" height="538" alt="image" src="https://github.com/user-attachments/assets/df7a4406-149e-4b99-8756-96ce0745eb0e" />

### :link: External links

* PR w/ missed changelog: https://github.com/hashicorp/design-system/pull/3045/files
* Related Slack thread: https://hashicorp.slack.com/archives/C08HK4CQ1U6/p1757535357067529

***

### :eyes: Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>