### PR TITLE
Website: Fix focus and brand gradient token names in color palette

### DIFF
--- a/website/docs/foundations/colors/index.js
+++ b/website/docs/foundations/colors/index.js
@@ -36,7 +36,7 @@ export default class Colors extends Component {
               colors['semantic'][context] = [];
             }
             const tokenObj = {
-              colorName: `${token.path[1]}-${token.path[2]}`,
+              colorName: token.path.slice(1).join('-'),
               cssVariable: `--${token.name}`,
               // note: we prefix `value` with `$` because we're using the DTCG format
               value: token.$value,
@@ -52,7 +52,7 @@ export default class Colors extends Component {
               colors['branding'][brand] = [];
             }
             colors['branding'][brand].push({
-              colorName: `${token.path[1]}-${token.path[2]}`,
+              colorName: token.path.slice(1).join('-'),
               cssVariable: `--${token.name}`,
               // note: we prefix `value` with `$` because we're using the DTCG format
               value: token.$value,


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the names displayed in the website color palette for the focus tokens and the brand gradient tokens, to display their full names. 

### :hammer_and_wrench: Detailed description

In the existing color palette page on the website, each token is displayed with its full name on each card. However, due to an issue with the script that generates these names currently the tokens for focus and brand gradients are having only part of their name displayed. 

This is due to the fact that the script only displays the first two "paths" of the token name, which works for all other tokens except these, which go beyond 2 name levels. The script has been updated to be more flexible with these longer name paths.

[Preview page](https://hds-website-git-dchyun-website-tokens-name-fix-hashicorp.vercel.app/foundations/colors?tab=palette)

### :camera_flash: Screenshots

**Before**
<img width="862" height="622" alt="Screenshot 2025-10-02 at 9 59 55 AM" src="https://github.com/user-attachments/assets/9b69f75a-9e5d-4cf0-8d71-80d5ac89578e" />
<img width="864" height="616" alt="Screenshot 2025-10-02 at 10 00 05 AM" src="https://github.com/user-attachments/assets/d611cec5-3c83-431a-b5b2-f8dfe8f9f8c4" />

**After**
<img width="859" height="623" alt="Screenshot 2025-10-02 at 9 59 36 AM" src="https://github.com/user-attachments/assets/adc25ca4-5afd-40e9-a87c-4263ac9c1cc7" />
<img width="860" height="617" alt="Screenshot 2025-10-02 at 9 59 28 AM" src="https://github.com/user-attachments/assets/9aaaf957-f1e6-4dff-87c0-a05cc8f3e0e6" />

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>