### PR TITLE
Remove unneeded sass-related dependencies

### DIFF
--- a/.changeset/full-showers-kiss.md
+++ b/.changeset/full-showers-kiss.md
@@ -1,0 +1,6 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+- Removed `sass` and `ember-cli-sass` as dependencies
+- Added `sass` as a dev-dependency

--- a/.changeset/full-showers-kiss.md
+++ b/.changeset/full-showers-kiss.md
@@ -2,5 +2,4 @@
 "@hashicorp/design-system-components": major
 ---
 
-- Removed `sass` and `ember-cli-sass` as dependencies
-- Added `sass` as a dev-dependency
+- Removed `sass` and `ember-cli-sass` dependencies. Consumers using `sass` in their projects should make sure it's added as a direct dependency to their project.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,6 @@
     "codemirror-lang-hcl": "^0.0.0-beta.2",
     "decorator-transforms": "^2.3.0",
     "ember-a11y-refocus": "^4.1.4",
-    "ember-cli-sass": "^11.0.1",
     "ember-concurrency": "^4.0.4",
     "ember-element-helper": "^0.8.6",
     "ember-focus-trap": "^1.1.1",
@@ -71,10 +70,9 @@
     "ember-truth-helpers": "^4.0.3",
     "luxon": "^3.4.2",
     "prismjs": "^1.30.0",
-    "sass": "^1.83.0",
-    "tracked-built-ins": "^4.0.0",
     "tabbable": "^6.2.0",
-    "tippy.js": "^6.3.7"
+    "tippy.js": "^6.3.7",
+    "tracked-built-ins": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.27.1",
@@ -113,6 +111,7 @@
     "rollup": "^4.39.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-scss": "^4.0.1",
+    "sass": "^1.89.2",
     "stylelint": "^16.17.0",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard-scss": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,9 +141,6 @@ importers:
       ember-a11y-refocus:
         specifier: ^4.1.4
         version: 4.1.4
-      ember-cli-sass:
-        specifier: ^11.0.1
-        version: 11.0.1
       ember-concurrency:
         specifier: ^4.0.4
         version: 4.0.4(@babel/core@7.28.0)(@glint/template@1.5.2)
@@ -177,9 +174,6 @@ importers:
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
-      sass:
-        specifier: ^1.83.0
-        version: 1.89.2
       tabbable:
         specifier: ^6.2.0
         version: 6.2.0
@@ -298,6 +292,9 @@ importers:
       rollup-plugin-scss:
         specifier: ^4.0.1
         version: 4.0.1
+      sass:
+        specifier: ^1.89.2
+        version: 1.89.2
       stylelint:
         specifier: ^16.17.0
         version: 16.23.0(typescript@5.9.2)
@@ -14201,7 +14198,6 @@ snapshots:
       codemirror-lang-hcl: 0.0.0-beta.2
       decorator-transforms: 2.3.0(@babel/core@7.28.0)
       ember-a11y-refocus: 4.1.4
-      ember-cli-sass: 11.0.1
       ember-concurrency: 4.0.4(@babel/core@7.28.0)(@glint/template@1.5.2)
       ember-element-helper: 0.8.8
       ember-focus-trap: 1.1.1(ember-source@6.5.0(@glimmer/component@1.1.2(@babel/core@7.28.0))(rsvp@4.8.5))
@@ -14213,7 +14209,6 @@ snapshots:
       ember-truth-helpers: 4.0.3(ember-source@6.5.0(@glimmer/component@1.1.2(@babel/core@7.28.0))(rsvp@4.8.5))
       luxon: 3.7.1
       prismjs: 1.30.0
-      sass: 1.89.2
       tabbable: 6.2.0
       tippy.js: 6.3.7
       tracked-built-ins: 4.0.0(@babel/core@7.28.0)
@@ -14259,7 +14254,6 @@ snapshots:
       codemirror-lang-hcl: 0.0.0-beta.2
       decorator-transforms: 2.3.0(@babel/core@7.28.0)
       ember-a11y-refocus: 4.1.4
-      ember-cli-sass: 11.0.1
       ember-concurrency: 4.0.4(@babel/core@7.28.0)(@glint/template@1.5.2)
       ember-element-helper: 0.8.8
       ember-focus-trap: 1.1.1(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.28.0))(rsvp@4.8.5))
@@ -14271,7 +14265,6 @@ snapshots:
       ember-truth-helpers: 4.0.3(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.28.0))(rsvp@4.8.5))
       luxon: 3.7.1
       prismjs: 1.30.0
-      sass: 1.89.2
       tabbable: 6.2.0
       tippy.js: 6.3.7
       tracked-built-ins: 4.0.0(@babel/core@7.28.0)


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR:

- Removed `sass` and `ember-cli-sass` as dependencies of the components package
- Adds `sass` as a dev dependency.

### :hammer_and_wrench: Detailed description

`ember-cli-sass` and `sass` are no-longer required as dependencies for our components package. `sass` is required, but only as a dev dependency.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4518](https://hashicorp.atlassian.net/browse/HDS-4518)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-4518]: https://hashicorp.atlassian.net/browse/HDS-4518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ