### PR TITLE
Removed vague a11y banner

### DIFF
--- a/website/docs/components/alert/partials/code/how-to-use.md
+++ b/website/docs/components/alert/partials/code/how-to-use.md
@@ -162,13 +162,6 @@ You can pass more than one `D.Description` contextual component to have multiple
 
 ### Generic content
 
-!!! Warning
-
-**Accessibility alert**
-
-Use this method with caution and as an escape hatch. [Contact the Design Systems Team](/about/support) to check that the solution is conformant and satisfies accessibility criteria.
-!!!
-
 Use the `Generic` contextual component to insert custom content. Generic content will appear after the title, description, and actions. Application teams will need to implement spacing, layout, and styling for generic content.
 
 ```handlebars


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR removes the vague a11y banner from the code documentation.

**Preview: **

### :camera_flash: Screenshots

**Before:**
<img width="820" height="327" alt="Screenshot 2025-10-03 at 11 38 27 AM" src="https://github.com/user-attachments/assets/422fdda4-9e35-4586-a8ef-2e6e0665a07c" />

**After:**


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5299](https://hashicorp.atlassian.net/browse/HDS-5299)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.