### PR TITLE
Update `eslint` in `tokens` package

### DIFF
--- a/packages/tokens/.npmignore
+++ b/packages/tokens/.npmignore
@@ -2,5 +2,6 @@
 /scripts
 
 /tsconfig.json
+/eslint.config.mjs
 
 /CONTRIBUTING.md

--- a/packages/tokens/eslint.config.mjs
+++ b/packages/tokens/eslint.config.mjs
@@ -1,0 +1,32 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['node_modules/', 'dist/'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['scripts/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-empty-object-type': 'off',
+    },
+  },
+  {
+    files: ['scripts/**/*.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+  }
+);

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -19,11 +19,12 @@
   "type": "module",
   "scripts": {
     "typecheck": "pnpm tsc --noEmit",
-    "lint": "pnpm eslint --quiet --ext .js,.ts",
+    "lint": "pnpm eslint --quiet .",
     "extract-carbon-tokens": "tsx ./scripts/extract-carbon-tokens",
     "build": "tsx ./scripts/build"
   },
   "devDependencies": {
+    "@eslint/js": "^9.27.0",
     "@carbon/colors": "^11.39.0",
     "@carbon/grid": "^11.42.0",
     "@carbon/layout": "^11.40.0",
@@ -36,8 +37,9 @@
     "@types/tinycolor2": "^1.4.6",
     "@typescript-eslint/eslint-plugin": "^8.18.1",
     "@typescript-eslint/parser": "^8.18.1",
-    "eslint": "^8.57.1",
+    "eslint": "^9.27.0",
     "fs-extra": "^11.2.0",
+    "globals": "^16.1.0",
     "lodash-es": "^4.18.1",
     "path": "^0.12.7",
     "prettier": "^3.4.2",
@@ -45,6 +47,7 @@
     "tinycolor2": "^1.6.0",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
+    "typescript-eslint": "^8.32.1",
     "typescript": "^5.7.2"
   }
 }

--- a/packages/tokens/scripts/build-parts/customFormatDocsJson.ts
+++ b/packages/tokens/scripts/build-parts/customFormatDocsJson.ts
@@ -11,11 +11,11 @@ export function customFormatDocsJsonFunction({ dictionary }: { dictionary: Dicti
   // Notice: this object shape is used also in the documentation so any updates
   // to this format should be reflected in the corresponding type definition.
   // See: https://github.com/search?q=repo%3Ahashicorp%2Fdesign-system%20%22dist%2Fdocs%2Fproducts%2Ftokens.json%22&type=code
-  const output: {}[] = [];
-  dictionary.allTokens.forEach((token: any) => {
+  const output: Record<string, unknown>[] = [];
+  dictionary.allTokens.forEach((token) => {
     // we remove the "filePath" prop from the token because the orginal file path is irrelevant for us
     // (plus its value is an absolute path, so it causes useless diffs in git)
-    const outputToken = cloneDeep(token);
+    const outputToken = cloneDeep(token) as Record<string, unknown>;
     delete outputToken.filePath;
     delete outputToken.isSource;
     output.push(outputToken);

--- a/packages/tokens/scripts/build-parts/generateElevationHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateElevationHelpers.ts
@@ -22,7 +22,7 @@ export function generateElevationHelpers(tokensElevation: TransformedTokens, tok
     const levelName = key;
     const levelValues = tokensElevation[key];
 
-    if (levelValues && levelValues.hasOwnProperty('box-shadow')) {
+    if (levelValues && Object.prototype.hasOwnProperty.call(levelValues, 'box-shadow')) {
       const selector = `.${PREFIX}-elevation-${levelName}`;
       const value = outputCssVars ? `var(--token-elevation-${levelName}-box-shadow)` : levelValues['box-shadow'].$value;
       helpersElevation.push(`${selector} { box-shadow: ${value}; }`);
@@ -34,7 +34,7 @@ export function generateElevationHelpers(tokensElevation: TransformedTokens, tok
     const levelName = key;
     const levelValues = tokensSurface[key];
 
-    if (levelValues && levelValues.hasOwnProperty('box-shadow')) {
+    if (levelValues && Object.prototype.hasOwnProperty.call(levelValues, 'box-shadow')) {
       const selector = `.${PREFIX}-surface-${levelName}`;
       const value = outputCssVars ? `var(--token-surface-${levelName}-box-shadow)` : levelValues['box-shadow'].$value;
       helpersSurface.push(`${selector} { box-shadow: ${value}; }`);

--- a/packages/tokens/scripts/build-parts/generateFocusRingHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateFocusRingHelpers.ts
@@ -15,7 +15,7 @@ export function generateFocusRingHelpers(tokens: TransformedTokens, outputCssVar
 
   Object.keys(tokens).forEach((key: string) => {
     const color = key;
-    if (tokens && tokens[color] && tokens[color].hasOwnProperty('box-shadow')) {
+    if (tokens && tokens[color] && Object.prototype.hasOwnProperty.call(tokens[color], 'box-shadow')) {
       const selector = `.${PREFIX}-focus-ring-${color}-box-shadow`;
       const value = outputCssVars ? `var(--token-focus-ring-${color}-box-shadow)` : tokens[color]['box-shadow'].$value;
       helpersFocusRing.push(`${selector} { box-shadow: ${value}; }`);

--- a/packages/tokens/scripts/build-parts/generateTypographyHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateTypographyHelpers.ts
@@ -49,7 +49,7 @@ export function generateTypographyHelpers(tokens: TransformedTokens, outputCssVa
 
     } else {
 
-      let stylename = key;
+      const stylename = key;
 
       // basic font styles
       if (outputCssVars) {

--- a/packages/tokens/scripts/extract-carbon-parts/convertObjectToDtcgFormat.ts
+++ b/packages/tokens/scripts/extract-carbon-parts/convertObjectToDtcgFormat.ts
@@ -4,7 +4,7 @@
  */
 
 
-type Args = { key?: string, value: Record<string, any>; type: string; group?: string };
+type Args = { key?: string; value: unknown; type: string; group?: string };
 
 import type { CarbonDesignTokens, CarbonDesignToken } from './@types/CarbonDesignTokens.d.ts'
 
@@ -16,14 +16,15 @@ export function convertObjectToDtcgFormat({ value, type, group }: Args): CarbonD
   return recursivelyProcessObject({ value, type, group });
 }
 
-function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesignTokens | CarbonDesignToken | Record<string, any> {
+function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesignTokens | CarbonDesignToken | Record<string, unknown> {
   if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
     // recursively process each key
-    const result: Record<string, any> = {};
+    const result: Record<string, unknown> = {};
+    const objectValue = value as Record<string, unknown>;
     for (const key in value) {
       // for better safety (says Copilot)
-      if (Object.prototype.hasOwnProperty.call(value, key)) {
-        result[key] = recursivelyProcessObject({ key, value: value[key], type, group });
+      if (Object.prototype.hasOwnProperty.call(objectValue, key)) {
+        result[key] = recursivelyProcessObject({ key, value: objectValue[key], type, group });
       }
     }
     return result;
@@ -39,8 +40,8 @@ function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesig
             'private': true,
             'cds-original-value': value
           };
-        case 'cubic-bezier':
-          const convertedCubicBezierValue = convertCubicBezierValue(value);
+        case 'cubic-bezier': {
+          const convertedCubicBezierValue = typeof value === 'string' ? convertCubicBezierValue(value) : undefined;
           if (convertedCubicBezierValue !== undefined) {
             return {
               // see: https://www.designtokens.org/tr/drafts/format/#cubic-bezier
@@ -50,12 +51,12 @@ function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesig
               'private': true,
               'cds-original-value': value
             };
-          } else {
-            const unknownCubicBezierToken = returnUnknownToken(value, `🚨 convertCubicBezierValue: value for key "${key}" / group "${group}" is not in the expected format:`);
-            return unknownCubicBezierToken;
           }
-        case 'duration':
-          const convertedDurationValue = convertDurationValue(value);
+          const unknownCubicBezierToken = returnUnknownToken(value, `🚨 convertCubicBezierValue: value for key "${key}" / group "${group}" is not in the expected format:`);
+          return unknownCubicBezierToken;
+        }
+        case 'duration': {
+          const convertedDurationValue = typeof value === 'string' ? convertDurationValue(value) : undefined;
           if (convertedDurationValue !== undefined) {
             return {
               '$type': 'duration',
@@ -65,10 +66,10 @@ function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesig
               'private': true,
               'cds-original-value': value
             };
-          } else {
-            const unknownDurationToken = returnUnknownToken(value, `🚨 convertDurationValue: value for key "${key}" / group "${group}" is not in the expected format:`);
-            return unknownDurationToken;
           }
+          const unknownDurationToken = returnUnknownToken(value, `🚨 convertDurationValue: value for key "${key}" / group "${group}" is not in the expected format:`);
+          return unknownDurationToken;
+        }
         case 'font-family':
           return {
             '$type': 'font-family',
@@ -77,7 +78,7 @@ function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesig
             'private': true,
             'cds-original-value': value
           };
-        case 'font-size':
+        case 'font-size': {
           const convertedFontSizeValue = convertSizeValue(value, true);
           if (convertedFontSizeValue !== undefined) {
             return {
@@ -88,10 +89,10 @@ function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesig
               'private': true,
               'cds-original-value': value
             };
-          } else {
-            const unknownSizeToken = returnUnknownToken(value, `🚨 convertSizeValue: value for key "${key}" / group "${group}" is not in the expected format:`);
-            return unknownSizeToken;
           }
+          const unknownSizeToken = returnUnknownToken(value, `🚨 convertSizeValue: value for key "${key}" / group "${group}" is not in the expected format:`);
+          return unknownSizeToken;
+        }
         case 'font-weight':
           return {
             '$type': 'font-weight',
@@ -108,7 +109,7 @@ function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesig
             'private': true,
             'cds-original-value': value
           };
-        case 'letter-spacing':
+        case 'letter-spacing': {
           const convertedLetterSpacingValue = convertSizeValue(value, false);
           if (convertedLetterSpacingValue !== undefined) {
             return {
@@ -119,10 +120,10 @@ function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesig
               'private': true,
               'cds-original-value': value
             };
-          } else {
-            const unknownSizeToken = returnUnknownToken(value, `🚨 convertSizeValue: value for key "${key}" / group "${group}" is not in the expected format:`);
-            return unknownSizeToken;
           }
+          const unknownSizeToken = returnUnknownToken(value, `🚨 convertSizeValue: value for key "${key}" / group "${group}" is not in the expected format:`);
+          return unknownSizeToken;
+        }
         case 'number':
           return {
             '$type': 'number',
@@ -131,7 +132,7 @@ function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesig
             'private': true,
             'cds-original-value': value
           };
-        case 'dimension':
+        case 'dimension': {
           const convertedSizeValue = convertSizeValue(value);
           if (convertedSizeValue !== undefined) {
             return {
@@ -142,10 +143,10 @@ function recursivelyProcessObject({ key, value, type, group}: Args): CarbonDesig
               'private': true,
               'cds-original-value': value
             };
-          } else {
-            const unknownSizeToken = returnUnknownToken(value, `🚨 convertSizeValue: value for key "${key}" / group "${group}" is not in the expected format:`);
-            return unknownSizeToken;
           }
+          const unknownSizeToken = returnUnknownToken(value, `🚨 convertSizeValue: value for key "${key}" / group "${group}" is not in the expected format:`);
+          return unknownSizeToken;
+        }
         default:
           return {
             '$type': 'unknown',

--- a/packages/tokens/scripts/extract-carbon-parts/extractThemes.ts
+++ b/packages/tokens/scripts/extract-carbon-parts/extractThemes.ts
@@ -11,6 +11,8 @@ import { convertObjectToDtcgFormat } from './convertObjectToDtcgFormat.ts';
 import { saveCarbonDtcgTokensAsJsonFile } from './saveCarbonDtcgTokensAsJsonFile.ts';
 import { dimensionRegex } from './convertObjectToDtcgFormat.ts';
 
+type NestedObject = Record<string, unknown>;
+
 export async function extractThemes(): Promise<void> {
 
   // button tokens
@@ -35,7 +37,7 @@ export async function extractThemes(): Promise<void> {
 
   // themes (this is a special case, )
   const carbonThemesAllTokensDtcg = convertThemeObjectToDtcg(cleanupObj(themes), '[root]');
-  await saveCarbonDtcgTokensAsJsonFile({ obj: carbonThemesAllTokensDtcg, group: 'themes', file: 'themes' });
+  await saveCarbonDtcgTokensAsJsonFile({ obj: carbonThemesAllTokensDtcg as object, group: 'themes', file: 'themes' });
 
 }
 
@@ -43,7 +45,7 @@ export async function extractThemes(): Promise<void> {
 // - replaces any key named 'whiteTheme' with 'white'
 // - removes entries whose value is an array (`breakpoints`)
 
-function cleanupObj(obj: Record<string, any>): Record<string, any> {
+function cleanupObj(obj: NestedObject): NestedObject {
   // Base case: if obj is not an object or is null, return it as is
   if (typeof obj !== 'object' || obj === null) {
     return obj;
@@ -51,11 +53,11 @@ function cleanupObj(obj: Record<string, any>): Record<string, any> {
 
   // For arrays, map over each element and process recursively
   if (Array.isArray(obj)) {
-    return obj.map(item => cleanupObj(item));
+    return obj;
   }
 
   // For objects, create a new object with potentially renamed keys
-  const result: Record<string, any> = {};
+  const result: NestedObject = {};
 
   for (const [key, value] of Object.entries(obj)) {
     // Skip entries whose value is an array
@@ -67,24 +69,29 @@ function cleanupObj(obj: Record<string, any>): Record<string, any> {
     const newKey = key === 'whiteTheme' ? 'white' : key;
 
     // Recursively process nested objects
-    result[newKey] = cleanupObj(value);
+    if (typeof value === 'object' && value !== null) {
+      result[newKey] = cleanupObj(value as NestedObject);
+    } else {
+      result[newKey] = value;
+    }
   }
 
   return result;
 }
 
-function convertThemeObjectToDtcg(obj: Record<string, any>, key: string) {
+function convertThemeObjectToDtcg(obj: unknown, key: string): unknown {
   if (typeof obj === 'object') {
     // it's an object, process all its keys
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        obj[key] = convertThemeObjectToDtcg(obj[key], key);
+    const objectValue = obj as Record<string, unknown>;
+    for (const key in objectValue) {
+      if (Object.prototype.hasOwnProperty.call(objectValue, key)) {
+        objectValue[key] = convertThemeObjectToDtcg(objectValue[key], key);
       }
     }
-    return obj;
+    return objectValue;
   } else {
     // it's a leaf, convert it
-    return convertThemeValueToDtcg(obj, key);
+    return convertThemeValueToDtcg(obj as string | number, key);
   }
 }
 

--- a/packages/tokens/scripts/extract-carbon-parts/extractTypography.ts
+++ b/packages/tokens/scripts/extract-carbon-parts/extractTypography.ts
@@ -18,6 +18,7 @@ type CarbonStyle = {
 };
 
 type CarbonStyles = Record<string, CarbonStyle>;
+type CarbonStyleKey = Exclude<keyof CarbonStyle, 'breakpoints'>;
 
 type MergedStyle = {
   'font-family'?: string;
@@ -64,8 +65,10 @@ export async function extractTypography(): Promise<void> {
     Object.entries(styleObj).forEach(([key, value]) => {
       // at the moment we're not interested in responsive typography
       if (key !== 'breakpoints') {
-        // Type assertion to ensure key is one of the expected keys
-        (carbonTypographyStylesEntries as any)[key][styleName] = value;
+        if (key in carbonTypographyStylesEntries) {
+          const typedKey = key as CarbonStyleKey;
+          carbonTypographyStylesEntries[typedKey][styleName] = value as CarbonStyle[CarbonStyleKey];
+        }
       }
     });
   });
@@ -88,7 +91,13 @@ export async function extractTypography(): Promise<void> {
   const carbonTypographyStylesFontWeightDtcg = convertObjectToDtcgFormat({ value: carbonTypographyStylesEntries.fontWeight, type: 'font-weight', group: 'cds-typography' });
   const carbonTypographyStylesLineHeightDtcg = convertObjectToDtcgFormat({ value: carbonTypographyStylesEntries.lineHeight, type: 'line-height', group: 'cds-typography' });
   const carbonTypographyStylesLetterSpacingDtcg = convertObjectToDtcgFormat({ value: carbonTypographyStylesEntries.letterSpacing, type: 'letter-spacing', group: 'cds-typography' });
-  const carbonTypographyStyle = mergeCarbonTypographyStyles(carbonTypographyStylesFontFamilyDtcg, carbonTypographyStylesFontSizeDtcg, carbonTypographyStylesFontWeightDtcg, carbonTypographyStylesLineHeightDtcg, carbonTypographyStylesLetterSpacingDtcg);
+  const carbonTypographyStyle = mergeCarbonTypographyStyles(
+    carbonTypographyStylesFontFamilyDtcg as Record<string, CarbonStyle['fontFamily']>,
+    carbonTypographyStylesFontSizeDtcg as Record<string, CarbonStyle['fontSize']>,
+    carbonTypographyStylesFontWeightDtcg as Record<string, CarbonStyle['fontWeight']>,
+    carbonTypographyStylesLineHeightDtcg as Record<string, CarbonStyle['lineHeight']>,
+    carbonTypographyStylesLetterSpacingDtcg as Record<string, CarbonStyle['letterSpacing']>
+  );
   await saveCarbonDtcgTokensAsJsonFile({ obj: carbonTypographyStyle, group: 'typography', file: 'styles' });
 
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,9 @@ importers:
       '@carbon/type':
         specifier: ^11.46.0
         version: 11.49.0
+      '@eslint/js':
+        specifier: ^9.27.0
+        version: 9.32.0
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -456,16 +459,19 @@ importers:
         version: 1.4.6
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.18.1
-        version: 8.38.0(@typescript-eslint/parser@8.38.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
+        version: 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0)(typescript@5.9.2))(eslint@9.32.0)(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^8.18.1
-        version: 8.38.0(eslint@8.57.1)(typescript@5.9.2)
+        version: 8.38.0(eslint@9.32.0)(typescript@5.9.2)
       eslint:
-        specifier: ^8.57.1
-        version: 8.57.1
+        specifier: ^9.27.0
+        version: 9.32.0
       fs-extra:
         specifier: ^11.2.0
         version: 11.3.0
+      globals:
+        specifier: ^16.1.0
+        version: 16.3.0
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -490,6 +496,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.32.1
+        version: 8.38.0(eslint@9.32.0)(typescript@5.9.2)
 
   showcase:
     devDependencies:


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR upgrades `packages/tokens` to ESLint 9 using a native flat config, updates lint dependencies/scripts accordingly, and fixes newly enforced lint violations.

### :hammer_and_wrench: Detailed description

- Migrated `packages/tokens` to native ESLint 9 flat config:
  - added `packages/tokens/eslint.config.mjs` using `@eslint/js`, `typescript-eslint`, and `globals`
  - configured flat-config ignores for `node_modules` and `dist`
  - scoped Node globals for `scripts/**/*.ts`
- Updated `packages/tokens/package.json` lint setup and dependencies:
  - upgraded `eslint` to `^9.27.0`
  - added `@eslint/js`, `typescript-eslint`, and `globals`
  - updated lint script from legacy `--ext` usage to `pnpm eslint --quiet`.
- Updated package publishing exclusions:
  - added `packages/tokens/eslint.config.mjs` to `packages/tokens/.npmignore`
- Fixed lint violations surfaced by the ESLint 9 migration in scripts:
  - removed/typed any usage in script helpers and extractors
  - replaced direct `.hasOwnProperty(...)` calls with `Object.prototype.hasOwnProperty.call(...)`
  - resolved `prefer-const` and related strict-rule issues
  - tightened typing around token conversion/merge paths where lint required explicit handling

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6238](https://hashicorp.atlassian.net/browse/HDS-6238)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6238]: https://hashicorp.atlassian.net/browse/HDS-6238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ