### PR TITLE
Use modern service imports in `showcase`

### DIFF
--- a/showcase/app/components/page-components/pagination/code-fragments/with-compact-and-routing.gts
+++ b/showcase/app/components/page-components/pagination/code-fragments/with-compact-and-routing.gts
@@ -4,7 +4,7 @@
  */
 import Component from '@glimmer/component';
 import { array } from '@ember/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 
 import USERS from 'showcase/mocks/user-data';

--- a/showcase/app/components/page-components/pagination/code-fragments/with-numbered-and-routing.gts
+++ b/showcase/app/components/page-components/pagination/code-fragments/with-numbered-and-routing.gts
@@ -5,7 +5,7 @@
 import Component from '@glimmer/component';
 import { array } from '@ember/helper';
 import { eq } from 'ember-truth-helpers';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 
 import USERS from 'showcase/mocks/user-data';

--- a/showcase/app/components/page-components/tabs/code-fragments/with-routing-and-nested-tabs.gts
+++ b/showcase/app/components/page-components/tabs/code-fragments/with-routing-and-nested-tabs.gts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 
 import ShwPlaceholder from 'showcase/components/shw/placeholder';

--- a/showcase/app/components/page-components/tabs/code-fragments/with-routing.gts
+++ b/showcase/app/components/page-components/tabs/code-fragments/with-routing.gts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 
 import ShwPlaceholder from 'showcase/components/shw/placeholder';

--- a/showcase/app/components/page-components/time/sub-sections/display.gts
+++ b/showcase/app/components/page-components/time/sub-sections/display.gts
@@ -4,7 +4,7 @@
  */
 import Component from '@glimmer/component';
 import style from 'ember-style-modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 import ShwTextH3 from 'showcase/components/shw/text/h3';

--- a/showcase/app/templates/application.gts
+++ b/showcase/app/templates/application.gts
@@ -5,7 +5,7 @@
 import Component from '@glimmer/component';
 import { pageTitle } from 'ember-page-title';
 import { LinkTo } from '@ember/routing';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 import type Owner from '@ember/owner';
 import { scheduleOnce } from '@ember/runloop';


### PR DESCRIPTION
### :pushpin: Summary

Replace the older import pattern `import { inject as service } from '@ember/service'` with the named `service` export across several components and the application template to align with the modern Ember API, improve consistency and avoid deprecation warnings.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
