### PR TITLE
Pin brace-expansion v5 to remediate lockfile vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "ajv@6": "6.14.0",
       "ajv@8": "8.18.0",
       "basic-ftp": "5.3.1",
+      "brace-expansion@5": "5.0.6",
       "flatted": "3.4.2",
       "ember-composable-helpers": "npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11",
       "handlebars": "4.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   ajv@6: 6.14.0
   ajv@8: 8.18.0
   basic-ftp: 5.3.1
+  brace-expansion@5: 5.0.6
   flatted: 3.4.2
   ember-composable-helpers: npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11
   handlebars: 4.7.9
@@ -4792,9 +4793,9 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
-  brace-expansion@5.0.2:
-    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
-    engines: {node: 20 || >=22}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@2.3.2:
     resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
@@ -17202,7 +17203,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.2:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.2
 
@@ -23766,7 +23767,7 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.2
+      brace-expansion: 5.0.6
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
## Summary

Remediate the brace-expansion zero-step DoS flagged in SECVULN-41365, SECVULN-41367, and SECVULN-41368 by forcing the in-scope `website -> glob@13.0.3 -> minimatch@10.2.3` chain onto `brace-expansion@5.0.6`.

## How to review

1. Check `package.json` for the new root `pnpm.overrides` entry.
2. Check `pnpm-lock.yaml` to confirm the override is recorded and `minimatch@10.2.3` now resolves to `brace-expansion@5.0.6`.
3. Confirm `brace-expansion@5.0.2` is no longer present in the lockfile.

## File-by-file review notes

- `package.json` — adds `brace-expansion@5: 5.0.6` under root `pnpm.overrides` to keep the vulnerable v5 chain on a patched release.
- `pnpm-lock.yaml` — records the override, replaces the `brace-expansion@5.0.2` package/snapshot entries with `5.0.6`, and updates the `minimatch@10.2.3` snapshot dependency accordingly.

## Behavior to verify

- The website dependency chain no longer resolves to `brace-expansion@5.0.2`.
- No unrelated manifests or package versions changed.

## Validation run

- `npx --yes pnpm install --lockfile-only --frozen-lockfile`
- Verified `pnpm-lock.yaml` contains `brace-expansion@5.0.6`
- Verified `pnpm-lock.yaml` no longer contains `brace-expansion@5.0.2`

## Risks / edge cases

- This intentionally targets the in-scope v5 chain only; older `brace-expansion` majors still present elsewhere in the lockfile were not changed because they appear to come from different dependency paths and were not part of these Jira findings.

## README / docs updates

- No docs updates were needed for this dependency remediation.

## Jira
- [SECVULN-41365](https://hashicorp.atlassian.net/browse/SECVULN-41365)
- [SECVULN-41367](https://hashicorp.atlassian.net/browse/SECVULN-41367)
- [SECVULN-41368](https://hashicorp.atlassian.net/browse/SECVULN-41368)

[SECVULN-41365]: https://hashicorp.atlassian.net/browse/SECVULN-41365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ