### PR TITLE
Toast docs - Add warning on where to include Toast code related to Flyout.Modal (HDS-6139)

### DIFF
--- a/website/docs/components/toast/partials/code/how-to-use.md
+++ b/website/docs/components/toast/partials/code/how-to-use.md
@@ -2,6 +2,14 @@ While we provide visual styling for this component, the product team must implem
 
 ## How to use this component
 
+!!! Warning
+
+**Displaying Toasts in relation to a Flyout or Modal**
+
+When displaying a `Toast` in reaction to an action or event that has occurred related to an open `Flyout` or `Modal`, the `Toast` code must be included inside the `Flyout` or `Modal` component content or else it will be displayed below it and may not be visible. This is due to how z-index works for HTML `dialog` elements which the `Flyout` and `Modal` are based upon.
+
+!!!
+
 The basic invocation requires the `type` argument, an `onDismiss` callback function, and the `title` and/or `description` content. By default a `neutral` Toast is generated.
 
 [[code-snippets/toast-basic]]

--- a/website/docs/components/toast/partials/code/how-to-use.md
+++ b/website/docs/components/toast/partials/code/how-to-use.md
@@ -4,9 +4,9 @@ While we provide visual styling for this component, the product team must implem
 
 !!! Warning
 
-**Displaying Toasts in relation to a Flyout or Modal**
+**Code alert**
 
-When displaying a `Toast` in reaction to an action or event that has occurred related to an open `Flyout` or `Modal`, the `Toast` code must be included inside the `Flyout` or `Modal` component content or else it will be displayed below it and may not be visible. This is due to how z-index works for HTML `dialog` elements which the `Flyout` and `Modal` are based upon.
+When displaying a Toast in reaction to an action or event that has occurred within an open Flyout or Modal, the Toast code must be included inside the Flyout or Modal component content or else it will be displayed below it and may not be visible. This is due to how z-index works for HTML dialog elements which the Flyout and Modal are based upon.
 
 !!!
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR will update the `Toast` documentation to influde a warning to engineers informing them where to include `Toast` code related to a `Flyout` or `Modal`.

👉 **Preview**: https://hds-website-git-hds-6139-toast-docs-z-index-warning-hashicorp.vercel.app/components/toast?tab=code

<!--
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why? -->

### :camera_flash: Screenshots

<img width="885" height="744" alt="image" src="https://github.com/user-attachments/assets/08201d0b-640d-4e7b-bf25-98e5fb46e9e9" />

### :link: External links

* Jira ticket: [HDS-6139](https://hashicorp.atlassian.net/browse/HDS-6139)

***

### :eyes: Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6139]: https://hashicorp.atlassian.net/browse/HDS-6139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ