### PR TITLE
Hide CSAT banner

### DIFF
--- a/website/app/templates/application.hbs
+++ b/website/app/templates/application.hbs
@@ -13,10 +13,8 @@
   @onToggleBurgerMenu={{this.onToggleBurgerMenu}}
   @routeChangeValidator={{this.transitionValidator}}
 />
-{{! 
-uncomment this to turn the survey banner back on, but ensure survey link has been updated as well
-<Doc::Page::Banner />
-}}
+{{! uncomment this to turn the survey banner back on, but ensure survey link has been updated as well }}
+{{! <Doc::Page::Banner /> }}
 <Doc::Page::Sidebar
   {{! `this.model.toc` comes from `routes/application.js` }}
   @toc={{this.model.toc}}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR takes down the CSAT banner from the website. We are closing the survey tomorrow (9/24) AM.

**Preview:** https://hds-website-git-hl-hide-csat-banner-hashicorp.vercel.app/

### :camera_flash: Screenshots

**Before**
<img width="1728" height="872" alt="Screenshot 2025-09-23 at 1 53 42 PM" src="https://github.com/user-attachments/assets/fe0aa648-506f-41bd-a7e7-4a4df628be12" />

**After**
<img width="1726" height="875" alt="Screenshot 2025-09-23 at 2 01 40 PM" src="https://github.com/user-attachments/assets/5b0766f4-1924-424c-9b7e-265ea7551b67" />



### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5479](https://hashicorp.atlassian.net/browse/HDS-5479)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

[HDS-5479]: https://hashicorp.atlassian.net/browse/HDS-5479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ