### PR TITLE
Advanced Table: Fix link to Figma

### DIFF
--- a/website/docs/components/table/advanced-table/index.md
+++ b/website/docs/components/table/advanced-table/index.md
@@ -4,7 +4,7 @@ description: 'Used to display complex, structured tabular data with advanced fea
 caption: 'Used to display complex, structured tabular data with advanced features.'
 links:
   figma: >-
-    https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?node-id=67216-35163&t=w8xQlWxzH7bwXLe2-1
+    https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?node-id=77513-16596&t=emmCBTTPFMW4gPx7-4
   github: >-
     https://github.com/hashicorp/design-system/tree/main/packages/components/src/components/hds/advanced-table
 related:


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes the Figma link for the Advanced Table. The original link was pointing to the Table stickersheet. It's been updated to navigate to the Advanced Table stickersheet.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5107](https://hashicorp.atlassian.net/browse/HDS-5107)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

[HDS-5107]: https://hashicorp.atlassian.net/browse/HDS-5107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ