### PR TITLE
`HdsAdvancedTableTh` Remove `@isVisuallyHidden` argument

### DIFF
--- a/.changeset/hot-owls-rescue.md
+++ b/.changeset/hot-owls-rescue.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+<!-- START components/table/advanced-table -->
+`AdvancedTable` - Removed the `@isVisuallyHidden` argument from `HdsAdvancedTableTh` component. This setting is supported via setting `isVisuallyHidden` in the corresponding `@columns` item's configuration.
+<!-- END -->

--- a/packages/components/src/components/hds/advanced-table/index.hbs
+++ b/packages/components/src/components/hds/advanced-table/index.hbs
@@ -84,7 +84,6 @@
               @isExpandable={{column.isExpandable}}
               @isStickyColumn={{this._isStickyColumn column}}
               @isStickyColumnPinned={{this.isStickyColumnPinned}}
-              @isVisuallyHidden={{column.isVisuallyHidden}}
               @tableHeight={{this._tableHeight}}
               @tooltip={{column.tooltip}}
               @onClickToggle={{this._tableModel.toggleAll}}

--- a/packages/components/src/components/hds/advanced-table/th.ts
+++ b/packages/components/src/components/hds/advanced-table/th.ts
@@ -44,7 +44,6 @@ export interface HdsAdvancedTableThSignature {
     isExpandable?: boolean;
     isStickyColumn?: boolean;
     isStickyColumnPinned?: boolean;
-    isVisuallyHidden?: boolean;
     newLabel?: string;
     parentId?: string;
     rowspan?: number;

--- a/website/docs/components/table/advanced-table/partials/code/component-api.md
+++ b/website/docs/components/table/advanced-table/partials/code/component-api.md
@@ -205,9 +205,6 @@ If the `Th` component is passed as the first cell of a body row, `role="rowheade
   <C.Property @name="tooltip" @type="string">
     Text string which will appear in the [`Tooltip`](/components/tooltip). May contain basic HTML tags for formatting text such as `strong` and `em` tags. Not intended for multi-paragraph text or other more complex content. May not contain interactive content such as links or buttons. The `placement` and `offset` are automatically set and can’t be overwritten.
   </C.Property>
-  <C.Property @name="isVisuallyHidden" @type="boolean" @default="false">
-    If set to `true`, it visually hides the column’s text content (it will still be available to screen readers for accessibility).
-  </C.Property>
   <C.Property @name="colspan" @type="string">
     The number of columns the cell spans. Used to apply the correct grid styles and the aria-rowspan attribute for accessibility.
   </C.Property>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR removes the `@isVisuallyHidden` argument from the `HdsAdvancedTableTh` component.

### :hammer_and_wrench: Detailed description

The functionality for controlling whether the label of the component is visually hidden is done through the column definition rather than by passing an argument to the component.

This change updates the documented functionality without actually changing how the component works.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5293](https://hashicorp.atlassian.net/browse/HDS-5293)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5293]: https://hashicorp.atlassian.net/browse/HDS-5293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ