### PR TITLE
`KeyValueInputs` -  Translate strings (HDS-6201)

### DIFF
--- a/.changeset/tiny-pumas-hunt.md
+++ b/.changeset/tiny-pumas-hunt.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
+<!-- START components/form/key-value-inputs -->
 `KeyValueInputs` - translated strings for `DeleteRowButton` and `Field` screen reader text
+<!-- END -->

--- a/.changeset/tiny-pumas-hunt.md
+++ b/.changeset/tiny-pumas-hunt.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`KeyValueInputs` - translated strings for `DeleteRowButton` and `Field` screen reader text

--- a/packages/components/src/components/hds/form/key-value-inputs/delete-row-button.gts
+++ b/packages/components/src/components/hds/form/key-value-inputs/delete-row-button.gts
@@ -5,6 +5,9 @@
 import Component from '@glimmer/component';
 import { modifier } from 'ember-modifier';
 import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+
+import type HdsIntlService from '../../../../services/hds-intl.ts';
 
 import HdsButton from '../../button/index.gts';
 
@@ -24,6 +27,8 @@ export interface HdsFormKeyValueInputsDeleteRowButtonSignature {
 }
 
 export default class HdsFormKeyValueInputsDeleteRowButton extends Component<HdsFormKeyValueInputsDeleteRowButtonSignature> {
+  @service declare readonly hdsIntl: HdsIntlService;
+
   private _onInsert = modifier(() => {
     if (this.args.onInsert) {
       this.args.onInsert();
@@ -43,7 +48,16 @@ export default class HdsFormKeyValueInputsDeleteRowButton extends Component<HdsF
   });
 
   get text(): string {
-    return this.args.text ?? `Delete row ${this.args.rowIndex + 1}`;
+    return (
+      this.args.text ??
+      this.hdsIntl.t(
+        'hds.components.form.key-value-inputs.delete-row-button.text',
+        {
+          default: 'Delete row {rowNumber}',
+          rowNumber: this.args.rowIndex + 1,
+        }
+      )
+    );
   }
 
   onClick = (): void => {

--- a/packages/components/src/components/hds/form/key-value-inputs/field.gts
+++ b/packages/components/src/components/hds/form/key-value-inputs/field.gts
@@ -26,6 +26,9 @@ import HdsFormSuperSelectSingleBase from '../super-select/single/base.gts';
 import HdsFormTextareaBase from '../textarea/base.gts';
 import HdsFormTextInputBase from '../text-input/base.gts';
 
+import { service } from '@ember/service';
+
+import type HdsIntlService from '../../../../services/hds-intl.ts';
 import type { AriaDescribedByComponent } from '../../../../utils/hds-aria-described-by.ts';
 
 export interface HdsFormKeyValueInputsFieldSignature {
@@ -96,6 +99,8 @@ export interface HdsFormKeyValueInputsFieldSignature {
 // @ts-expect-error: decorator function return type 'ClassOf<AriaDescribedBy>' is not assignable to 'typeof HdsFormField'
 @ariaDescribedBy
 export default class HdsFormKeyValueInputsField extends Component<HdsFormKeyValueInputsFieldSignature> {
+  @service declare readonly hdsIntl: HdsIntlService;
+
   private _onInsert = modifier(() => {
     if (this.args.onInsert) {
       this.args.onInsert();
@@ -113,7 +118,13 @@ export default class HdsFormKeyValueInputsField extends Component<HdsFormKeyValu
   }
 
   get labelHiddenText(): string {
-    return `row ${this.args.rowIndex + 1}`;
+    return this.hdsIntl.t(
+      'hds.components.form.key-value-inputs.field.label-hidden-text',
+      {
+        default: 'row {rowNumber}',
+        rowNumber: this.args.rowIndex + 1,
+      }
+    );
   }
 
   get labelIdPrefix(): string {

--- a/packages/components/translations/hds/components/form/key-value-inputs/en-us.yml
+++ b/packages/components/translations/hds/components/form/key-value-inputs/en-us.yml
@@ -1,5 +1,7 @@
 add-row-button:
   aria-description: Adds a new row of one or more inputs at the end of the form field. Press shift tab to move focus back to the newly added row.
   text: Add row
+delete-row-button:
+  text: "Delete row {rowNumber}"
 field:
   label-hidden-text: "row {rowNumber}"

--- a/packages/components/translations/hds/components/form/key-value-inputs/en-us.yml
+++ b/packages/components/translations/hds/components/form/key-value-inputs/en-us.yml
@@ -1,3 +1,5 @@
 add-row-button:
   aria-description: Adds a new row of one or more inputs at the end of the form field. Press shift tab to move focus back to the newly added row.
   text: Add row
+field:
+  label-hidden-text: "row {rowNumber}"


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR translates previously hard-coded strings in the `KeyValueInputs` screen reader text.

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-6201](https://hashicorp.atlassian.net/browse/HDS-6201)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6201]: https://hashicorp.atlassian.net/browse/HDS-6201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ