### PR TITLE
Clarified accessibility statements for form components

### DIFF
--- a/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/checkbox/partials/accessibility/accessibility.md
@@ -20,7 +20,7 @@
 
 ## Known issues
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, care should be used if considering this approach.
+If a link is used within a label, helper text, or error text associated with a form field, it will not be presented as a link to the user with a screen reader; only the text content is read out. If a link is present, this will cause an accessibility compliance failure. If additional context is required for the user, consider placing any text with links outside of the form fields. Consider placement of such text at the top of the form, or before the form field, so that the user is able to find the information before interacting with the form element.
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/form/checkbox/partials/code/how-to-use.md
+++ b/website/docs/components/form/checkbox/partials/code/how-to-use.md
@@ -34,9 +34,9 @@ To better fit your spacing requirements, choose between two different layout ori
 
 !!! Info
 
-**Accessibility consideration**
+**Accessibility compliance note**
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, care should be used when considering this feature. If needing to use a link, include a screen reader-only message that informs the user that some help text includes links, and additional keyboard exploration may be required.
+If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, if a link is present in a label, help text, or error text associated with a form field, it would be considered non-compliant. If additional links are needed to provide the user with information, place them outside of these elements. It is possible that you may wish to include some additional context for the form with instructions that include any necessary links.
 !!!
 
 The `Legend` and `HelperText` contextual components used in the Field component yield their content. This means you can also pass structured content.
@@ -65,7 +65,7 @@ A group of Checkboxes is made of one or more `Form::Checkbox::Field` components.
 
 #### Group with a single choice
 
-There may be use cases in which you need to create a Checkbox group that contains a single field element (e.g., to show the `Legend` in a similar position for other control’s labels). 
+There may be use cases in which you need to create a Checkbox group that contains a single field element (e.g., to show the `Legend` in a similar position for other control’s labels).
 
 [[code-snippets/checkbox-group-one-item]]
 
@@ -104,9 +104,9 @@ In addition to the checked and unchecked states, a checkbox can be in an indeter
 
 !!! Info
 
-**Accessibility consideration**
+**Accessibility compliance note**
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, care should be used when considering this feature. If needing to use a link, include a screen reader-only message that informs the user that some help text includes links, and additional keyboard exploration may be required.
+Do not use a link is used within a label, helper text, or error text associated with a form field. It will not be presented as a link to the user with a screen reader; only the text content is read out. Refer to the accessibility guidance for this component for additional information.
 !!!
 
 The `Label` and `HelperText` contextual components used in the Field component yield their content. This means you can also pass structured content.
@@ -143,7 +143,7 @@ This component supports use of `...attributes`. This means you can use all the s
 
 #### Events handling
 
-Because this component supports use of `...attributes`, you can use all the usual Ember techniques for event handling (e.g., `input`, `change`), validation, etc. 
+Because this component supports use of `...attributes`, you can use all the usual Ember techniques for event handling (e.g., `input`, `change`), validation, etc.
 
 [[code-snippets/checkbox-field-events]]
 
@@ -157,7 +157,7 @@ The Base element is intended for rare cases where the Field or Group components 
 
 **Consumer responsibility**
 
-`Form::Checkbox::Base` does not come with built-in accessibility functionality. It is the responsibility of the product team to ensure the implementation is conformant.
+`Form::Checkbox::Base` does not come with built-in accessibility functionality. It is the responsibility of the product team to ensure the implementation meets compliance requirements.
 !!!
 
 A basic invocation creates an `<input type="checkbox">` control with an automatically generated `ID` attribute.

--- a/website/docs/components/form/file-input/partials/specifications/states.md
+++ b/website/docs/components/form/file-input/partials/specifications/states.md
@@ -6,5 +6,5 @@
 
 **Accessibility consideration**
 
-Because disabled states completely remove the interactive function of an element, it can be challenging for a user to understand why it has been disabled and/or why they cannot interact with that element. For this reason, we recommend using disabled fields sparingly and with intention. Instead, consider using methods like enabling or hiding the element. Read more about [when to enable vs hide](/patterns/disabled-patterns).
+The `disabled` attribute completely remove the element from the accessibility tree, it will be hidden from a user with assistive technology. This is different from the `readonly` attribute, which will remain available for all users, but inform them that the element is not available to be edited. We recommend careful consideration when using these attributes; see [when to enable vs hide](/patterns/disabled-patterns) for more information.
 !!!

--- a/website/docs/components/form/key-value-inputs/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/key-value-inputs/partials/accessibility/accessibility.md
@@ -2,7 +2,7 @@
 
 <Doc::Badge @type="warning">Conditionally conformant</Doc::Badge>
 
-To be conformant, a Legend must be included in the `:header` named block identifying the purpose of the input groups.
+To achieve accessibility compliance, a `legend` must be included in the `:header` named block identifying the purpose of the input groups. See the code samples for this component for examples.
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/form/masked-input/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/masked-input/partials/accessibility/accessibility.md
@@ -36,7 +36,7 @@ Activates toggle to show/hide the input value
 
 ## Known issues
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, care should be used when considering this feature.
+If a link is used within a label, helper text, or error text associated with a form field, it will not be presented as a link to the user with a screen reader; only the text content is read out. If a link is present, this will cause an accessibility compliance failure. If additional context is required for the user, consider placing any text with links outside of the form fields. Consider placement of such text at the top of the form, or before the form field, so that the user is able to find the information before interacting with the form element.  
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/form/primitives/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/primitives/partials/accessibility/accessibility.md
@@ -6,7 +6,7 @@ Form Primitives aren’t conformant until used in conjunction with the other com
 
 ## Known issues
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, care should be used when considering this feature.
+If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, we discourage use of links within labels, helper text, or error text when associated with input elements.
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/form/primitives/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/primitives/partials/accessibility/accessibility.md
@@ -6,7 +6,7 @@ Form Primitives aren’t conformant until used in conjunction with the other com
 
 ## Known issues
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, we discourage use of links within labels, helper text, or error text when associated with input elements.
+If a link is used within a label, helper text, or error text associated with a form field, it will not be presented as a link to the user with a screen reader; only the text content is read out. If a link is present, this will cause an accessibility compliance failure. If additional context is required for the user, consider placing any text with links outside of the form fields. Consider placement of such text at the top of the form, or before the form field, so that the user is able to find the information before interacting with the form element.
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/radio-card/partials/accessibility/accessibility.md
@@ -16,7 +16,7 @@
 
 **Links within labels, helper text, or error text**
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. We understand avoiding links within help/error text or labels may be impossible, but we recommend using this method sparingly.
+If a link is used within a label, helper text, or error text associated with a form field, it will not be presented as a link to the user with a screen reader; only the text content is read out. If a link is present, this will cause an accessibility compliance failure. If additional context is required for the user, consider placing any text with links outside of the form fields. Consider placement of such text at the top of the form, or before the form field, so that the user is able to find the information before interacting with the form element.
 !!!
 
 ## Keyboard navigation

--- a/website/docs/components/form/text-input/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/text-input/partials/accessibility/accessibility.md
@@ -14,7 +14,7 @@
 
 ## Known issues
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, care should be used when considering this feature.
+If a link is used within a label, helper text, or error text associated with a form field, it will not be presented as a link to the user with a screen reader; only the text content is read out. If a link is present, this will cause an accessibility compliance failure. If additional context is required for the user, consider placing any text with links outside of the form fields. Consider placement of such text at the top of the form, or before the form field, so that the user is able to find the information before interacting with the form element.
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/form/textarea/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/textarea/partials/accessibility/accessibility.md
@@ -10,11 +10,11 @@
 
 <Doc::Badge @type="warning">Conditionally conformant</Doc::Badge>
 
-`Form::Textarea::Base` is not conformant until it has an accessible name. 
+`Form::Textarea::Base` is not conformant until it has an accessible name.
 
 ## Known issues
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, care should be used when considering this feature.
+If a link is used within a label, helper text, or error text associated with a form field, it will not be presented as a link to the user with a screen reader; only the text content is read out. If a link is present, this will cause an accessibility compliance failure. If additional context is required for the user, consider placing any text with links outside of the form fields. Consider placement of such text at the top of the form, or before the form field, so that the user is able to find the information before interacting with the form element.
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/form/toggle/partials/accessibility/accessibility.md
+++ b/website/docs/components/form/toggle/partials/accessibility/accessibility.md
@@ -4,11 +4,11 @@
 
 <Doc::Badge @type="warning">Conditionally conformant</Doc::Badge>
 
-`Form::Toggle::Base` is not conformant until it has an accessible name. 
+`Form::Toggle::Base` is not conformant until it has an accessible name.
 
 ## Known issues
 
-If a link is used within a label, helper text, or error text, it will not be presented as a link to the user with a screen reader; only the text content is read out. As such, care should be used when considering this feature.
+If a link is used within a label, helper text, or error text associated with a form field, it will not be presented as a link to the user with a screen reader; only the text content is read out. If a link is present, this will cause an accessibility compliance failure. If additional context is required for the user, consider placing any text with links outside of the form fields. Consider placement of such text at the top of the form, or before the form field, so that the user is able to find the information before interacting with the form element.
 
 ## Applicable WCAG Success Criteria
 

--- a/website/docs/components/pagination/partials/guidelines/guidelines.md
+++ b/website/docs/components/pagination/partials/guidelines/guidelines.md
@@ -11,7 +11,7 @@
 
 ## Numbered vs Compact
 
-!!! Callout 
+!!! Callout
 
 We strongly suggest that you talk to your engineering team to see which pagination variant is right for your project.
 
@@ -23,10 +23,10 @@ Cursor-based pagination allows users to navigate to the next or previous set of 
 
 Offset or page-based pagination divides a dataset into pages containing a default or user-determined number of records, and allows users navigate to any particular page. In most cases, the numbered pagination provides a better user experience. It allows users to jump between pages and always return to the first page or go to the last page without navigating through the pages manually.
 
-![Supported by offset (page-based) pagination.](/assets/components/pagination/pagination-offset-example.png)
+![](/assets/components/pagination/pagination-offset-example.png)
 <Doc::ImageCaption @text="Supported by offset (page-based) pagination."/>
 
-![Supported by offset and cursor based pagination.](/assets/components/pagination/pagination-cursor-example.png)
+![](/assets/components/pagination/pagination-cursor-example.png)
 <Doc::ImageCaption @text="Supported by offset and cursor based pagination."/>
 
 ## Truncation
@@ -69,10 +69,10 @@ When pairing the pagination or pagination bar with your content, we recommend le
 
 If your product uses a significantly higher or lower spacing scale, increase or decrease the spacing accordingly.
 
-![Pagination paired with a Table](/assets/components/pagination/pagination-spacing-tables.png)
+![](/assets/components/pagination/pagination-spacing-tables.png)
 <Doc::ImageCaption @text="Pagination paired with a Table"/>
 
-![Pagination paired with other types of content](/assets/components/pagination/pagination-spacing-not-contained.png)
+![](/assets/components/pagination/pagination-spacing-not-contained.png)
 <Doc::ImageCaption @text="Pagination paired with other types of content"/>
 
 ## Pagination and filtering


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR resolves the issue where accessibility compliance language for form elements was not clear enough for consumers.



### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6155](https://hashicorp.atlassian.net/browse/HDS-6155)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6155]: https://hashicorp.atlassian.net/browse/HDS-6155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ