### PR TITLE
Suppress deprecation warnings for fastboot in `website`

### DIFF
--- a/website/config/environment.js
+++ b/website/config/environment.js
@@ -23,6 +23,7 @@ module.exports = function (environment) {
 
     EmberENV: {
       EXTEND_PROTOTYPES: false,
+      LOG_STACKTRACE_ON_DEPRECATION: false,
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true


### PR DESCRIPTION
There is currently a lot of noise caused by the service inject deprecations, coming from various packages. This makes it very difficult to discover actual errors thrown by fastboot. I applied the `LOG_STACKTRACE_ON_DEPRECATION` config so fastboot output is much less noisy with deprecation warnings.

The alternative is patch those ember packages – I did try it locally, but as we update some of these ember dependencies we'll have to regenerate the patches.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
