### PR TITLE
`ApplicationState` - Remove center alignment rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- TEMPORARY ADDITION SO BRANCH DIVERGES FROM MAIN -->
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/hashicorp/design-system/assets/788096/5d6969b7-f8b4-4ad3-9ece-b16b4527522e" width="300">
   <source media="(prefers-color-scheme: light)" srcset="https://github.com/hashicorp/design-system/assets/788096/8e278094-427f-40cc-912f-9ccd3a0ff879" width="300">

--- a/packages/components/src/styles/components/application-state.scss
+++ b/packages/components/src/styles/components/application-state.scss
@@ -14,7 +14,6 @@ $hds-application-state-content-max-width: 480px;
   flex-direction: column;
   align-items: start;
   width: fit-content;
-  margin: 0 auto; // this will center the component in the parent container
 
   &.hds-application-state--align-center {
     align-items: center;


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR removed a style rule that center-aligns the `ApplicationState` component.

### :hammer_and_wrench: Detailed description

The current implementation of the `ApplicationState` component has a `margin: 0 auto;` rule on the root element (`.hds-application-state`). This forces a center alignment of the component, which consumers need to override.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-3584](https://hashicorp.atlassian.net/browse/HDS-3584)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>