### PR TITLE
[Project Solar / Phase 1 / Follow-up] Fix `DialogPrimitive` header spacing

### DIFF
--- a/packages/components/src/styles/components/dialog-primitive.scss
+++ b/packages/components/src/styles/components/dialog-primitive.scss
@@ -89,6 +89,8 @@
 
   @include hds-apply-only-if-carbon() {
     position: relative;
+    // we increase the right padding to avoid that the content ends up below the dismiss button (which is absolutely positioned)
+    padding-right: calc(var(--token-dialog-primitive-padding-horizontal) + 32px);
   }
 }
 

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -4273,6 +4273,7 @@ button.hds-button[href]::after {
 .hds-mode-cds-g90 .hds-dialog-primitive__header,
 .hds-mode-cds-g100 .hds-dialog-primitive__header {
   position: relative;
+  padding-right: calc(var(--token-dialog-primitive-padding-horizontal) + 32px);
 }
 
 .hds-dialog-primitive__icon {

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -4930,6 +4930,7 @@ button.hds-button[href]::after {
 .hds-mode-cds-g90 .hds-dialog-primitive__header,
 .hds-mode-cds-g100 .hds-dialog-primitive__header {
   position: relative;
+  padding-right: calc(var(--token-dialog-primitive-padding-horizontal) + 32px);
 }
 
 .hds-dialog-primitive__icon {


### PR DESCRIPTION
### :pushpin: Summary

While reviewing https://github.com/hashicorp/design-system/pull/3809 I noticed that there was an issue in the implementation of the "carbonized" version of the `DialogPrimitive`, where the dismiss button would have `position: absolute` and the content of the header would end up below it, if too long.

This PR fixes the issue by increasing the right padding when the mode is "carbon".

<img width="430" height="251" alt="screenshot_6231" src="https://github.com/user-attachments/assets/ef100525-36db-4e7c-8c77-3c389c4ece2c" />

<img width="432" height="314" alt="screenshot_6230" src="https://github.com/user-attachments/assets/cbebcfe6-64cc-4d90-9e78-45f2d6e871f9" />

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-6228

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>