### PR TITLE
Remove deprecated `ember-flight-icon` `lazyEmbed` flag

### DIFF
--- a/.changeset/young-meals-knock.md
+++ b/.changeset/young-meals-knock.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+Removed support for deprecated `ember-flight-icons` `lazyEmbed` config

--- a/packages/components/addon-main.cjs
+++ b/packages/components/addon-main.cjs
@@ -9,11 +9,8 @@ const flightIconSprite = require('@hashicorp/flight-icons/svg-sprite/svg-sprite-
 module.exports = {
   ...addonV1Shim(__dirname),
   contentFor(type, config) {
-    const legacyLazyEmbed = config?.emberFlightIcons?.lazyEmbed;
-
     if (
       !config.flightIconsSpriteLazyEmbed &&
-      !legacyLazyEmbed &&
       !config.__flightIconsSpriteLoaded &&
       type === 'body-footer'
     ) {

--- a/packages/components/src/instance-initializers/load-sprite.ts
+++ b/packages/components/src/instance-initializers/load-sprite.ts
@@ -6,11 +6,8 @@
 import config from 'ember-get-config';
 
 export async function initialize() {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-  const legacyLazyEmbed = config?.emberFlightIcons?.lazyEmbed;
-
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (config?.flightIconsSpriteLazyEmbed || legacyLazyEmbed) {
+  if (config?.flightIconsSpriteLazyEmbed) {
     const { default: svgSprite } = await import(
       '@hashicorp/flight-icons/svg-sprite/svg-sprite-module'
     );


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will remove support for the deprecated `lazyEmbed` flag for `ember-flight-icons` in favor of supporting the `flightIconsSpriteLazyEmbed` config only.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-4883](https://hashicorp.atlassian.net/browse/HDS-4883)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-4883]: https://hashicorp.atlassian.net/browse/HDS-4883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ