### PR TITLE
[Project Solar / Phase 1 / Follow-up] Fix issue in extraction of Carbon tokens when color value is in "modern" `rgb()` format

### DIFF
--- a/packages/tokens/dist/docs/products/themed-tokens.json
+++ b/packages/tokens/dist/docs/products/themed-tokens.json
@@ -10501,8 +10501,8 @@
         "default": "#fafafa",
         "cds-g0": "#c6c6c6",
         "cds-g10": "#c6c6c6",
-        "cds-g90": "#8d8d8d",
-        "cds-g100": "#8d8d8d"
+        "cds-g90": "rgba(141, 141, 141, 0.3)",
+        "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
       "original": {
         "$type": "color",
@@ -29285,8 +29285,8 @@
         "default": "#f4f4f4",
         "cds-g0": "#c6c6c6",
         "cds-g10": "#c6c6c6",
-        "cds-g90": "#8d8d8d",
-        "cds-g100": "#8d8d8d"
+        "cds-g90": "rgba(141, 141, 141, 0.3)",
+        "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
       "original": {
         "$type": "color",
@@ -48069,8 +48069,8 @@
         "default": "#ffffff",
         "cds-g0": "#c6c6c6",
         "cds-g10": "#c6c6c6",
-        "cds-g90": "#8d8d8d",
-        "cds-g100": "#8d8d8d"
+        "cds-g90": "rgba(141, 141, 141, 0.3)",
+        "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
       "original": {
         "$type": "color",
@@ -66848,13 +66848,13 @@
     "token-button-surface-color-disabled": {
       "key": "{button.surface.color.disabled}",
       "$type": "color",
-      "$value": "#8d8d8d",
+      "$value": "rgba(141, 141, 141, 0.3)",
       "$modes": {
         "default": "#393939",
         "cds-g0": "#c6c6c6",
         "cds-g10": "#c6c6c6",
-        "cds-g90": "#8d8d8d",
-        "cds-g100": "#8d8d8d"
+        "cds-g90": "rgba(141, 141, 141, 0.3)",
+        "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
       "original": {
         "$type": "color",
@@ -85632,13 +85632,13 @@
     "token-button-surface-color-disabled": {
       "key": "{button.surface.color.disabled}",
       "$type": "color",
-      "$value": "#8d8d8d",
+      "$value": "rgba(141, 141, 141, 0.3)",
       "$modes": {
         "default": "#262626",
         "cds-g0": "#c6c6c6",
         "cds-g10": "#c6c6c6",
-        "cds-g90": "#8d8d8d",
-        "cds-g100": "#8d8d8d"
+        "cds-g90": "rgba(141, 141, 141, 0.3)",
+        "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
       "original": {
         "$type": "color",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
@@ -10494,8 +10494,8 @@
       "default": "#f4f4f4",
       "cds-g0": "#c6c6c6",
       "cds-g10": "#c6c6c6",
-      "cds-g90": "#8d8d8d",
-      "cds-g100": "#8d8d8d"
+      "cds-g90": "rgba(141, 141, 141, 0.3)",
+      "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
     "original": {
       "$type": "color",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
@@ -10494,8 +10494,8 @@
       "default": "#ffffff",
       "cds-g0": "#c6c6c6",
       "cds-g10": "#c6c6c6",
-      "cds-g90": "#8d8d8d",
-      "cds-g100": "#8d8d8d"
+      "cds-g90": "rgba(141, 141, 141, 0.3)",
+      "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
     "original": {
       "$type": "color",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
@@ -10489,13 +10489,13 @@
   {
     "key": "{button.surface.color.disabled}",
     "$type": "color",
-    "$value": "#8d8d8d",
+    "$value": "rgba(141, 141, 141, 0.3)",
     "$modes": {
       "default": "#262626",
       "cds-g0": "#c6c6c6",
       "cds-g10": "#c6c6c6",
-      "cds-g90": "#8d8d8d",
-      "cds-g100": "#8d8d8d"
+      "cds-g90": "rgba(141, 141, 141, 0.3)",
+      "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
     "original": {
       "$type": "color",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
@@ -10489,13 +10489,13 @@
   {
     "key": "{button.surface.color.disabled}",
     "$type": "color",
-    "$value": "#8d8d8d",
+    "$value": "rgba(141, 141, 141, 0.3)",
     "$modes": {
       "default": "#393939",
       "cds-g0": "#c6c6c6",
       "cds-g10": "#c6c6c6",
-      "cds-g90": "#8d8d8d",
-      "cds-g100": "#8d8d8d"
+      "cds-g90": "rgba(141, 141, 141, 0.3)",
+      "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
     "original": {
       "$type": "color",

--- a/packages/tokens/dist/docs/products/themed-tokens/default.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/default.json
@@ -10500,8 +10500,8 @@
       "default": "#fafafa",
       "cds-g0": "#c6c6c6",
       "cds-g10": "#c6c6c6",
-      "cds-g90": "#8d8d8d",
-      "cds-g100": "#8d8d8d"
+      "cds-g90": "rgba(141, 141, 141, 0.3)",
+      "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
     "original": {
       "$type": "color",

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -10500,8 +10500,8 @@
       "default": "#fafafa",
       "cds-g0": "#c6c6c6",
       "cds-g10": "#c6c6c6",
-      "cds-g90": "#8d8d8d",
-      "cds-g100": "#8d8d8d"
+      "cds-g90": "rgba(141, 141, 141, 0.3)",
+      "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
     "original": {
       "$type": "color",

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -1269,7 +1269,7 @@
     --token-button-surface-color-critical-default: #da1e28;
     --token-button-surface-color-critical-focus: #da1e28;
     --token-button-surface-color-critical-hover: #b81921;
-    --token-button-surface-color-disabled: #8d8d8d;
+    --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
     --token-button-surface-color-primary-active: #002d9c;
     --token-button-surface-color-primary-default: #0f62fe;
     --token-button-surface-color-primary-focus: #0f62fe;
@@ -2132,7 +2132,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;
@@ -2988,7 +2988,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
@@ -1269,7 +1269,7 @@
     --token-button-surface-color-critical-default: #da1e28;
     --token-button-surface-color-critical-focus: #da1e28;
     --token-button-surface-color-critical-hover: #b81921;
-    --token-button-surface-color-disabled: #8d8d8d;
+    --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
     --token-button-surface-color-primary-active: #002d9c;
     --token-button-surface-color-primary-default: #0f62fe;
     --token-button-surface-color-primary-focus: #0f62fe;
@@ -2130,7 +2130,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
@@ -980,7 +980,7 @@
     --token-button-surface-color-critical-default: #da1e28;
     --token-button-surface-color-critical-focus: #da1e28;
     --token-button-surface-color-critical-hover: #b81921;
-    --token-button-surface-color-disabled: #8d8d8d;
+    --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
     --token-button-surface-color-primary-active: #002d9c;
     --token-button-surface-color-primary-default: #0f62fe;
     --token-button-surface-color-primary-focus: #0f62fe;
@@ -1841,7 +1841,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
@@ -115,7 +115,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
@@ -115,7 +115,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;

--- a/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
@@ -1284,7 +1284,7 @@
     --token-button-surface-color-critical-default: #da1e28;
     --token-button-surface-color-critical-focus: #da1e28;
     --token-button-surface-color-critical-hover: #b81921;
-    --token-button-surface-color-disabled: #8d8d8d;
+    --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
     --token-button-surface-color-primary-active: #002d9c;
     --token-button-surface-color-primary-default: #0f62fe;
     --token-button-surface-color-primary-focus: #0f62fe;
@@ -2589,7 +2589,7 @@
     --token-button-surface-color-critical-default: #da1e28;
     --token-button-surface-color-critical-focus: #da1e28;
     --token-button-surface-color-critical-hover: #b81921;
-    --token-button-surface-color-disabled: #8d8d8d;
+    --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
     --token-button-surface-color-primary-active: #002d9c;
     --token-button-surface-color-primary-default: #0f62fe;
     --token-button-surface-color-primary-focus: #0f62fe;
@@ -3024,7 +3024,7 @@
     --token-button-surface-color-critical-default: #da1e28;
     --token-button-surface-color-critical-focus: #da1e28;
     --token-button-surface-color-critical-hover: #b81921;
-    --token-button-surface-color-disabled: #8d8d8d;
+    --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
     --token-button-surface-color-primary-active: #002d9c;
     --token-button-surface-color-primary-default: #0f62fe;
     --token-button-surface-color-primary-focus: #0f62fe;

--- a/packages/tokens/scripts/extract-carbon-parts/convertModernRgbToRgba.ts
+++ b/packages/tokens/scripts/extract-carbon-parts/convertModernRgbToRgba.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export const modernRgbColorFormatRegex: RegExp = /^rgb\(\s*(\d+)\s+(\d+)\s+(\d+)\s*\/\s*(\d+)%\s*\)$/;
+
+export function convertModernRgbToRgba(value: string): string {
+  const modernRgbMatch = value.match(modernRgbColorFormatRegex);
+
+  if (!modernRgbMatch) {
+    return value;
+  }
+
+  const [, red, green, blue, alphaPercentString] = modernRgbMatch;
+  const alphaPercent = Number.parseInt(alphaPercentString, 10);
+  const clampedAlphaPercent = Math.max(0, Math.min(100, alphaPercent));
+  const alpha = clampedAlphaPercent === 100 ? '1' : String(clampedAlphaPercent / 100);
+
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+}

--- a/packages/tokens/scripts/extract-carbon-parts/extractThemes.ts
+++ b/packages/tokens/scripts/extract-carbon-parts/extractThemes.ts
@@ -7,6 +7,7 @@ import { themes, buttonTokens, contentSwitcherTokens, notificationTokens, status
 
 import { CarbonDesignToken } from './@types/CarbonDesignTokens.js';
 
+import { modernRgbColorFormatRegex, convertModernRgbToRgba } from './convertModernRgbToRgba.ts';
 import { convertObjectToDtcgFormat } from './convertObjectToDtcgFormat.ts';
 import { saveCarbonDtcgTokensAsJsonFile } from './saveCarbonDtcgTokensAsJsonFile.ts';
 import { dimensionRegex } from './convertObjectToDtcgFormat.ts';
@@ -41,6 +42,7 @@ export async function extractThemes(): Promise<void> {
 
 // function that recursively iterates on an object and
 // - replaces any key named 'whiteTheme' with 'white'
+// - converts `rgb(** ** ** / *%)` colors to the standard `rgba(**, **, **, 0.*)` format
 // - removes "colorScheme" entries (irrelevant)
 // - removes entries whose value is an array (`breakpoints`)
 
@@ -58,7 +60,7 @@ function cleanupObj(obj: Record<string, any>): Record<string, any> {
   // For objects, create a new object with potentially renamed keys
   const result: Record<string, any> = {};
 
-  for (const [key, value] of Object.entries(obj)) {
+  for (let [key, value] of Object.entries(obj)) {
     // Skip "colorScheme" entries
     if (key === "colorScheme") {
       continue;
@@ -70,10 +72,19 @@ function cleanupObj(obj: Record<string, any>): Record<string, any> {
     }
 
     // Rename 'whiteTheme' key to 'white'
-    const newKey = key === 'whiteTheme' ? 'white' : key;
+    if (key === 'whiteTheme') {
+      key = 'white';
+    }
+
+    // replace `rgb(** ** ** / *%)` colors with `rgba(**, **, **, 0.*)`
+    // note: the reason is that the current version `1.6.0` of TinyColor does not support this format
+    // and it's used in the `color/css` transform in StyleDictionary, so the alpha value is ignored
+    if (typeof value === 'string' && value.match(modernRgbColorFormatRegex)) {
+      value = convertModernRgbToRgba(value);
+    }
 
     // Recursively process nested objects
-    result[newKey] = cleanupObj(value);
+    result[key] = cleanupObj(value);
   }
 
   return result;

--- a/packages/tokens/src/carbon-extracted/themes/button-tokens.json
+++ b/packages/tokens/src/carbon-extracted/themes/button-tokens.json
@@ -139,17 +139,17 @@
           },
           "g90": {
             "$type": "color",
-            "$value": "rgb(141 141 141 / 30%)",
+            "$value": "rgba(141, 141, 141, 0.3)",
             "group": "cds-themes",
             "private": true,
-            "cds-original-value": "rgb(141 141 141 / 30%)"
+            "cds-original-value": "rgba(141, 141, 141, 0.3)"
           },
           "g100": {
             "$type": "color",
-            "$value": "rgb(141 141 141 / 30%)",
+            "$value": "rgba(141, 141, 141, 0.3)",
             "group": "cds-themes",
             "private": true,
-            "cds-original-value": "rgb(141 141 141 / 30%)"
+            "cds-original-value": "rgba(141, 141, 141, 0.3)"
           }
         },
         "buttonPrimary": {

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -1269,7 +1269,7 @@
     --token-button-surface-color-critical-default: #da1e28;
     --token-button-surface-color-critical-focus: #da1e28;
     --token-button-surface-color-critical-hover: #b81921;
-    --token-button-surface-color-disabled: #8d8d8d;
+    --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
     --token-button-surface-color-primary-active: #002d9c;
     --token-button-surface-color-primary-default: #0f62fe;
     --token-button-surface-color-primary-focus: #0f62fe;
@@ -2132,7 +2132,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;
@@ -2988,7 +2988,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
@@ -1269,7 +1269,7 @@
     --token-button-surface-color-critical-default: #da1e28;
     --token-button-surface-color-critical-focus: #da1e28;
     --token-button-surface-color-critical-hover: #b81921;
-    --token-button-surface-color-disabled: #8d8d8d;
+    --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
     --token-button-surface-color-primary-active: #002d9c;
     --token-button-surface-color-primary-default: #0f62fe;
     --token-button-surface-color-primary-focus: #0f62fe;
@@ -2130,7 +2130,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
@@ -980,7 +980,7 @@
     --token-button-surface-color-critical-default: #da1e28;
     --token-button-surface-color-critical-focus: #da1e28;
     --token-button-surface-color-critical-hover: #b81921;
-    --token-button-surface-color-disabled: #8d8d8d;
+    --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
     --token-button-surface-color-primary-active: #002d9c;
     --token-button-surface-color-primary-default: #0f62fe;
     --token-button-surface-color-primary-focus: #0f62fe;
@@ -1841,7 +1841,7 @@
   --token-button-surface-color-critical-default: #da1e28;
   --token-button-surface-color-critical-focus: #da1e28;
   --token-button-surface-color-critical-hover: #b81921;
-  --token-button-surface-color-disabled: #8d8d8d;
+  --token-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
   --token-button-surface-color-primary-active: #002d9c;
   --token-button-surface-color-primary-default: #0f62fe;
   --token-button-surface-color-primary-focus: #0f62fe;


### PR DESCRIPTION
### :pushpin: Summary

After going down in a rabbit hole for a few hours, I’ve finally found out that there is an issue with a specific Carbon token for the `buttonDisabled` color in the `g90/g100` modes, where the value `rgb(141 141 141 / 30%)` is not interpreted correctly by StyleDictionary, more precisely by the underlying `TinyColor` library used in the `color/css` transform.

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the `cleanupObj` function to handle conversion of “modern” `rgb()` color format to “standard” `rgba()`
- updated the extracted Carbon tokens
- re-generated the files in output

### :camera_flash: Screenshots

<img width="930" height="706" alt="screenshot_6164" src="https://github.com/user-attachments/assets/fe147175-e293-4d6a-9121-a271113786af" />

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-6190

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>