### PR TITLE
`AppSideNav`: add additional tests for when the nav is removed from the DOM

### DIFF
--- a/showcase/app/components/mock/app/sidebar/app-side-nav.gts
+++ b/showcase/app/components/mock/app/sidebar/app-side-nav.gts
@@ -24,7 +24,7 @@ export interface MockAppSidebarAppSideNavSignature {
     isResponsive?: HdsAppSideNavSignature['Args']['isResponsive'];
     isCollapsible?: HdsAppSideNavSignature['Args']['isCollapsible'];
     showDevToggle?: boolean;
-    shouldRemoveFromDomOnCollapse?: boolean;
+    onToggleMinimizedStatus?: HdsAppSideNavSignature['Args']['onToggleMinimizedStatus'];
   };
   Element: HdsAppSideNavSignature['Element'];
 }
@@ -33,7 +33,6 @@ export default class MockAppSidebarAppSideNav extends Component<MockAppSidebarAp
   isResponsive;
   isCollapsible;
   @tracked showMockInteractionState = false;
-  @tracked isRendered = true;
 
   constructor(owner: Owner, args: MockAppSidebarAppSideNavSignature['Args']) {
     super(owner, args);
@@ -45,118 +44,111 @@ export default class MockAppSidebarAppSideNav extends Component<MockAppSidebarAp
     this.showMockInteractionState = !this.showMockInteractionState;
   };
 
-  removeSideNavFromDOM = (isOpen: boolean) => {
-    if (isOpen && this.args.shouldRemoveFromDomOnCollapse)
-      this.isRendered = false;
-  };
-
   <template>
-    {{#if this.isRendered}}
-      <HdsAppSideNav
-        @isResponsive={{this.isResponsive}}
-        @isCollapsible={{this.isCollapsible}}
-        @onToggleMinimizedStatus={{this.removeSideNavFromDOM}}
+    <HdsAppSideNav
+      @isResponsive={{this.isResponsive}}
+      @isCollapsible={{this.isCollapsible}}
+      @onToggleMinimizedStatus={{@onToggleMinimizedStatus}}
+    >
+      <HdsAppSideNavList
+        class="hds-side-nav-hide-when-minimized"
+        aria-label="Dashboard"
+        as |SNL|
       >
-        <HdsAppSideNavList
-          class="hds-side-nav-hide-when-minimized"
-          aria-label="Dashboard"
-          as |SNL|
-        >
-          <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
-        </HdsAppSideNavList>
-        <HdsAppSideNavList
-          class="hds-side-nav-hide-when-minimized"
-          aria-label="Services"
-          as |SNL|
-        >
-          <SNL.Title>Services</SNL.Title>
-          <SNL.Link
-            @text={{if this.showMockInteractionState "isActive" "Boundary"}}
-            @icon="boundary"
-            @href="#"
-            class="active"
-          />
-          <SNL.Link
-            @text={{if this.showMockInteractionState ":focus" "Consul"}}
-            @icon="consul"
-            @href="#"
-            class="mock-focus"
-          />
-          <SNL.Link
-            @text={{if this.showMockInteractionState ":hover" "Packer"}}
-            @icon="packer"
-            @href="#"
-            class="mock-hover"
-          />
-          <SNL.Link
-            @text={{if this.showMockInteractionState ":active" "Vault"}}
-            @icon="vault"
-            @href="#"
-            class="mock-active"
-          />
-          <SNL.Link
-            @text="Vault Secrets"
-            @icon="vault-secrets-square"
-            @href="#"
-          />
-          <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
-          <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
-          <SNL.Link
-            @text="Waypoint"
-            @icon="waypoint"
-            @badge="Alpha"
-            @hasSubItems={{true}}
-          />
-        </HdsAppSideNavList>
-        <HdsAppSideNavList
-          class="hds-side-nav-hide-when-minimized"
-          aria-label="Organization"
-          as |SNL|
-        >
-          <SNL.Title>Default Org</SNL.Title>
-          <SNL.Link
-            @text="HashiCorp Virtual Networks"
-            @icon="network"
-            @href="#"
-          />
-          <SNL.Link
-            @text="Access control (IAM)"
-            @icon="users"
-            @href="#"
-            @hasSubItems={{true}}
-          />
-          <SNL.Link
-            @text="Billing"
-            @icon="credit-card"
-            @href="#"
-            @hasSubItems={{true}}
-          />
-          <SNL.Link
-            @text="Settings"
-            @icon="settings"
-            @href="#"
-            @hasSubItems={{true}}
-          />
-          <SNL.Link
-            @href="#"
-            @isHrefExternal={{true}}
-            @icon="guide"
-            @text="Documentation"
-          />
-          {{#if @showDevToggle}}
-            <SNL.ExtraAfter>
-              <div {{style margin="32px 6px"}}>
-                <HdsFormToggleField
-                  {{on "change" this.toggleMockInteractionState}}
-                  as |F|
-                >
-                  <F.Label>Show mock states</F.Label>
-                </HdsFormToggleField>
-              </div>
-            </SNL.ExtraAfter>
-          {{/if}}
-        </HdsAppSideNavList>
-      </HdsAppSideNav>
-    {{/if}}
+        <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
+      </HdsAppSideNavList>
+      <HdsAppSideNavList
+        class="hds-side-nav-hide-when-minimized"
+        aria-label="Services"
+        as |SNL|
+      >
+        <SNL.Title>Services</SNL.Title>
+        <SNL.Link
+          @text={{if this.showMockInteractionState "isActive" "Boundary"}}
+          @icon="boundary"
+          @href="#"
+          class="active"
+        />
+        <SNL.Link
+          @text={{if this.showMockInteractionState ":focus" "Consul"}}
+          @icon="consul"
+          @href="#"
+          class="mock-focus"
+        />
+        <SNL.Link
+          @text={{if this.showMockInteractionState ":hover" "Packer"}}
+          @icon="packer"
+          @href="#"
+          class="mock-hover"
+        />
+        <SNL.Link
+          @text={{if this.showMockInteractionState ":active" "Vault"}}
+          @icon="vault"
+          @href="#"
+          class="mock-active"
+        />
+        <SNL.Link
+          @text="Vault Secrets"
+          @icon="vault-secrets-square"
+          @href="#"
+        />
+        <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
+        <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
+        <SNL.Link
+          @text="Waypoint"
+          @icon="waypoint"
+          @badge="Alpha"
+          @hasSubItems={{true}}
+        />
+      </HdsAppSideNavList>
+      <HdsAppSideNavList
+        class="hds-side-nav-hide-when-minimized"
+        aria-label="Organization"
+        as |SNL|
+      >
+        <SNL.Title>Default Org</SNL.Title>
+        <SNL.Link
+          @text="HashiCorp Virtual Networks"
+          @icon="network"
+          @href="#"
+        />
+        <SNL.Link
+          @text="Access control (IAM)"
+          @icon="users"
+          @href="#"
+          @hasSubItems={{true}}
+        />
+        <SNL.Link
+          @text="Billing"
+          @icon="credit-card"
+          @href="#"
+          @hasSubItems={{true}}
+        />
+        <SNL.Link
+          @text="Settings"
+          @icon="settings"
+          @href="#"
+          @hasSubItems={{true}}
+        />
+        <SNL.Link
+          @href="#"
+          @isHrefExternal={{true}}
+          @icon="guide"
+          @text="Documentation"
+        />
+        {{#if @showDevToggle}}
+          <SNL.ExtraAfter>
+            <div {{style margin="32px 6px"}}>
+              <HdsFormToggleField
+                {{on "change" this.toggleMockInteractionState}}
+                as |F|
+              >
+                <F.Label>Show mock states</F.Label>
+              </HdsFormToggleField>
+            </div>
+          </SNL.ExtraAfter>
+        {{/if}}
+      </HdsAppSideNavList>
+    </HdsAppSideNav>
   </template>
 }

--- a/showcase/app/components/mock/app/sidebar/app-side-nav.gts
+++ b/showcase/app/components/mock/app/sidebar/app-side-nav.gts
@@ -24,6 +24,7 @@ export interface MockAppSidebarAppSideNavSignature {
     isResponsive?: HdsAppSideNavSignature['Args']['isResponsive'];
     isCollapsible?: HdsAppSideNavSignature['Args']['isCollapsible'];
     showDevToggle?: boolean;
+    shouldRemoveFromDomOnCollapse?: boolean;
   };
   Element: HdsAppSideNavSignature['Element'];
 }
@@ -32,6 +33,7 @@ export default class MockAppSidebarAppSideNav extends Component<MockAppSidebarAp
   isResponsive;
   isCollapsible;
   @tracked showMockInteractionState = false;
+  @tracked isRendered = true;
 
   constructor(owner: Owner, args: MockAppSidebarAppSideNavSignature['Args']) {
     super(owner, args);
@@ -43,110 +45,118 @@ export default class MockAppSidebarAppSideNav extends Component<MockAppSidebarAp
     this.showMockInteractionState = !this.showMockInteractionState;
   };
 
+  removeSideNavFromDOM = (isOpen: boolean) => {
+    if (isOpen && this.args.shouldRemoveFromDomOnCollapse)
+      this.isRendered = false;
+  };
+
   <template>
-    <HdsAppSideNav
-      @isResponsive={{this.isResponsive}}
-      @isCollapsible={{this.isCollapsible}}
-    >
-      <HdsAppSideNavList
-        class="hds-side-nav-hide-when-minimized"
-        aria-label="Dashboard"
-        as |SNL|
+    {{#if this.isRendered}}
+      <HdsAppSideNav
+        @isResponsive={{this.isResponsive}}
+        @isCollapsible={{this.isCollapsible}}
+        @onToggleMinimizedStatus={{this.removeSideNavFromDOM}}
       >
-        <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
-      </HdsAppSideNavList>
-      <HdsAppSideNavList
-        class="hds-side-nav-hide-when-minimized"
-        aria-label="Services"
-        as |SNL|
-      >
-        <SNL.Title>Services</SNL.Title>
-        <SNL.Link
-          @text={{if this.showMockInteractionState "isActive" "Boundary"}}
-          @icon="boundary"
-          @href="#"
-          class="active"
-        />
-        <SNL.Link
-          @text={{if this.showMockInteractionState ":focus" "Consul"}}
-          @icon="consul"
-          @href="#"
-          class="mock-focus"
-        />
-        <SNL.Link
-          @text={{if this.showMockInteractionState ":hover" "Packer"}}
-          @icon="packer"
-          @href="#"
-          class="mock-hover"
-        />
-        <SNL.Link
-          @text={{if this.showMockInteractionState ":active" "Vault"}}
-          @icon="vault"
-          @href="#"
-          class="mock-active"
-        />
-        <SNL.Link
-          @text="Vault Secrets"
-          @icon="vault-secrets-square"
-          @href="#"
-        />
-        <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
-        <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
-        <SNL.Link
-          @text="Waypoint"
-          @icon="waypoint"
-          @badge="Alpha"
-          @hasSubItems={{true}}
-        />
-      </HdsAppSideNavList>
-      <HdsAppSideNavList
-        class="hds-side-nav-hide-when-minimized"
-        aria-label="Organization"
-        as |SNL|
-      >
-        <SNL.Title>Default Org</SNL.Title>
-        <SNL.Link
-          @text="HashiCorp Virtual Networks"
-          @icon="network"
-          @href="#"
-        />
-        <SNL.Link
-          @text="Access control (IAM)"
-          @icon="users"
-          @href="#"
-          @hasSubItems={{true}}
-        />
-        <SNL.Link
-          @text="Billing"
-          @icon="credit-card"
-          @href="#"
-          @hasSubItems={{true}}
-        />
-        <SNL.Link
-          @text="Settings"
-          @icon="settings"
-          @href="#"
-          @hasSubItems={{true}}
-        />
-        <SNL.Link
-          @href="#"
-          @isHrefExternal={{true}}
-          @icon="guide"
-          @text="Documentation"
-        />
-        {{#if @showDevToggle}}
-          <SNL.ExtraAfter>
-            <div {{style margin="32px 6px"}}>
-              <HdsFormToggleField
-                {{on "change" this.toggleMockInteractionState}}
-                as |F|
-              >
-                <F.Label>Show mock states</F.Label>
-              </HdsFormToggleField>
-            </div>
-          </SNL.ExtraAfter>
-        {{/if}}
-      </HdsAppSideNavList>
-    </HdsAppSideNav>
+        <HdsAppSideNavList
+          class="hds-side-nav-hide-when-minimized"
+          aria-label="Dashboard"
+          as |SNL|
+        >
+          <SNL.Link @icon="dashboard" @text="Dashboard" @isActive={{true}} />
+        </HdsAppSideNavList>
+        <HdsAppSideNavList
+          class="hds-side-nav-hide-when-minimized"
+          aria-label="Services"
+          as |SNL|
+        >
+          <SNL.Title>Services</SNL.Title>
+          <SNL.Link
+            @text={{if this.showMockInteractionState "isActive" "Boundary"}}
+            @icon="boundary"
+            @href="#"
+            class="active"
+          />
+          <SNL.Link
+            @text={{if this.showMockInteractionState ":focus" "Consul"}}
+            @icon="consul"
+            @href="#"
+            class="mock-focus"
+          />
+          <SNL.Link
+            @text={{if this.showMockInteractionState ":hover" "Packer"}}
+            @icon="packer"
+            @href="#"
+            class="mock-hover"
+          />
+          <SNL.Link
+            @text={{if this.showMockInteractionState ":active" "Vault"}}
+            @icon="vault"
+            @href="#"
+            class="mock-active"
+          />
+          <SNL.Link
+            @text="Vault Secrets"
+            @icon="vault-secrets-square"
+            @href="#"
+          />
+          <SNL.Link @text="Terraform" @icon="terraform" @href="#" />
+          <SNL.Link @text="Vagrant" @icon="vagrant" @badge="Alpha" @href="#" />
+          <SNL.Link
+            @text="Waypoint"
+            @icon="waypoint"
+            @badge="Alpha"
+            @hasSubItems={{true}}
+          />
+        </HdsAppSideNavList>
+        <HdsAppSideNavList
+          class="hds-side-nav-hide-when-minimized"
+          aria-label="Organization"
+          as |SNL|
+        >
+          <SNL.Title>Default Org</SNL.Title>
+          <SNL.Link
+            @text="HashiCorp Virtual Networks"
+            @icon="network"
+            @href="#"
+          />
+          <SNL.Link
+            @text="Access control (IAM)"
+            @icon="users"
+            @href="#"
+            @hasSubItems={{true}}
+          />
+          <SNL.Link
+            @text="Billing"
+            @icon="credit-card"
+            @href="#"
+            @hasSubItems={{true}}
+          />
+          <SNL.Link
+            @text="Settings"
+            @icon="settings"
+            @href="#"
+            @hasSubItems={{true}}
+          />
+          <SNL.Link
+            @href="#"
+            @isHrefExternal={{true}}
+            @icon="guide"
+            @text="Documentation"
+          />
+          {{#if @showDevToggle}}
+            <SNL.ExtraAfter>
+              <div {{style margin="32px 6px"}}>
+                <HdsFormToggleField
+                  {{on "change" this.toggleMockInteractionState}}
+                  as |F|
+                >
+                  <F.Label>Show mock states</F.Label>
+                </HdsFormToggleField>
+              </div>
+            </SNL.ExtraAfter>
+          {{/if}}
+        </HdsAppSideNavList>
+      </HdsAppSideNav>
+    {{/if}}
   </template>
 }

--- a/showcase/app/router.ts
+++ b/showcase/app/router.ts
@@ -37,6 +37,7 @@ Router.map(function () {
     this.route('app-side-nav', function () {
       this.route('frameless', function () {
         this.route('demo-responsiveness');
+        this.route('demo-remove-from-dom');
       });
     });
     this.route('application-state');

--- a/showcase/app/templates/page-components/app-side-nav/frameless/demo-remove-from-dom.gts
+++ b/showcase/app/templates/page-components/app-side-nav/frameless/demo-remove-from-dom.gts
@@ -1,18 +1,32 @@
-import type { TemplateOnlyComponent } from '@ember/component/template-only';
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
 import { pageTitle } from 'ember-page-title';
+import { tracked } from '@glimmer/tracking';
 
 import MockApp from 'showcase/components/mock/app';
 
-const PageComponentsAppSideNavFramelessDemoRemoveFromDom: TemplateOnlyComponent =
+export default class PageComponentsAppSideNavFramelessDemoRemoveFromDom extends Component {
+  @tracked isRendered = true;
+
+  removeSideNavFromDOM = (isOpen: boolean) => {
+    if (isOpen) this.isRendered = false;
+  };
+
   <template>
     {{pageTitle "App SideNav remove from DOM demo - Frameless"}}
 
     <MockApp>
       <:sidebar as |S|>
-        <S.SideNav
-          @showDevToggle={{true}}
-          @shouldRemoveFromDomOnCollapse={{true}}
-        />
+        {{#if this.isRendered}}
+          <S.SideNav
+            @showDevToggle={{true}}
+            @onToggleMinimizedStatus={{this.removeSideNavFromDOM}}
+          />
+        {{/if}}
       </:sidebar>
       <:main as |M|>
         <M.PageHeader @showActionButton={{true}} />
@@ -22,6 +36,5 @@ const PageComponentsAppSideNavFramelessDemoRemoveFromDom: TemplateOnlyComponent 
         <M.GenericTextContent />
       </:main>
     </MockApp>
-  </template>;
-
-export default PageComponentsAppSideNavFramelessDemoRemoveFromDom;
+  </template>
+}

--- a/showcase/app/templates/page-components/app-side-nav/frameless/demo-remove-from-dom.gts
+++ b/showcase/app/templates/page-components/app-side-nav/frameless/demo-remove-from-dom.gts
@@ -1,0 +1,27 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { pageTitle } from 'ember-page-title';
+
+import MockApp from 'showcase/components/mock/app';
+
+const PageComponentsAppSideNavFramelessDemoRemoveFromDom: TemplateOnlyComponent =
+  <template>
+    {{pageTitle "App SideNav remove from DOM demo - Frameless"}}
+
+    <MockApp>
+      <:sidebar as |S|>
+        <S.SideNav
+          @showDevToggle={{true}}
+          @shouldRemoveFromDomOnCollapse={{true}}
+        />
+      </:sidebar>
+      <:main as |M|>
+        <M.PageHeader @showActionButton={{true}} />
+        <M.GenericTextContent />
+        <M.GenericTextContent />
+        <M.GenericTextContent />
+        <M.GenericTextContent />
+      </:main>
+    </MockApp>
+  </template>;
+
+export default PageComponentsAppSideNavFramelessDemoRemoveFromDom;

--- a/showcase/app/templates/page-components/app-side-nav/index.hbs
+++ b/showcase/app/templates/page-components/app-side-nav/index.hbs
@@ -699,4 +699,22 @@
     @label="Full AppFrame with AppHeader & AppSideNav (small viewport)"
   />
 
+  <Shw::Divider />
+
+  <Shw::Frame
+    @id="demo-full-app-frame-with-remove-from-dom"
+    @src="/components/app-side-nav/frameless/demo-remove-from-dom"
+    @height="780"
+    @width="800"
+    @label="Remove AppSideNav from DOM when collapse"
+  />
+  <Shw::Text::Body>
+    This demo verifies that when the `AppSideNav` component is removed from the DOM while page overflow styles are
+    overridden, the page's scroll functionality is properly restored.
+  </Shw::Text::Body>
+
+  <Shw::Text::Body>
+    To check this, expand and then collapse the AppSideNav. Then try to scroll the page.
+  </Shw::Text::Body>
+
 </section>

--- a/showcase/tests/integration/components/hds/app-side-nav/index-test.js
+++ b/showcase/tests/integration/components/hds/app-side-nav/index-test.js
@@ -314,13 +314,49 @@ module('Integration | Component | hds/app-side-nav/index', function (hooks) {
     assert.dom('body', document).doesNotHaveStyle('overflow');
   });
 
+  test('when expanded in mobile and the component is removed from the DOM, scrolling is enabled', async function (assert) {
+    this.mockMedia();
+
+    let calls = [];
+    this.setProperties({
+      onDesktopViewportChange: (...args) => calls.push(args),
+    });
+
+    this.set('isAppSideNavRendered', true);
+
+    await render(hbs`{{#if this.isAppSideNavRendered}}
+  <Hds::AppSideNav
+    @isCollapsible={{true}}
+    @onDesktopViewportChange={{this.onDesktopViewportChange}}
+  />
+{{/if}}`);
+
+    await this.changeBrowserSize(false);
+
+    assert.deepEqual(
+      calls[1],
+      [false],
+      'resizing to mobile triggers a false event',
+    );
+
+    await click('.hds-app-side-nav__toggle-button');
+
+    assert.dom('body', document).hasStyle({
+      overflow: 'hidden',
+    });
+
+    this.set('isAppSideNavRendered', false);
+
+    assert.dom('body', document).doesNotHaveStyle('overflow');
+  });
+
   test('when collapsed, the content in the AppSideNav is not focusable', async function (assert) {
     await render(hbs`<Hds::AppSideNav
     id='test-app-side-nav'
   @isCollapsible={{true}}
 >
-  <button id='button-inside'>Click</button>
-</Hds::AppSideNav><button id='button-outside'>Click</button>`);
+  <button id='button-inside' type="button">Click</button>
+</Hds::AppSideNav><button id='button-outside' type="button">Click</button>`);
 
     await click('.hds-app-side-nav__toggle-button');
     assert.dom('#test-app-side-nav').hasClass('hds-app-side-nav--is-minimized');


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add tests and a showcase example of the AppSideNav being removed from the DOM when in mobile view to verify that the overflow property is restored to the page.

**[SHOWCASE PREVIEW](https://hds-showcase-git-hds-5025-test-improvements-hashicorp.vercel.app/components/app-side-nav)**

### :hammer_and_wrench: Detailed description

This work is the result of a ticket to audit the design system for components that reach outside of the component to the DOM. The only component besides Modal and Flyout that does this is AppSideNav.

The AppSideNav (unlike the SideNav) prevents scrolling on the page when it is expanded on a mobile screen by setting `overflow: hidden` on the body of the page.

To verify that the component is properly cleaned up if it is removed from the DOM (which is unlikely), I added 2 things:
* An integration test that if the component is removed from the DOM, the `overflow: hidden` style is removed 
* An example to the showcase page of the component being removed from the DOM so it can be manually tested

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5025](https://hashicorp.atlassian.net/browse/HDS-5025)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5025]: https://hashicorp.atlassian.net/browse/HDS-5025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ