### PR TITLE
`Tag` - Fix a runtime error when `ResizeObserver` is undefined

### DIFF
--- a/.changeset/polite-beds-behave.md
+++ b/.changeset/polite-beds-behave.md
@@ -1,0 +1,9 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/hds/tag -->
+
+`Tag` - Fixed a runtime error when `ResizeObserver` is undefined (e.g. SSR)
+
+<!-- END -->

--- a/packages/components/src/components/hds/tag/index.gts
+++ b/packages/components/src/components/hds/tag/index.gts
@@ -45,21 +45,25 @@ export interface HdsTagSignature {
 
 const overflowed = new TrackedWeakSet<Element>();
 
-const observer = new ResizeObserver((entries) => {
-  entries.forEach((entry) => {
-    const textContainer = entry.target.querySelector(
-      '.hds-tag__text-container'
-    );
-    if (
-      textContainer &&
-      textContainer.scrollHeight > textContainer.clientHeight
-    ) {
-      overflowed.add(entry.target);
-    } else {
-      overflowed.delete(entry.target);
-    }
+let observer: ResizeObserver | undefined;
+
+if (typeof ResizeObserver !== 'undefined') {
+  observer = new ResizeObserver((entries) => {
+    entries.forEach((entry) => {
+      const textContainer = entry.target.querySelector(
+        '.hds-tag__text-container'
+      );
+      if (
+        textContainer &&
+        textContainer.scrollHeight > textContainer.clientHeight
+      ) {
+        overflowed.add(entry.target);
+      } else {
+        overflowed.delete(entry.target);
+      }
+    });
   });
-});
+}
 
 export default class HdsTag extends Component<HdsTagSignature> {
   @tracked private _element?: HTMLElement;
@@ -72,11 +76,11 @@ export default class HdsTag extends Component<HdsTagSignature> {
 
   private _setUpObserver = modifier((element: HTMLElement) => {
     this._element = element;
-    observer.observe(element);
+    observer?.observe(element);
 
     return () => {
       if (this._element) {
-        observer.unobserve(this._element);
+        observer?.unobserve(this._element);
       }
       delete this._element;
     };


### PR DESCRIPTION
### :pushpin: Summary

Fixed a runtime error in our Tag component when `ResizeObserver` is undefined (e.g. SSR in `website`)

### :hammer_and_wrench: Detailed description

We use observers in other parts of our component library, but the Tag component is the only place where it's not encapsulated within the backing class (for performance reasons). Because the observer sits outside the component instance, it gets picked up during SSR and throws a hard error. This change will result in a much cleaner console output when running `website`, helping us debug any further issues, without impacting our consumers.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
