### PR TITLE
StepperList: Type fix for STATUSES export

### DIFF
--- a/packages/components/src/components/hds/stepper/list/step.ts
+++ b/packages/components/src/components/hds/stepper/list/step.ts
@@ -21,7 +21,9 @@ import type {
 } from '../types.ts';
 
 export const DEFAULT_STATUS = HdsStepperStatusesValues.Incomplete;
-export const STATUSES: string[] = Object.values(HdsStepperStatusesValues);
+export const STATUSES: HdsStepperStatuses[] = Object.values(
+  HdsStepperStatusesValues
+);
 export const MAPPING_STATUS_TO_SR_ONLY_TEXT = HdsStepperStatusToSrOnlyText;
 
 export interface HdsStepperListStepSignature {

--- a/showcase/app/components/page-components/stepper/list/sub-sections/base-elements.gts
+++ b/showcase/app/components/page-components/stepper/list/sub-sections/base-elements.gts
@@ -14,7 +14,7 @@ import ShwTextH4 from 'showcase/components/shw/text/h4';
 
 import { HdsStepperList } from '@hashicorp/design-system-components/components';
 
-import { STATUSES } from '@hashicorp/design-system-components/components/hds/stepper/step/indicator';
+import { STATUSES } from '@hashicorp/design-system-components/components/hds/stepper/list/step';
 
 const SubSectionBaseElements: TemplateOnlyComponent = <template>
   <ShwTextH2>Base elements</ShwTextH2>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the type of the `STATUSES` export in the StepperList::Step to fix linting issues.

### :hammer_and_wrench: Detailed description

Originally this PR was to update an incorrect import path in the showcase pages of the StepperList. Upon fixing this path, however a new linting error was thrown in the showcase. 

<img width="1049" height="73" alt="Screenshot 2025-09-18 at 3 22 45 PM" src="https://github.com/user-attachments/assets/d84aa09a-d2be-4f72-a921-22b64801e2ea" />


Upon further investigation, this linting error is due to the type of the `STATUES` export of the StepperList. The type of `STATUSES` is set to `string[]`, but the `@status` argument of the component is typed as the component specific type `HdsStepperStatuses`. When using `STATUSES` in the showcase examples this then causes a type mismatch. 

```
 {{#each STATUSES as |status|}}
      <SG.Item @label="{{capitalize status}}">
        <HdsStepperList @ariaLabel="Label" as |S|>
          <S.Step @status={{status}}>
          ...
```

To fix this issue, the type of the export `STATUSES` was updated from `string[]` to `HdsStepperStatuses[]`

```
export enum HdsStepperStatusesValues {
  Incomplete = 'incomplete',
  Progress = 'progress',
  Processing = 'processing',
  Complete = 'complete',
}

export type HdsStepperStatuses = `${HdsStepperStatusesValues}`;
```

### Potential follow-ups

In the component library, the majority of exported arrays of possible values for an argument are typed as the custom type for that component. However, there are various exports that follow this same pattern of typing the export as `string[]`. These exports will most likely run into the same type issues as those found here.

An effort could be taken to update these types to follow the changes made here.

Example from the Separator component
```
export const SPACING: string[] = Object.values(HdsSeparatorSpacingValues);
```

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>