### PR TITLE
Apply a set of overrides to address flagged secvuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
       "minimatch@<3.0.5": "3.1.2",
       "qs": "6.14.1",
       "serialize-javascript": "7.0.3",
+      "socket.io-parser": "4.2.6",
       "systeminformation": "5.31.0",
       "undici": "6.24.0",
       "underscore": "1.13.8"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "overrides": {
       "@glimmer/component": "^2.0.0",
       "basic-ftp": "5.2.0",
+      "flatted": "3.4.2",
       "ember-composable-helpers": "npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11",
       "js-yaml@3": "3.14.2",
       "js-yaml@4": "4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ settings:
 overrides:
   '@glimmer/component': ^2.0.0
   basic-ftp: 5.2.0
+  flatted: 3.4.2
   ember-composable-helpers: npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11
   js-yaml@3: 3.14.2
   js-yaml@4: 4.1.1
@@ -7403,11 +7404,8 @@ packages:
   flat-cache@6.1.12:
     resolution: {integrity: sha512-U+HqqpZPPXP5d24bWuRzjGqVqUcw64k4nZAbruniDwdRg0H10tvN7H6ku1tjhA4rg5B9GS3siEvwO2qjJJ6f8Q==}
 
-  flatted@2.0.2:
-    resolution: {integrity: sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==}
-
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   flow-parser@0.258.1:
     resolution: {integrity: sha512-Y8CrO98EcXVCiYE4s5z0LTMbeYjKyd3MAEUJqxA7B8yGRlmdrG5UDqq4pVrUAfAu2tMFgpQESvBhBu9Xg1tpow==}
@@ -21286,35 +21284,33 @@ snapshots:
 
   flat-cache@2.0.1:
     dependencies:
-      flatted: 2.0.2
+      flatted: 3.4.2
       rimraf: 2.6.3
       write: 1.0.3
 
   flat-cache@3.2.0:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
       rimraf: 3.0.2
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
   flat-cache@5.0.0:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
   flat-cache@6.1.12:
     dependencies:
       cacheable: 1.10.3
-      flatted: 3.3.3
+      flatted: 3.4.2
       hookified: 1.11.0
 
-  flatted@2.0.2: {}
-
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   flow-parser@0.258.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   minimatch@<3.0.5: 3.1.2
   qs: 6.14.1
   serialize-javascript: 7.0.3
+  socket.io-parser: 4.2.6
   systeminformation: 5.31.0
   undici: 6.24.0
   underscore: 1.13.8
@@ -10826,8 +10827,8 @@ packages:
   socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
 
-  socket.io-parser@4.2.4:
-    resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
 
   socket.io@4.8.1:
@@ -25477,10 +25478,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.4:
+  socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -25492,7 +25493,7 @@ snapshots:
       debug: 4.3.7
       engine.io: 6.6.2
       socket.io-adapter: 2.5.5
-      socket.io-parser: 4.2.4
+      socket.io-parser: 4.2.6
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
### :pushpin: Summary

Apply two overrides in the root `package.json` to address a set of [flagged secvuln](https://github.com/hashicorp/design-system/security/code-scanning) due this week:

- `flatted` to 3.4.2 (used by many eslint and typescript-related deps)
- `socket.io-parser` to 4.2.6 (used by ember-cli 6.4.0 via testem)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5912](https://hashicorp.atlassian.net/browse/HDS-5912)

***


[HDS-5912]: https://hashicorp.atlassian.net/browse/HDS-5912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ