### PR TITLE
feat: improve logic for modal/flyout lifecycle handling

### DIFF
--- a/packages/components/src/components/hds/flyout/index.hbs
+++ b/packages/components/src/components/hds/flyout/index.hbs
@@ -6,10 +6,9 @@
   class={{this.classNames}}
   ...attributes
   aria-labelledby={{this.id}}
-  {{did-insert this.didInsert}}
-  {{will-destroy this.willDestroyNode}}
+  {{this._registerDialog}}
   {{! @glint-expect-error - https://github.com/josemarluedke/ember-focus-trap/issues/86 }}
-  {{focus-trap isActive=this._isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=true)}}
+  {{focus-trap isActive=this._isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss)}}
 >
   <:header>
     {{yield

--- a/packages/components/src/components/hds/flyout/index.ts
+++ b/packages/components/src/components/hds/flyout/index.ts
@@ -10,6 +10,9 @@ import { assert } from '@ember/debug';
 import { getElementId } from '../../../utils/hds-get-element-id.ts';
 import { buildWaiter } from '@ember/test-waiters';
 import type { WithBoundArgs } from '@glint/template';
+import { modifier } from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
+import type Owner from '@ember/owner';
 
 import type { HdsFlyoutSizes } from './types.ts';
 
@@ -64,6 +67,27 @@ export default class HdsFlyout extends Component<HdsFlyoutSignature> {
   _element!: HTMLDialogElement;
   private _body!: HTMLElement;
   private _bodyInitialOverflowValue = '';
+  private _clickHandler!: (event: MouseEvent) => void;
+
+  constructor(owner: Owner, args: HdsFlyoutSignature['Args']) {
+    super(owner, args);
+
+    registerDestructor(this, (): void => {
+      // if the <dialog> is removed from the dom while open we emulate the close event
+      if (this._element && this._isOpen) {
+        this._element.dispatchEvent(new Event('close'));
+
+        this._element.removeEventListener(
+          'close',
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          this.registerOnCloseCallback,
+          true
+        );
+      }
+
+      document.removeEventListener('click', this._clickHandler, true);
+    });
+  }
 
   /**
    * Sets the size of the flyout
@@ -115,8 +139,7 @@ export default class HdsFlyout extends Component<HdsFlyoutSignature> {
     this._isOpen = false;
   }
 
-  @action
-  didInsert(element: HTMLDialogElement): void {
+  private _registerDialog = modifier((element: HTMLDialogElement) => {
     // Store references of `<dialog>` and `<body>` elements
     this._element = element;
     this._body = document.body;
@@ -135,7 +158,19 @@ export default class HdsFlyout extends Component<HdsFlyoutSignature> {
     if (!this._element.open) {
       this.open();
     }
-  }
+
+    this._clickHandler = (event: MouseEvent) => {
+      // check if the click is outside the flyout and the flyout is open
+      if (!this._element.contains(event.target as Node) && this._isOpen) {
+        void this.onDismiss();
+      }
+    };
+
+    document.addEventListener('click', this._clickHandler, {
+      capture: true,
+      passive: false,
+    });
+  });
 
   @action
   willDestroyNode(): void {

--- a/packages/components/src/components/hds/modal/index.hbs
+++ b/packages/components/src/components/hds/modal/index.hbs
@@ -6,10 +6,9 @@
   class={{this.classNames}}
   ...attributes
   aria-labelledby={{this.id}}
-  {{did-insert this.didInsert}}
-  {{will-destroy this.willDestroyNode}}
+  {{this._registerDialog}}
   {{! @glint-expect-error - https://github.com/josemarluedke/ember-focus-trap/issues/86 }}
-  {{focus-trap isActive=this._isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss clickOutsideDeactivates=true)}}
+  {{focus-trap isActive=this._isOpen focusTrapOptions=(hash onDeactivate=this.onDismiss)}}
 >
   <:header>
     {{yield

--- a/packages/components/src/components/hds/modal/index.ts
+++ b/packages/components/src/components/hds/modal/index.ts
@@ -9,8 +9,11 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import { getElementId } from '../../../utils/hds-get-element-id.ts';
 import { buildWaiter } from '@ember/test-waiters';
+import { registerDestructor } from '@ember/destroyable';
+import { modifier } from 'ember-modifier';
 
 import type { WithBoundArgs } from '@glint/template';
+import type Owner from '@ember/owner';
 import type { HdsModalSizes, HdsModalColors } from './types.ts';
 
 import HdsDialogPrimitiveHeaderComponent from '../dialog-primitive/header.ts';
@@ -61,6 +64,27 @@ export default class HdsModal extends Component<HdsModalSignature> {
   private _element!: HTMLDialogElement;
   private _body!: HTMLElement;
   private _bodyInitialOverflowValue = '';
+  private _clickHandler!: (event: MouseEvent) => void;
+
+  constructor(owner: Owner, args: HdsModalSignature['Args']) {
+    super(owner, args);
+
+    registerDestructor(this, (): void => {
+      // if the <dialog> is removed from the dom while open we emulate the close event
+      if (this._element && this._isOpen) {
+        this._element.dispatchEvent(new Event('close'));
+
+        this._element.removeEventListener(
+          'close',
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          this.registerOnCloseCallback,
+          true
+        );
+      }
+
+      document.removeEventListener('click', this._clickHandler, true);
+    });
+  }
 
   get isDismissDisabled(): boolean {
     return this.args.isDismissDisabled ?? false;
@@ -128,11 +152,33 @@ export default class HdsModal extends Component<HdsModalSignature> {
       }
     } else {
       this._isOpen = false;
+
+      // Reset page `overflow` property
+      if (this._body) {
+        this._body.style.removeProperty('overflow');
+        if (this._bodyInitialOverflowValue === '') {
+          if (this._body.style.length === 0) {
+            this._body.removeAttribute('style');
+          }
+        } else {
+          this._body.style.setProperty(
+            'overflow',
+            this._bodyInitialOverflowValue
+          );
+        }
+      }
+
+      // Return focus to a specific element (if provided)
+      if (this.args.returnFocusTo) {
+        const initiator = document.getElementById(this.args.returnFocusTo);
+        if (initiator) {
+          initiator.focus();
+        }
+      }
     }
   }
 
-  @action
-  didInsert(element: HTMLDialogElement): void {
+  private _registerDialog = modifier((element: HTMLDialogElement) => {
     // Store references of `<dialog>` and `<body>` elements
     this._element = element;
     this._body = document.body;
@@ -151,19 +197,21 @@ export default class HdsModal extends Component<HdsModalSignature> {
     if (!this._element.open) {
       this.open();
     }
-  }
 
-  @action
-  willDestroyNode(): void {
-    if (this._element) {
-      this._element.removeEventListener(
-        'close',
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        this.registerOnCloseCallback,
-        true
-      );
-    }
-  }
+    this._clickHandler = (event: MouseEvent) => {
+      // check if the click is outside the modal and the modal is open
+      if (!this._element.contains(event.target as Node) && this._isOpen) {
+        if (!this.isDismissDisabled) {
+          void this.onDismiss();
+        }
+      }
+    };
+
+    document.addEventListener('click', this._clickHandler, {
+      capture: true,
+      passive: false,
+    });
+  });
 
   @action
   open(): void {
@@ -185,7 +233,6 @@ export default class HdsModal extends Component<HdsModalSignature> {
   async onDismiss(): Promise<void> {
     // allow ember test helpers to be aware of when the `close` event fires
     // when using `click` or other helpers from '@ember/test-helpers'
-    // Notice: this code will get stripped out in production builds (DEBUG evaluates to `true` in dev/test builds, but `false` in prod builds)
     if (this._element.open) {
       const token = waiter.beginAsync();
       const listener = () => {
@@ -197,28 +244,5 @@ export default class HdsModal extends Component<HdsModalSignature> {
 
     // Make modal dialog invisible using the native `close` method
     this._element.close();
-
-    // Reset page `overflow` property
-    if (this._body) {
-      this._body.style.removeProperty('overflow');
-      if (this._bodyInitialOverflowValue === '') {
-        if (this._body.style.length === 0) {
-          this._body.removeAttribute('style');
-        }
-      } else {
-        this._body.style.setProperty(
-          'overflow',
-          this._bodyInitialOverflowValue
-        );
-      }
-    }
-
-    // Return focus to a specific element (if provided)
-    if (this.args.returnFocusTo) {
-      const initiator = document.getElementById(this.args.returnFocusTo);
-      if (initiator) {
-        initiator.focus();
-      }
-    }
   }
 }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would use `registerDestructor` to trigger the close callback when a Modal or Flyout is closed to ensure the proper cleanup happens when a Modal/Flyout is removed from the DOM.

**TODO:**
- [ ] test in cloud ui

### :hammer_and_wrench: Detailed description

This is a follow up from the Modal incident that happened earlier this summer when the modal is simply destroyed and removed from the DOM (eg. on submit) the onDismiss is not run, just the willDestroyNode method, which leaves the overflow applied to the body, making the page unscrollable.

This solution was previously suggested in https://github.com/hashicorp/design-system/pull/2962, but was not used because it was safer to just revert the change that caused the bug.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5038](https://hashicorp.atlassian.net/browse/HDS-5038)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>