### PR TITLE
Website accessibility bugfixes

### DIFF
--- a/website/docs/components/accordion/partials/guidelines/guidelines.md
+++ b/website/docs/components/accordion/partials/guidelines/guidelines.md
@@ -98,13 +98,13 @@ Use the `flush` variant where space is limited such as within a [Card](/componen
 
 The toggle accepts many different types of content, from text-based content to nested HDS components or generic content.
 
-![Toggle type with basic text](/assets/components/accordion/toggle-content-text.png =690x*)
+![](/assets/components/accordion/toggle-content-text.png =690x*)
 <Doc::ImageCaption @text="Toggle type with basic text"/>
 
-![Toggle type with generic content](/assets/components/accordion/toggle-content-custom.png =690x*)
+![](/assets/components/accordion/toggle-content-custom.png =690x*)
 <Doc::ImageCaption @text="Toggle type with generic content"/>
 
-### Interactive 
+### Interactive
 
 Use this variant only when you need to put interactive elements such as a button or a link within the toggle area. Avoid placing complex elements that may compromise the usability and accessibility of the component.
 
@@ -135,10 +135,10 @@ The content type property is only relevant within Figma and doesn’t exist as a
 
 Content type supports any generic content, local components, or Helios components via an instance swap property (`genericInstance`) in Figma. In code, `yield` is supported.
 
-![Content type with basic text](/assets/components/accordion/content-text.png =690x*)
+![](/assets/components/accordion/content-text.png =690x*)
 <Doc::ImageCaption @text="Content type with basic text"/>
 
-![Content type with generic content](/assets/components/accordion/content-custom.png =690x*)
+![](/assets/components/accordion/content-custom.png =690x*)
 <Doc::ImageCaption @text="Content type with generic content"/>
 
 ## Nesting Accordions
@@ -147,7 +147,7 @@ Content type supports any generic content, local components, or Helios component
 
 **Differences between Figma and code**
 
-Nesting Accordions is only supported [in code](/components/accordion?tab=code#complex-html-content), as Figma does not support nesting an instance inside itself. 
+Nesting Accordions is only supported [in code](/components/accordion?tab=code#complex-html-content), as Figma does not support nesting an instance inside itself.
 
 While you can work around this by detaching the HDS component and turning it into a local component, then inserting the local component within the linked HDS component, we do not recommend this approach. Doing so means your local Accordion component will not receive future updates.
 !!!
@@ -156,7 +156,7 @@ Nesting Accordions can help organize complex content, but should be used in mode
 
 !!! Do
 
-Use nested Accordions for up to two layers of related content. You can nest `flush` Accordions within each other or inside `card` type Accordions. 
+Use nested Accordions for up to two layers of related content. You can nest `flush` Accordions within each other or inside `card` type Accordions.
 
 ![Example of a flush Accordion nested inside of a card within another flush Accordion](/assets/components/accordion/accordion-nesting-do.png)
 !!!
@@ -182,7 +182,7 @@ To ensure consistency across all products, use “Expand all” / “Collapse al
 
 Note that if an AccordionItem is static, the expand/collapse all feature will not affect its behavior.
 
-!!! Dont 
+!!! Dont
 
 Avoid using this feature if only one AccordionItem is visible.
 

--- a/website/docs/components/icon-tile/partials/accessibility/accessibility.md
+++ b/website/docs/components/icon-tile/partials/accessibility/accessibility.md
@@ -8,7 +8,7 @@ When used as recommended, there should not be any accessibility issues with this
 
 Because Icon Tiles are purely decorative, they’re hidden from screen readers by default.
 
-![Accessibility example of an IconTile](/assets/components/icon-tile/icontile-hidden-example.png =343x*)
+![An IconTile has the aria-hidden attribute set to true](/assets/components/icon-tile/icontile-hidden-example.png =343x*)
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/icon-tile/partials/guidelines/guidelines.md
+++ b/website/docs/components/icon-tile/partials/guidelines/guidelines.md
@@ -12,29 +12,28 @@
 
 Use **Neutral** if the object or page is not a specific product feature but something universal. For example, for a “Dashboard” or “User” page.
 
-![Icon Tile with neutral color and dashboard icon](/assets/components/icon-tile/icon-tile.png)
-
+![](/assets/components/icon-tile/icon-tile.png)
 
 Use a **product-specific color** for objects or pages directly related to a product. For example:
 
 - For a page showing a “Consul cluster”
 - In a card or table row that represents a “Consul cluster”
 
-![Product specific Icon Tiles](/assets/components/icon-tile/icon-tiles-colors.png)
+![](/assets/components/icon-tile/icon-tiles-colors.png)
 
-<Doc::ImageCaption @text="Examples of product-specific Icon Tiles"/>
+<Doc::ImageCaption @text="Examples of product-specific Icon Tiles, where each tile's background color is the product's brand color"/>
 
 ## Size
 
 Medium is the default size, but we recommend using the size that best fits the supporting text or UI. For example, don’t use large Icon Tiles in tables.
 
-![Icon Tile sizes](/assets/components/icon-tile/icon-tiles-sizes.png)
+![Icon Tile sizes: small, medium, and large](/assets/components/icon-tile/icon-tiles-sizes.png)
 
 ## Secondary icon
 
-A secondary icon can be added to provide additional context. For example, for an “Add user” page the “plus” icon indicates the action.
+A secondary icon can be added to provide additional context. For example, in features where an object or element is being added, an Icon Tile with a "plus" secondary icon reinforces the action.
 
-![Icon Tiles with secondary icon](/assets/components/icon-tile/icon-tiles-scondary-icon.png)
+![](/assets/components/icon-tile/icon-tiles-scondary-icon.png)
 
 ## Using with content
 
@@ -44,9 +43,9 @@ Use Icon Tiles as a decorative element or accessory next to a text label for the
 
 !!! Insight
 
-**Accessibility tips**
+**Accessibility tip**
 
-For more information on making interactive and non-interactive elements easily distinguishable, refer to the [WCAG 2.1 Guideline 1.4: Distinguishable.](https://www.w3.org/WAI/WCAG21/Understanding/distinguishable)
+For more information on making interactive and non-interactive elements easily distinguishable, refer to [WCAG Guideline 1.4: Distinguishable.](https://www.w3.org/WAI/WCAG22/Understanding/distinguishable)
 !!!
 
-Avoid placing Icon Tiles immediately next to secondary icon only button variants. Even though they visually look different, their proximity can confuse users because they share similar characteristics. [Distinguishability](https://www.w3.org/WAI/WCAG21/Understanding/distinguishable), an accessibility standard, discourages interfaces from using elements that look alike but behave differently when in close visual proximity. 
+Avoid placing Icon Tiles immediately next to secondary icon-only Button variants. Even though they visually look different, their proximity can confuse users because they share similar characteristics. [Distinguishability](https://www.w3.org/WAI/WCAG22/Understanding/distinguishable) discourages the use of elements that look alike but behave differently when in close visual proximity.

--- a/website/docs/components/icon-tile/partials/guidelines/overview.md
+++ b/website/docs/components/icon-tile/partials/guidelines/overview.md
@@ -1,1 +1,1 @@
-Icon Tiles represent objects and resources unrelated or directly related to a product.
+Icon Tiles visually identify product-related entities and supporting resources, which can help some users quickly scan and recognize key concepts.

--- a/website/docs/components/pagination/partials/guidelines/guidelines.md
+++ b/website/docs/components/pagination/partials/guidelines/guidelines.md
@@ -11,7 +11,7 @@
 
 ## Numbered vs Compact
 
-!!! Callout 
+!!! Callout
 
 We strongly suggest that you talk to your engineering team to see which pagination variant is right for your project.
 
@@ -23,10 +23,10 @@ Cursor-based pagination allows users to navigate to the next or previous set of 
 
 Offset or page-based pagination divides a dataset into pages containing a default or user-determined number of records, and allows users navigate to any particular page. In most cases, the numbered pagination provides a better user experience. It allows users to jump between pages and always return to the first page or go to the last page without navigating through the pages manually.
 
-![Supported by offset (page-based) pagination.](/assets/components/pagination/pagination-offset-example.png)
+![](/assets/components/pagination/pagination-offset-example.png)
 <Doc::ImageCaption @text="Supported by offset (page-based) pagination."/>
 
-![Supported by offset and cursor based pagination.](/assets/components/pagination/pagination-cursor-example.png)
+![](/assets/components/pagination/pagination-cursor-example.png)
 <Doc::ImageCaption @text="Supported by offset and cursor based pagination."/>
 
 ## Truncation
@@ -69,10 +69,10 @@ When pairing the pagination or pagination bar with your content, we recommend le
 
 If your product uses a significantly higher or lower spacing scale, increase or decrease the spacing accordingly.
 
-![Pagination paired with a Table](/assets/components/pagination/pagination-spacing-tables.png)
+![](/assets/components/pagination/pagination-spacing-tables.png)
 <Doc::ImageCaption @text="Pagination paired with a Table"/>
 
-![Pagination paired with other types of content](/assets/components/pagination/pagination-spacing-not-contained.png)
+![](/assets/components/pagination/pagination-spacing-not-contained.png)
 <Doc::ImageCaption @text="Pagination paired with other types of content"/>
 
 ## Pagination and filtering

--- a/website/docs/components/table/advanced-table/partials/guidelines/guidelines.md
+++ b/website/docs/components/table/advanced-table/partials/guidelines/guidelines.md
@@ -29,7 +29,7 @@ Sorting is not supported for nested rows at this time.
 - In addition to standard sorting methods (like alphabetical or chronological), domain-specific sorting, such as by status severity, can also be useful.
 - Sorting is not relevant for all content and should be applied thoughtfully.
 
-![A group of 4 Advanced Table header cells, with each variant of sort button: no sort button, the default unsorted, sorted ascending, and sorted descending.](/assets/components/table/advanced-table/table-sorting.png)
+![](/assets/components/table/advanced-table/table-sorting.png)
 
 ### Tooltips
 
@@ -40,7 +40,7 @@ Some examples where it may be useful to include additional context in a tooltip 
 - When the label contains a product or HashiCorp-specific term.
 - When the label refers to a setting that can be changed elsewhere in the application.
 
-![Tooltips in a Header Column](/assets/components/table/advanced-table/table-tooltip-example.png)
+![](/assets/components/table/advanced-table/table-tooltip-example.png)
 
 ### Width
 
@@ -67,7 +67,7 @@ The content's alignment can impact readability and scannability. The proper alig
 
 Use consistent alignment between the header label and the cell content in a column.
 
-![An Advanced Table with two columns, the first column is left aligned and the second is right aligned.](/assets/components/table/advanced-table/table-alignment-do.png)
+![](/assets/components/table/advanced-table/table-alignment-do.png)
 
 !!!
 
@@ -75,7 +75,7 @@ Use consistent alignment between the header label and the cell content in a colu
 
 Avoid misaligned header labels and content.
 
-![An Advanced Table with two columns, the header of the first column is left aligned and the cell below is right aligned. The header of the second column is right aligned and the cell below is left aligned.](/assets/components/table/advanced-table/table-alignment-dont.png)
+![](/assets/components/table/advanced-table/table-alignment-dont.png)
 
 !!!
 
@@ -110,7 +110,7 @@ Common examples of right alignment include:
 
 Don’t align content of varied lengths to the right. This can make it difficult to read by forcing an unnatural [reading pattern](/patterns/button-organization?tab=research#layout-and-reading-patterns).
 
-![Column with badges that have different length labels end aligned. The badge labels are "Successful", "Needs confirmation", and "Error".](/assets/components/table/advanced-table/end-alignment-variable-length.png)
+![](/assets/components/table/advanced-table/end-alignment-variable-length.png)
 
 !!!
 
@@ -144,7 +144,7 @@ Actions related to moving columns are displayed in a context menu in the table h
 - Move column: moves focus to the reordering handle
 - Move column to start/end: moves the column to the first or last position in the table unless the column is already in this position.
 
-![The open context menu in the Advanced Table displaying "Move column", "Move column to start", and "Move column to end" actions.](/assets/components/table/advanced-table/advanced-table-reorder-context-menu.png)
+![](/assets/components/table/advanced-table/advanced-table-reorder-context-menu.png)
 
 ### Resizing columns
 
@@ -161,13 +161,13 @@ The Figma component does not support this resizing feature. Instead, we publish 
 
 When resizable columns are enabled, actions related to each function are rendered in a context menu in the table header. These functions are not customizable.
 
-![An example of the open context menu in the Advanced Table displaying an action to reset the width of the column](/assets/components/table/advanced-table/advanced-table-context-menu.png)
+![An open context menu in the Advanced Table displays two options; resize column, and reset column width](/assets/components/table/advanced-table/advanced-table-context-menu.png)
 
 #### Minimum and maximum width
 
 To prevent a column from being resized beyond a reasonable amount, we enforce a default minimum width of `150px` and a maximum width of `800px`. These can be overridden via the [component API](/components/table/advanced-table?tab=code#advancedtable) if necessary.
 
-![An example of a column being resized to the minimum default width](/assets/components/table/advanced-table/advanced-table-resize-min-width.png)
+![](/assets/components/table/advanced-table/advanced-table-resize-min-width.png)
 
 ## Column and row span
 
@@ -189,7 +189,7 @@ To prevent a column from being resized beyond a reasonable amount, we enforce a 
 
 Expandable rows let users show or hide more content without navigating away from the table. The expanded content should align with the header labels, even if the parent row includes minimal data.
 
-![Advanced Table expandable rows. The parent rows display a summary of a Hashicorp product and the total price, the children rows show a breakdown of each billing item from that product and their individual cost.](/assets/components/table/advanced-table/expandable-rows.png)
+![](/assets/components/table/advanced-table/expandable-rows.png)
 
 !!! Dont
 
@@ -203,7 +203,7 @@ Avoid using expandable rows when data is not structured in parent-child relation
 
 Avoid using different density settings for parent and child rows.
 
-![Advanced Table with default height parent rows and short density nested rows.](/assets/components/table/advanced-table/advanced-table-density-mix.png)
+![Advanced Table with default height parent rows and short density nested rows is something to avoid](/assets/components/table/advanced-table/advanced-table-density-mix.png)
 
 !!!
 
@@ -217,16 +217,16 @@ The Expand/Collapse All button allows users to expand or collapse all rows, incl
 
 The Advanced Table supports any combination of expanded or collapsed rows on load. The button reflects the initial state.
 
-![Expand all button with an expand icon.](/assets/components/table/advanced-table/expandable-rows-expand-all.png)
+![](/assets/components/table/advanced-table/expandable-rows-expand-all.png)
 <Doc::ImageCaption @text="The “Expand All” button displays if any rows are currently collapsed" />
 
-![Expand all button with a collapse icon.](/assets/components/table/advanced-table/expandable-rows-collapse-all.png)
+![](/assets/components/table/advanced-table/expandable-rows-collapse-all.png)
 <Doc::ImageCaption @text="“Collapse All” button displays if all rows are expanded." />
 
 ##### Collapsed state
 
 ![](/assets/components/table/advanced-table/expandable-rows-expand-state.png)
-<Doc::ImageCaption @text="Clicking “Expand All” expands all rows, including nested rows."/>
+<Doc::ImageCaption @text="Interacting with the “Expand All” button expands all rows, including nested rows."/>
 
 ##### Expanded state
 
@@ -252,7 +252,7 @@ Striping enhances readability by alternating row colors, making it easier to sca
 - Non-Nested Advanced Tables: Striping starts with the second row, distinguishing it from the header.
 - Nested Advanced Tables: Child rows are automatically striped, while parent rows remain unstriped to visually reinforce hierarchy. This behavior cannot be disabled.
 
-![Advanced Tables with row striping have rows that alternate between white and light grey background color.](/assets/components/table/advanced-table/advanced-table-striping.png)
+![](/assets/components/table/advanced-table/advanced-table-striping.png)
 
 ### Placement
 
@@ -265,7 +265,7 @@ The row placement property is only relevant within Figma and doesn’t exist as 
 
 The `rowPlacement` property determines the border radius of a cell. It is only available on cells where the `colPlacement` property is set to `start` or `end`.
 
-![The cell with column placement end and row placement end has a border radius set on the bottom right corner.](/assets/components/table/advanced-table/table-row-placement.png)
+![](/assets/components/table/advanced-table/table-row-placement.png)
 
 ## Cells
 
@@ -294,9 +294,9 @@ There are a few things to consider when implementing a sticky header or column:
 
 If `hasStickyFirstColumn` is set to true or false in the Ember component, a control will be exposed in the context menu allowing users to "Pin" and "Unpin" the first column in the Advanced Table.
 
-![An Advanced Table with the context menu open and a single "Pin column" option](/assets/components/table/advanced-table/advanced-table-pin-column.png)
+![With the sticky column option set, the Advanced Table will have a context menu in the column header cell with a single option to pin column](/assets/components/table/advanced-table/advanced-table-pin-column.png)
 
-![An Advanced Table with a pinned column with the context menu open and a single "Unpin column" option](/assets/components/table/advanced-table/advanced-table-unpin-column.png)
+![Once pinned, the same context menu in the column header cell will then contain single "Unpin column" option](/assets/components/table/advanced-table/advanced-table-unpin-column.png)
 
 ## Multi-Select
 
@@ -313,11 +313,11 @@ A multi-select pattern consists of:
 
 A "Select all" checkbox is used in the header row to allow the simultaneous selection or deselection of all child rows.
 
-![Example of multi-select in a table header](/assets/components/table/advanced-table/table-multi-select-header.png)
+![](/assets/components/table/advanced-table/table-multi-select-header.png)
 
 Individual checkboxes added to each row allow for the selection of that row.
 
-![Example of multi-select within table cells](/assets/components/table/advanced-table/table-multi-select-cells.png)
+![](/assets/components/table/advanced-table/table-multi-select-cells.png)
 
 For more details, see the [Multi-Select Table Pattern](https://helios.hashicorp.design/patterns/table-multi-select).
 
@@ -325,6 +325,6 @@ For more details, see the [Multi-Select Table Pattern](https://helios.hashicorp.
 
 The Advanced Table supports displaying an empty state using the [Application State](/components/application-state) component to display an informative message and prompt user action. There are several reasons an empty state may occur: the data set is empty, the applied filters return no results, etc.
 
-![An Advanced Table with filters applied and no results. The empty state explains that there are no results from the filters applied and has a button to clear the filters.](/assets/components/table/advanced-table/filter-bar-empty-state.png)
+![](/assets/components/table/advanced-table/filter-bar-empty-state.png)
 
 Displaying the empty state in the Ember component is handled automatically when the data model contains no entries. In Figma we provide a [template](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?m=auto&node-id=93099-20265&t=NoxgnXab3XEBcxIr-1) component that can be inserted in a design, while also including it in the [Advanced Table](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?m=auto&node-id=72039-7258&t=TyzLB01NVzEN2lsz-1) template components.

--- a/website/docs/patterns/filter-patterns/partials/guidelines/guidelines.md
+++ b/website/docs/patterns/filter-patterns/partials/guidelines/guidelines.md
@@ -6,10 +6,10 @@ A filtering pattern consists of a number of Helios components that work together
 
 A data set is a broad term for an array of items, objects, or related information presented as separate but related records. A data set is commonly represented via a [Table](/components/table/table) or [Advanced Table](/components/table/advanced-table) but may be expressed in other formats depending on the type of information.
 
-![Data set implemented using HDS Table component](/assets/patterns/filter-patterns/example-data-set-tabular-data.png =1048x*)
+![](/assets/patterns/filter-patterns/example-data-set-tabular-data.png =1048x*)
 <Doc::ImageCaption @text="Data set represented by a table"/>
 
-![Data set implemented using a grid of multiple HDS Card components ](/assets/patterns/filter-patterns/example-data-set-non-tabular-data.png =878x*)
+![](/assets/patterns/filter-patterns/example-data-set-non-tabular-data.png =878x*)
 <Doc::ImageCaption @text="Data set represented by a grid"/>
 
 ### Filters
@@ -40,29 +40,29 @@ If space permits, filters can be positioned vertically in a **sidebar** at the p
 
 Page-level sidebars can be used to filter a data set presented in a non-tabular fashion and if filtering the content of the entire page is required. A sidebar should be oriented on the left (start) side of the viewport.
 
-![Vertical orientation of the filter bar](/assets/patterns/filter-patterns/layout-sidebar-left-page-level.png =559x*)
+![](/assets/patterns/filter-patterns/layout-sidebar-left-page-level.png =559x*)
 
 ##### In-line sidebar
 
 In-line sidebars can be used when the number of filterable parameters is minimal and if space permits.
 
-![Vertical orientation of the filter bar on the left](/assets/patterns/filter-patterns/layout-sidebar-left-inline.png =559x*)
+![](/assets/patterns/filter-patterns/layout-sidebar-left-inline.png =559x*)
 
 ### Applied filters
 
 Display the **applied filters** and provide the user with a method to clear all filters at once. Applied filters should be represented using a [Tag](/components/tag) component, which allows for the individual dismissal of a filter value.
 
-![Applied filters](/assets/patterns/filter-patterns/applied-filters.png =547x*)
+![](/assets/patterns/filter-patterns/applied-filters.png =547x*)
 
 #### Positioning with filter bars
 
 Applied filters should be positioned between the data set and the filter bar with a `16px` gap between elements.
 
-![Applied filters with filter bar positioning](/assets/patterns/filter-patterns/applied-filters-positioning-filter-bar.png =559x*)
+![](/assets/patterns/filter-patterns/applied-filters-positioning-filter-bar.png =559x*)
 
 If the filters are positioned in a page-level sidebar, the applied filters should be positioned directly above the dataset with a `16px` gap.
 
-![Applied filters with filter sidebar](/assets/patterns/filter-patterns/applied-filters-positioning-sidebar.png =559x*)
+![](/assets/patterns/filter-patterns/applied-filters-positioning-sidebar.png =559x*)
 
 ### Global filter functions
 
@@ -83,7 +83,7 @@ In the case a multiple filter functions, use the [Segmented Group](/components/s
 
 Use pagination to break down the filtered data set into pages. For more details, refer to the [Pagination](/components/pagination) guidelines.
 
-![Pagination example](/assets/patterns/filter-patterns/pagination-layout.png =559x*)
+![](/assets/patterns/filter-patterns/pagination-layout.png =559x*)
 
 ## Filtering methods
 
@@ -129,7 +129,7 @@ Communicate that values corresponding with a filter parameter have been applied 
 ![Filter bar with multiple filters selected from one parameter shows badges for each selected filter below](/assets/patterns/filter-patterns/filter-bar-dropdown-count.png =661x*)
 <Doc::ImageCaption @text="Communicating that two values within a parameter have been applied in the Dropdown"/>
 
-This, when combined with the applied filters provides a detailed snapshot of what specific filter values are applied to the data set and the relevant parameters that they correspond with.
+This, when combined with the applied filters, provides a detailed snapshot of what specific filter values are applied to the data set and the relevant parameters that they correspond with.
 
 ![Filter bar with multiple filters selected from multiple parameter shows badges for each selected filter below](/assets/patterns/filter-patterns/filter-bar-dropdown-count-multiple.png =728x*)
 <Doc::ImageCaption @text="Communicating that multiple filter parameters have been applied"/>
@@ -147,13 +147,13 @@ Depending on the applied filters, there may not be any records returned from a d
 
 Use the Helios [Application State](/components/application-state) component to communicate the lack of results and steps the user can take to remedy the situation.
 
-![Empty state example](/assets/patterns/filter-patterns/filter-patterns-empty-state.png =559x*)
+![](/assets/patterns/filter-patterns/filter-patterns-empty-state.png =559x*)
 
 ### Within applied filters
 
 If no filters have been applied, use a [Tooltip](/components/tooltip) coupled with the applied filters label to guide the user to the filter functions. Not only does this provide context and direct the user to the filters, but it prevents unnecessary layout shift upon applying filters.
 
-![Empty state in applied filters](/assets/patterns/filter-patterns/applied-filters-empty-state.png =450x*)
+![](/assets/patterns/filter-patterns/applied-filters-empty-state.png =450x*)
 
 ### Avoiding an empty state
 
@@ -163,7 +163,7 @@ If technically feasible, use the `count` property within the Dropdown ListItem t
 
 In this example, "Status > Pending" does not return any results.
 
-![Count property in ListItem](/assets/patterns/filter-patterns/avoid-empty-state-list-item-count.png)
+![](/assets/patterns/filter-patterns/avoid-empty-state-list-item-count.png)
 
 ### Reverting filters
 
@@ -187,9 +187,9 @@ These scenarios can clutter the UI, detracting from a table's primary purpose: o
 
 For simple data sets or Tables with a few columns, managing filter overflow may not be necessary. As more filters are applied, wrapping to new lines follows a common browser reflow pattern. This approach is predictable: the user's explicit filter action is directly reflected in the UI, providing positive reinforcement and allowing easy scanning of applied filters.
 
-![Basic example of applied filters and reflow](/assets/patterns/filter-patterns/applied-filters-overflow-basic-example.png)
+![](/assets/patterns/filter-patterns/applied-filters-overflow-basic-example.png)
 
-<Doc::ImageCaption @text="Allowing applied filters to wrap and reflow naturally." />
+<Doc::ImageCaption @text="Allow applied filters to wrap and reflow naturally." />
 
 #### Intermediate example
 
@@ -201,9 +201,9 @@ In this scenario, consider moving the applied filter [Tags](/components/tag) to 
 - Simplifies the UI, reducing cognitive load
 - Supports complex, interactive content within the Accordion (e.g., a "Clear all filters" function)
 
-![Intermediate example of applied filters within an open Accordion](/assets/patterns/filter-patterns/applied-filters-overflow-intermediate-example-open.png)
+![](/assets/patterns/filter-patterns/applied-filters-overflow-intermediate-example-open.png)
 
-<Doc::ImageCaption @text="Moving the applied filters to an Accordion." />
+<Doc::ImageCaption @text="Moving the applied filters to an Accordion can help to simplify a UI" />
 
 ### Filter parameters overflow
 
@@ -214,19 +214,19 @@ In complex data sets with numerous filterable parameters, considering establishi
 
 This approach offers a scalable solution for highly complex data sets while communicating a natural hierarchy of filter importance.
 
-![Trigger the overflow of filter parameters with a Button](/assets/patterns/filter-patterns/filter-parameters-overflow-more-filters.png)
+![](/assets/patterns/filter-patterns/filter-parameters-overflow-more-filters.png)
 
-<Doc::ImageCaption @text="Use a secondary Button to trigger a Flyout." />
+<Doc::ImageCaption @text="Use a secondary Button to trigger a Flyout to handle scenarios where there are many filter options" />
 
-![Display the overflow of filter parameters within a Flyout](/assets/patterns/filter-patterns/filter-parameters-overflow-flyout.png)
+![](/assets/patterns/filter-patterns/filter-parameters-overflow-flyout.png)
 
-<Doc::ImageCaption @text="Display the overflow of filter parameters in a Flyout" />
+<Doc::ImageCaption @text="Too many filter options? Display them in a Flyout" />
 
 #### Accordions within a Flyout
 
 For excessive filter parameters causing a long scroll in the [Flyout](/components/flyout), consider placing each parameter in a `flush`, `small` [Accordion](/components/accordion), and optionally, add an "Expand/Collapse All" Button. This approach gives users more control over the UI and allows for visual comparison between filter parameters.
 
-![Accordions within a Flyout containing filter parameters](/assets/patterns/filter-patterns/filter-parameters-overflow-flyout-accordion.png)
+![](/assets/patterns/filter-patterns/filter-parameters-overflow-flyout-accordion.png)
 
 <Doc::ImageCaption @text="Use Accordions within a Flyout to support an excessive number of filter parameters." />
 
@@ -237,7 +237,7 @@ A holistic approach to supporting overflow in a filter pattern will consist of:
 1. A filter bar with high-impact parameters, plus a secondary [Button](/components/button) that triggers a [Flyout](/components/flyout) for less common filters.
 2. An Accordion displaying all applied filters with a bulk dismiss option.
 
-![A holistic filter pattern support overflow](/assets/patterns/filter-patterns/filter-overflow-holistic-example.png)
+![](/assets/patterns/filter-patterns/filter-overflow-holistic-example.png)
 
 This contextual example demonstrates a comprehensive yet simple method of composing multiple Helios components to support these overflow concepts. It is interactive but doesn't include any functional logic.
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves the issue where accessibility tests were failing for the accordion page because images had `alt` attribute values that were repeated in the image caption.

### :hammer_and_wrench: Detailed description

Removed the `alt` attribute value, left the image caption.

### :camera_flash: Screenshots

No change to the UI. 

Failing tests: 
<img width="2478" height="838" alt="CleanShot 2026-04-07 at 12 16 02@2x" src="https://github.com/user-attachments/assets/d2695e03-0fe0-49c8-b7e3-ec83c1eb79d9" />

After fix:
<img width="1208" height="470" alt="CleanShot 2026-04-07 at 12 26 50@2x" src="https://github.com/user-attachments/assets/29df404f-5ea5-4f1d-b14f-fe47118548dc" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6169](https://hashicorp.atlassian.net/browse/HDS-6169)


***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6169]: https://hashicorp.atlassian.net/browse/HDS-6169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ