### PR TITLE
`CopySnippet` - Translate string (HDS-6199)

### DIFF
--- a/.changeset/slick-cycles-shake.md
+++ b/.changeset/slick-cycles-shake.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/copy/snippet-->
+`CopySnippet` - translated string for button aria-label
+<!-- END -->

--- a/packages/components/src/components/hds/copy/snippet/index.gts
+++ b/packages/components/src/components/hds/copy/snippet/index.gts
@@ -12,6 +12,7 @@ import { HdsCopySnippetColorValues } from './types.ts';
 import HdsTextCode from '../../text/code.gts';
 import HdsIcon from '../../icon/index.gts';
 import hdsClipboard from '../../../../modifiers/hds-clipboard.ts';
+import hdsT from '../../../../helpers/hds-t.ts';
 
 import type { HdsCopySnippetColors } from './types.ts';
 import type { HdsClipboardModifierSignature } from '../../../../modifiers/hds-clipboard.ts';
@@ -149,7 +150,11 @@ export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
         onSuccess=this.onSuccess
         onError=this.onError
       }}
-      aria-label={{concat "copy " @textToCopy}}
+      aria-label={{hdsT
+        "hds.components.copy-snippet.button.aria-label"
+        textToCopy=@textToCopy
+        default=(concat "copy " @textToCopy)
+      }}
       ...attributes
     >
       <HdsTextCode class="hds-copy-snippet__text" @tag="span" @size="100">

--- a/packages/components/translations/hds/components/copy-snippet/en-us.yaml
+++ b/packages/components/translations/hds/components/copy-snippet/en-us.yaml
@@ -1,0 +1,2 @@
+button:
+  aria-label: Copy {textToCopy}

--- a/packages/components/translations/hds/components/copy-snippet/en-us.yaml
+++ b/packages/components/translations/hds/components/copy-snippet/en-us.yaml
@@ -1,2 +1,2 @@
 button:
-  aria-label: Copy {textToCopy}
+  aria-label: copy {textToCopy}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR translates previously hard-coded strings in the `CopySnippet` component's aria-label.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-6199](https://hashicorp.atlassian.net/browse/HDS-6199)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6199]: https://hashicorp.atlassian.net/browse/HDS-6199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ