### PR TITLE
Add changeset for `volume-2` icon rename

### DIFF
--- a/.changeset/sweet-mangos-relate.md
+++ b/.changeset/sweet-mangos-relate.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": major
+---
+
+<!-- START components/icon -->
+`Icon` - Renamed the `volume-2` icon to `volume-up`
+<!-- END -->


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a changeset documenting the renaming of the `volume-2` icon to `volume-up` as a possible option for `HdsIcon`.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5537](https://hashicorp.atlassian.net/browse/HDS-5537)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>