### PR TITLE
Flyout: Fix restrictive language and formatting issues

### DIFF
--- a/website/docs/components/flyout/partials/guidelines/guidelines.md
+++ b/website/docs/components/flyout/partials/guidelines/guidelines.md
@@ -35,10 +35,10 @@ While each of these components is triggered by a user action, where they exist i
 - A Flyout extends or "branches" off from the main flow to add detail and highlight secondary features and functions (Fig 1.1).
 - Rather than blocking the user from continuing in the main flow, a Flyout enhances and adds detail to the flow to aid in the completion of a function.
 
-![Modal Hierarchy in the user flow](/assets/components/flyout/flyout-vs-modal-01.png)
+![User flow for modal: the user's action triggers the modal, then the user confirms or cancels and continues in the flow.](/assets/components/flyout/flyout-vs-modal-01.png)
 <Doc::ImageCaption @text="Fig. 1.0: Hierarchy representation of a Modal blocking the user progression through a flow."/>
 
-![Flyout hierarchy in the user flow](/assets/components/flyout/flyout-vs-modal-02.png)
+![User flow for flyout: the user's action triggers the flyout to provide additional information for a task. Then the user continues in the flow.](/assets/components/flyout/flyout-vs-modal-02.png)
 <Doc::ImageCaption @text="Fig. 1.1: Hierarchy representation of the Flyout relative to the user flow."/>
 
 ### Usage examples
@@ -160,7 +160,7 @@ A Flyout supports actions within the footer allowing for basic functions to be p
 
 A Flyout can be used for actions like batch selection that are secondary to the main page.
 
-![Simple actions within a Flyout](/assets/components/flyout/flyout-simple-actions.png)
+![Flyout with links to get support or submit feedback.](/assets/components/flyout/flyout-simple-actions.png)
 !!!
 
 !!! Do
@@ -174,7 +174,7 @@ Use a Flyout for simple declarative content like text and links that enhance the
 
 Avoid using a Flyout for editing or creating objects. These are generally considered primary functions and should be handled on their own page or within a Modal in simple scenarios.
 
-![Complex actions within a Flyout](/assets/components/flyout/flyout-complex-actions.png)
+![Flyout with a form to create a new user and assign them to groups, which includes a table with checkboxes for each group.](/assets/components/flyout/flyout-complex-actions.png)
 !!!
 
 ## Dismissal


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR:

- adjusts the restrictive language about using forms in flyouts, so instead of "don't" it says "avoid"
- moves bold text being used to caption images into the image caption component instead (these weren't available when this documentation was written, so aligning it to our latest best practices)
- makes some of the content slightly more concise

This is based on an [internal team Slack conversation](https://hashicorp.slack.com/archives/C025N5V4PFZ/p1758641271545879) where we discussed that product teams read our language as a "hard no" vs something "we recommend against." Based on our principle of "Guidance over control," this language should more accurately reflect the possibility of valid edge cases being acceptable and thus soften the language from "don't" to "avoid."

**Preview:** https://hds-website-git-hl-flyout-soften-forms-language-hashicorp.vercel.app/components/flyout

### :camera_flash: Screenshots

#### Forms in flyout language
**Before:**
<img width="1106" height="837" alt="Screenshot 2025-09-23 at 12 21 21 PM" src="https://github.com/user-attachments/assets/64d93f39-5a6a-4fc3-ba43-a3b6dd5eb32e" />

**After:**
<img width="1141" height="805" alt="Screenshot 2025-09-23 at 12 44 47 PM" src="https://github.com/user-attachments/assets/47985ed8-01e7-4765-9bf8-4edaf09b4395" />


#### Image captions
**Before:**
<img width="1137" height="1118" alt="Screenshot 2025-09-23 at 12 21 40 PM" src="https://github.com/user-attachments/assets/855889ad-3a53-4355-847e-b6db2e6722c8" />

**After:**
<img width="1074" height="1033" alt="Screenshot 2025-09-23 at 12 45 07 PM" src="https://github.com/user-attachments/assets/0398b06b-c460-4ad5-b7f0-0e7fee478cb2" />

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.