### PR TITLE
[Project Solar / Phase 1 / Showcase] Fix copy button showcase status icons

### DIFF
--- a/showcase/app/components/page-components/code-block/sub-sections/base-elements.gts
+++ b/showcase/app/components/page-components/code-block/sub-sections/base-elements.gts
@@ -6,12 +6,16 @@ import Component from '@glimmer/component';
 import { capitalize } from '@ember/string';
 import { array } from '@ember/helper';
 import { modifier } from 'ember-modifier';
+import style from 'ember-style-modifier';
 
 import ShwGrid from 'showcase/components/shw/grid';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 import ShwTextH3 from 'showcase/components/shw/text/h3';
 
-import { HdsCodeBlockCopyButton } from '@hashicorp/design-system-components/components';
+import {
+  HdsCodeBlockCopyButton,
+  HdsIcon,
+} from '@hashicorp/design-system-components/components';
 import {
   SUCCESS_ICON,
   ERROR_ICON,
@@ -30,10 +34,13 @@ export default class SubSectionBaseElements extends Component {
 
       if (icon) {
         if (status === 'success') {
-          // eg. href="#flight-clipboard-checked-16"
-          icon.setAttribute('href', `#flight-${SUCCESS_ICON}-16`);
+          window.setTimeout(() => {
+            icon.setAttribute('href', `#hds-icon-flight-${SUCCESS_ICON}-16`);
+          }, 100);
         } else if (status === 'error') {
-          icon.setAttribute('href', `#flight-${ERROR_ICON}-16`);
+          window.setTimeout(() => {
+            icon.setAttribute('href', `#hds-icon-flight-${ERROR_ICON}-16`);
+          }, 100);
         }
       }
     });
@@ -46,6 +53,9 @@ export default class SubSectionBaseElements extends Component {
 
     <span class="shw-component-code-block-display-none" id="test-target">Copy me</span>
 
+    {{!-- Note: HdsIcons are needed to load the svgs for the copy button statuses --}}
+    <HdsIcon @name="clipboard-checked" {{style display="none"}} />
+    <HdsIcon @name="clipboard-x" {{style display="none"}} />
     <ShwGrid @columns={{6}} {{this.replaceCopyStatus}} as |SG|>
       {{#each STATES as |state|}}
         <SG.Item

--- a/showcase/app/components/page-components/code-block/sub-sections/base-elements.gts
+++ b/showcase/app/components/page-components/code-block/sub-sections/base-elements.gts
@@ -34,13 +34,14 @@ export default class SubSectionBaseElements extends Component {
 
       if (icon) {
         if (status === 'success') {
+          // Note: Timeout is needed to allow the copy button component to load the default icon before it's replaced with the status icon
           window.setTimeout(() => {
             icon.setAttribute('href', `#hds-icon-flight-${SUCCESS_ICON}-16`);
-          }, 100);
+          }, 200);
         } else if (status === 'error') {
           window.setTimeout(() => {
             icon.setAttribute('href', `#hds-icon-flight-${ERROR_ICON}-16`);
-          }, 100);
+          }, 200);
         }
       }
     });
@@ -53,7 +54,7 @@ export default class SubSectionBaseElements extends Component {
 
     <span class="shw-component-code-block-display-none" id="test-target">Copy me</span>
 
-    {{! Note: HdsIcons are needed to load the svgs for the copy button statuses }}
+    {{! Note: HdsIcons are needed to preload the SVGs for the copy button statuses }}
     <HdsIcon @name="clipboard-checked" {{style display="none"}} />
     <HdsIcon @name="clipboard-x" {{style display="none"}} />
     <ShwGrid @columns={{6}} {{this.replaceCopyStatus}} as |SG|>

--- a/showcase/app/components/page-components/code-block/sub-sections/base-elements.gts
+++ b/showcase/app/components/page-components/code-block/sub-sections/base-elements.gts
@@ -53,7 +53,7 @@ export default class SubSectionBaseElements extends Component {
 
     <span class="shw-component-code-block-display-none" id="test-target">Copy me</span>
 
-    {{!-- Note: HdsIcons are needed to load the svgs for the copy button statuses --}}
+    {{! Note: HdsIcons are needed to load the svgs for the copy button statuses }}
     <HdsIcon @name="clipboard-checked" {{style display="none"}} />
     <HdsIcon @name="clipboard-x" {{style display="none"}} />
     <ShwGrid @columns={{6}} {{this.replaceCopyStatus}} as |SG|>

--- a/showcase/app/components/page-components/copy/button/sub-sections/base-elements.gts
+++ b/showcase/app/components/page-components/copy/button/sub-sections/base-elements.gts
@@ -16,7 +16,10 @@ import ShwGrid from 'showcase/components/shw/grid';
 import ShwOutliner from 'showcase/components/shw/outliner';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 
-import { HdsCopyButton, HdsIcon } from '@hashicorp/design-system-components/components';
+import {
+  HdsCopyButton,
+  HdsIcon,
+} from '@hashicorp/design-system-components/components';
 import {
   SIZES,
   SUCCESS_ICON,
@@ -95,7 +98,7 @@ export default class SubSectionBaseElements extends Component {
     <ShwTextH2>States</ShwTextH2>
 
     <div {{this.replaceCopyStatus}}>
-      {{!-- Note: HdsIcons are needed to load the svgs for the copy button statuses --}}
+      {{! Note: HdsIcons are needed to load the svgs for the copy button statuses }}
       <HdsIcon @name="clipboard-checked" {{style display="none"}} />
       <HdsIcon @name="clipboard-x" {{style display="none"}} />
       <ShwGrid @columns={{6}} as |SG|>

--- a/showcase/app/components/page-components/copy/button/sub-sections/base-elements.gts
+++ b/showcase/app/components/page-components/copy/button/sub-sections/base-elements.gts
@@ -16,7 +16,7 @@ import ShwGrid from 'showcase/components/shw/grid';
 import ShwOutliner from 'showcase/components/shw/outliner';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 
-import { HdsCopyButton } from '@hashicorp/design-system-components/components';
+import { HdsCopyButton, HdsIcon } from '@hashicorp/design-system-components/components';
 import {
   SIZES,
   SUCCESS_ICON,
@@ -36,10 +36,13 @@ export default class SubSectionBaseElements extends Component {
 
       if (icon) {
         if (status === 'success') {
-          // eg. href="#flight-clipboard-checked-16"
-          icon.setAttribute('href', `#flight-${SUCCESS_ICON}-16`);
+          window.setTimeout(() => {
+            icon.setAttribute('href', `#hds-icon-flight-${SUCCESS_ICON}-16`);
+          }, 100);
         } else if (status === 'error') {
-          icon.setAttribute('href', `#flight-${ERROR_ICON}-16`);
+          window.setTimeout(() => {
+            icon.setAttribute('href', `#hds-icon-flight-${ERROR_ICON}-16`);
+          }, 100);
         }
       }
     });
@@ -92,6 +95,9 @@ export default class SubSectionBaseElements extends Component {
     <ShwTextH2>States</ShwTextH2>
 
     <div {{this.replaceCopyStatus}}>
+      {{!-- Note: HdsIcons are needed to load the svgs for the copy button statuses --}}
+      <HdsIcon @name="clipboard-checked" {{style display="none"}} />
+      <HdsIcon @name="clipboard-x" {{style display="none"}} />
       <ShwGrid @columns={{6}} as |SG|>
         {{#each SIZES as |size|}}
           {{#each STATES as |state|}}

--- a/showcase/app/components/page-components/copy/button/sub-sections/base-elements.gts
+++ b/showcase/app/components/page-components/copy/button/sub-sections/base-elements.gts
@@ -39,13 +39,14 @@ export default class SubSectionBaseElements extends Component {
 
       if (icon) {
         if (status === 'success') {
+          // Note: Timeout is needed to allow the copy button component to load the default icon before it's replaced with the status icon
           window.setTimeout(() => {
             icon.setAttribute('href', `#hds-icon-flight-${SUCCESS_ICON}-16`);
-          }, 100);
+          }, 200);
         } else if (status === 'error') {
           window.setTimeout(() => {
             icon.setAttribute('href', `#hds-icon-flight-${ERROR_ICON}-16`);
-          }, 100);
+          }, 200);
         }
       }
     });
@@ -98,7 +99,7 @@ export default class SubSectionBaseElements extends Component {
     <ShwTextH2>States</ShwTextH2>
 
     <div {{this.replaceCopyStatus}}>
-      {{! Note: HdsIcons are needed to load the svgs for the copy button statuses }}
+      {{! Note: HdsIcons are needed to preload the SVGs for the copy button statuses }}
       <HdsIcon @name="clipboard-checked" {{style display="none"}} />
       <HdsIcon @name="clipboard-x" {{style display="none"}} />
       <ShwGrid @columns={{6}} as |SG|>

--- a/showcase/app/components/page-components/copy/snippet/sub-sections/states.gts
+++ b/showcase/app/components/page-components/copy/snippet/sub-sections/states.gts
@@ -8,12 +8,16 @@ import { capitalize } from '@ember/string';
 import { array } from '@ember/helper';
 import { eq, or } from 'ember-truth-helpers';
 import { modifier } from 'ember-modifier';
+import style from 'ember-style-modifier';
 
 import ShwDivider from 'showcase/components/shw/divider';
 import ShwGrid from 'showcase/components/shw/grid';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 
-import { HdsCopySnippet } from '@hashicorp/design-system-components/components';
+import {
+  HdsCopySnippet,
+  HdsIcon,
+} from '@hashicorp/design-system-components/components';
 import {
   COLORS,
   SUCCESS_ICON,
@@ -33,10 +37,13 @@ export default class SubSectionBaseElements extends Component {
 
       if (icon) {
         if (status === 'success') {
-          // eg. href="#flight-clipboard-checked-16"
-          icon.setAttribute('href', `#flight-${SUCCESS_ICON}-16`);
+          window.setTimeout(() => {
+            icon.setAttribute('href', `#hds-icon-flight-${SUCCESS_ICON}-16`);
+          }, 100);
         } else if (status === 'error') {
-          icon.setAttribute('href', `#flight-${ERROR_ICON}-16`);
+          window.setTimeout(() => {
+            icon.setAttribute('href', `#hds-icon-flight-${ERROR_ICON}-16`);
+          }, 100);
         }
       }
     });
@@ -45,6 +52,9 @@ export default class SubSectionBaseElements extends Component {
   <template>
     <ShwTextH2>States</ShwTextH2>
 
+    {{!-- Note: HdsIcons are needed to load the svgs for the copy button statuses --}}
+    <HdsIcon @name="clipboard-checked" {{style display="none"}} />
+    <HdsIcon @name="clipboard-x" {{style display="none"}} />
     <div {{this.replaceCopyStatus}}>
       <ShwGrid @columns={{6}} as |SG|>
         {{#each COLORS as |color|}}

--- a/showcase/app/components/page-components/copy/snippet/sub-sections/states.gts
+++ b/showcase/app/components/page-components/copy/snippet/sub-sections/states.gts
@@ -52,7 +52,7 @@ export default class SubSectionBaseElements extends Component {
   <template>
     <ShwTextH2>States</ShwTextH2>
 
-    {{!-- Note: HdsIcons are needed to load the svgs for the copy button statuses --}}
+    {{! Note: HdsIcons are needed to load the svgs for the copy button statuses }}
     <HdsIcon @name="clipboard-checked" {{style display="none"}} />
     <HdsIcon @name="clipboard-x" {{style display="none"}} />
     <div {{this.replaceCopyStatus}}>

--- a/showcase/app/components/page-components/copy/snippet/sub-sections/states.gts
+++ b/showcase/app/components/page-components/copy/snippet/sub-sections/states.gts
@@ -37,13 +37,14 @@ export default class SubSectionBaseElements extends Component {
 
       if (icon) {
         if (status === 'success') {
+          // Note: Timeout is needed to allow the copy button component to load the default icon before it's replaced with the status icon
           window.setTimeout(() => {
             icon.setAttribute('href', `#hds-icon-flight-${SUCCESS_ICON}-16`);
-          }, 100);
+          }, 200);
         } else if (status === 'error') {
           window.setTimeout(() => {
             icon.setAttribute('href', `#hds-icon-flight-${ERROR_ICON}-16`);
-          }, 100);
+          }, 200);
         }
       }
     });
@@ -52,7 +53,7 @@ export default class SubSectionBaseElements extends Component {
   <template>
     <ShwTextH2>States</ShwTextH2>
 
-    {{! Note: HdsIcons are needed to load the svgs for the copy button statuses }}
+    {{! Note: HdsIcons are needed to preload the SVGs for the copy button statuses }}
     <HdsIcon @name="clipboard-checked" {{style display="none"}} />
     <HdsIcon @name="clipboard-x" {{style display="none"}} />
     <div {{this.replaceCopyStatus}}>

--- a/website/app/components/doc/page/header/algolia-search/parts/htmlTemplatesItemPreview.js
+++ b/website/app/components/doc/page/header/algolia-search/parts/htmlTemplatesItemPreview.js
@@ -12,7 +12,7 @@ const htmlPreviewIcon = ({ html, iconName }) => html`
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <use href="#flight-${iconName}-24"></use>
+      <use href="#hds-icon-flight-${iconName}-24"></use>
     </svg>
   </div>
 `;

--- a/website/docs/components/icon/partials/code/how-to-use.md
+++ b/website/docs/components/icon/partials/code/how-to-use.md
@@ -20,7 +20,7 @@ It renders to this (where the `id` will be unique each time):
   aria-hidden="true"
   data-test-icon="alert-circle"
 >
-  <use href="#flight-alert-circle-16"></use>
+  <use href="#hds-icon-flight-alert-circle-16"></use>
 </svg>
 ```
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue in the showcase where the "success" and "error" icons for the statuses of various copy-related components are not rendering as expected. The following component examples have been fixed:

- CopyButton
- CoppySnippet
- CodeBlock - CopyButton

[Preview page](https://hds-showcase-git-project-solar-phase-1copy-but-aefa55-hashicorp.vercel.app/components/copy/button)

### :hammer_and_wrench: Detailed description

As part of #3584 the format for how icon svgs for the HdsIcon was refactored in two important ways which have broken some showcase examples

- The icons are now loaded dynamically based on their use and not all at once
- The `href` path of the svgs changed from `#flight-icon-name` to `#hds-icon-flight-icon-name`

This change broke showcase examples in various copy buttons where the "success" and "errored" states were forced to being visible by updating the `href` of the svg manually.

This PR fixes these examples by reworking how they are shown, and updates a couple docs to reference the new path format.

### :camera_flash: Screenshots

**Before**

<img width="320" height="141" alt="Screenshot 2026-03-10 at 10 48 45 AM" src="https://github.com/user-attachments/assets/819afedb-a375-4442-a446-bb3a0e7fc05d" />

**After**
<img width="320" height="152" alt="Screenshot 2026-03-10 at 10 49 01 AM" src="https://github.com/user-attachments/assets/74e71150-d930-4f70-badc-8c71771e5530" />


***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>