### PR TITLE
Override yaml@2 to remediate SECVULN yaml findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "socket.io-parser": "4.2.6",
       "systeminformation": "5.31.0",
       "undici": "6.24.0",
-      "underscore": "1.13.8"
+      "underscore": "1.13.8",
+      "yaml@2": "2.8.3"
     },
     "patchedDependencies": {
       "broccoli-asset-rewrite": "patches/broccoli-asset-rewrite.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   systeminformation: 5.31.0
   undici: 6.24.0
   underscore: 1.13.8
+  yaml@2: 2.8.3
 
 patchedDependencies:
   broccoli-asset-rewrite:
@@ -12062,8 +12063,8 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
-  yaml@2.8.0:
-    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -15036,7 +15037,7 @@ snapshots:
   '@percy/cli-snapshot@1.31.1(typescript@5.9.2)':
     dependencies:
       '@percy/cli-command': 1.31.1(typescript@5.9.2)
-      yaml: 2.8.0
+      yaml: 2.8.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -15085,7 +15086,7 @@ snapshots:
       '@percy/logger': 1.31.1
       ajv: 8.18.0
       cosmiconfig: 8.3.6(typescript@5.9.2)
-      yaml: 2.8.0
+      yaml: 2.8.3
     transitivePeerDependencies:
       - typescript
 
@@ -15107,7 +15108,7 @@ snapshots:
       path-to-regexp: 6.3.0
       rimraf: 3.0.2
       ws: 8.18.3
-      yaml: 2.8.0
+      yaml: 2.8.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -18329,7 +18330,7 @@ snapshots:
     dependencies:
       '@cspell/cspell-types': 8.19.4
       comment-json: 4.2.5
-      yaml: 2.8.0
+      yaml: 2.8.3
 
   cspell-dictionary@8.19.4:
     dependencies:
@@ -27094,7 +27095,7 @@ snapshots:
 
   yaml@1.10.2: {}
 
-  yaml@2.8.0: {}
+  yaml@2.8.3: {}
 
   yargs-parser@10.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add a root `pnpm.overrides` entry to pin `yaml@2` to `2.8.3`
- update `pnpm-lock.yaml` so the affected `yaml@2.8.0` resolution and transitive references move to `2.8.3`
- address the duplicate Jira-backed findings for `SECVULN-41236` and `SECVULN-41237`

## How to review
- inspect the `package.json` override change first
- confirm the lockfile only updates the `yaml@2` override, package entry, snapshot entry, and dependent references
- verify no `yaml@2.8.0` entries remain in `pnpm-lock.yaml`

## File-by-file review notes
- `package.json` — adds a root `pnpm.overrides` pin for `yaml@2: 2.8.3`
- `pnpm-lock.yaml` — updates the lockfile override and replaces the vulnerable `yaml@2.8.0` package/snapshot/reference entries with `2.8.3`

## Behavior to verify
- dependency resolution should now prefer `yaml@2.8.3` for the affected paths
- the vulnerable `yaml@2.8.0` lockfile entries should be gone

## Validation run
- reviewed the diff for `package.json` and `pnpm-lock.yaml`
- confirmed `yaml@2.8.0` no longer appears in `pnpm-lock.yaml`
- confirmed `yaml@2.8.3` appears in the expected override/package/snapshot/reference locations
- ran `git diff --check -- package.json pnpm-lock.yaml`

## Risks / edge cases
- `yaml@1.10.2` still exists elsewhere in the lockfile and was left unchanged because it appears out of scope for these specific Jira findings
- full lockfile regeneration with pnpm was not used because it caused unrelated churn; this keeps the remediation narrowly scoped

## README / docs updates
- no docs updates were needed for this dependency remediation

## Jira
- [SECVULN-41236](https://hashicorp.atlassian.net/browse/SECVULN-41236)
- [SECVULN-41237](https://hashicorp.atlassian.net/browse/SECVULN-41237)

[SECVULN-41236]: https://hashicorp.atlassian.net/browse/SECVULN-41236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ