### PR TITLE
Showcase: Update copilot instructions to follow gts structure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,7 +136,7 @@ For a given component, the following items should be shown on its showcase page:
 For each HDS component, follow the following structure for showcase component files.
 - `components/page-components/<component-name>/index.gts` - Index file for the component's showcase page.
 - `components/page-components/<component-name>/code-fragments/<code-fragment-name>.gts` - Reusable examples of the main HDS component. Used multiple tiomes within the component's page.
-- `components/page-components/<component-name>/nav/sub-sections/<sub-section-name>.gts` - Sub-sections of the main component's showcase page. They should contains examples of the main HDS component's attributes, properties, interactive states, and other use cases. Each major section of the showcase should be broken into its own sub-section component. What constitutes a section can be flexible, but generally its each `ShwTextH2` plus the content below it.
+- `components/page-components/<component-name>/sub-sections/<sub-section-name>.gts` - Sub-sections of the main component's showcase page. They should contains examples of the main HDS component's attributes, properties, interactive states, and other use cases. Each major section of the showcase should be broken into its own sub-section component. What constitutes a section can be flexible, but generally its each `ShwTextH2` plus the content below it.
 
 #### Best practices
 - Use arrow functions instead of `@action` for event handlers.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the repo's Copilot instructions to reflect the changes to the showcase structure and format for components using gts.

Note: These updates were based off of the instructions for [converting showcase files to gts](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/4220158068/How+to+convert+showcase+pages+to+gts+format), and the [showcase infrastructure](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3249307671/Showcase+infrastructure) documentation.

***

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>