### PR TITLE
Update component blueprint to use gts

### DIFF
--- a/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.gts
+++ b/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.gts
@@ -32,4 +32,11 @@ export default class Hds<%= classifiedModuleName %> extends Component<Hds<%= cla
 
     return classes.join(' ');
   }
+
+  <template>
+    {{! ADD YOUR TEMPLATE CONTENT HERE }}
+    <div class={{this.classNames}} ...attributes>
+      {{yield}}
+    </div>
+  </template>
 }

--- a/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.hbs
+++ b/showcase/blueprints/hds-component/files/src/components/hds/__name__/index.hbs
@@ -1,8 +1,0 @@
-{{!
-  Copyright IBM Corp. 2021, 2025
-  SPDX-License-Identifier: MPL-2.0
-}}
-{{! ADD YOUR TEMPLATE CONTENT HERE }}
-<div class={{this.classNames}} ...attributes>
-  {{yield}}
-</div>

--- a/showcase/blueprints/hds-component/index.js
+++ b/showcase/blueprints/hds-component/index.js
@@ -53,7 +53,7 @@ const updateHDSComponentsCSS = (options) => {
     firstComponentImportIndex,
     lastComponentImportIndex + 1,
   );
-  importLinesArray.push(`@use "../components/${name}";`);
+  importLinesArray.push(`@use "./${name}";`);
   const newImportLinesArray = importLinesArray
     .filter((line, index, self) => self.indexOf(line) === index)
     .sort();


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the blueprint used by `ember generate hds-component` to output a gts file.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>