### PR TITLE
[Project Solar / Phase 1 / Follow-up] Update `focus` to `focus-ring` in "component-level" tokens 

### DIFF
--- a/packages/components/src/modifiers/hds-code-editor/themes/hds-theme.ts
+++ b/packages/components/src/modifiers/hds-code-editor/themes/hds-theme.ts
@@ -113,9 +113,10 @@ const hdsTheme = EditorView.theme({
   '.cm-panel.cm-panel-lint ul:focus li.cm-diagnostic[aria-selected]': {
     background: 'none',
     backgroundColor: 'var(--token-code-block-surface-color-primary)',
-    border: '4px solid var(--token-code-block-focus-color-action-external)',
+    border:
+      '4px solid var(--token-code-block-focus-ring-color-action-external)',
     boxShadow:
-      'inset 0 0 0 1px var(--token-code-block-focus-color-action-internal)',
+      'inset 0 0 0 1px var(--token-code-block-focus-ring-color-action-internal)',
     color: 'var(--token-code-block-foreground-color-primary)',
   },
   '.cm-panels-bottom': {
@@ -161,8 +162,9 @@ const hdsTheme = EditorView.theme({
       color: 'var(--token-code-block-foreground-color-primary)',
     },
   [`${CLOSE_BUTTON_SELECTOR}:focus`]: {
-    borderColor: 'var(--token-code-block-focus-color-action-internal)',
-    outline: '3px solid var(--token-code-block-focus-color-action-external)',
+    borderColor: 'var(--token-code-block-focus-ring-color-action-internal)',
+    outline:
+      '3px solid var(--token-code-block-focus-ring-color-action-external)',
   },
 
   // tooltips

--- a/packages/components/src/styles/components/code-block/index.scss
+++ b/packages/components/src/styles/components/code-block/index.scss
@@ -187,10 +187,10 @@ $hds-code-block-code-footer-height: 48px;
   &:focus-visible {
     color: var(--token-code-block-foreground-color-primary);
     background-color: var(--token-code-block-button-surface-color-default);
-    border-color: var(--token-code-block-focus-color-action-internal);
+    border-color: var(--token-code-block-focus-ring-color-action-internal);
 
     &::before {
-      border-color: var(--token-code-block-focus-color-action-external);
+      border-color: var(--token-code-block-focus-ring-color-action-external);
     }
   }
 

--- a/packages/components/src/styles/components/code-editor/index.scss
+++ b/packages/components/src/styles/components/code-editor/index.scss
@@ -113,10 +113,10 @@
     &:hover,
     &.mock-hover {
       background-color: var(--token-code-block-button-surface-color-hover);
-      border-color: var(--token-code-block-focus-color-action-internal);
+      border-color: var(--token-code-block-focus-ring-color-action-internal);
 
       &::before {
-        border-color: var(--token-code-block-focus-color-action-external);
+        border-color: var(--token-code-block-focus-ring-color-action-external);
       }
 
       .hds-button__icon {

--- a/packages/tokens/dist/docs/products/themed-tokens.json
+++ b/packages/tokens/dist/docs/products/themed-tokens.json
@@ -12067,8 +12067,8 @@
         "primary"
       ]
     },
-    "token-code-block-focus-color-action-internal": {
-      "key": "{code-block.focus.color.action-internal}",
+    "token-code-block-focus-ring-color-action-internal": {
+      "key": "{code-block.focus-ring.color.action-internal}",
       "$type": "color",
       "$value": "#9bc7fd",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12090,21 +12090,21 @@
           "cds-g90": "{carbon.themes.g90.focusInset}",
           "cds-g100": "{carbon.themes.g100.focusInset}"
         },
-        "key": "{code-block.focus.color.action-internal}"
+        "key": "{code-block.focus-ring.color.action-internal}"
       },
-      "name": "token-code-block-focus-color-action-internal",
+      "name": "token-code-block-focus-ring-color-action-internal",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-internal"
       ]
     },
-    "token-code-block-focus-color-action-external": {
-      "key": "{code-block.focus.color.action-external}",
+    "token-code-block-focus-ring-color-action-external": {
+      "key": "{code-block.focus-ring.color.action-external}",
       "$type": "color",
       "$value": "#0d69f2",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12126,15 +12126,15 @@
           "cds-g90": "{carbon.themes.g90.focus}",
           "cds-g100": "{carbon.themes.g100.focus}"
         },
-        "key": "{code-block.focus.color.action-external}"
+        "key": "{code-block.focus-ring.color.action-external}"
       },
-      "name": "token-code-block-focus-color-action-external",
+      "name": "token-code-block-focus-ring-color-action-external",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-external"
       ]
@@ -32230,8 +32230,8 @@
         "primary"
       ]
     },
-    "token-code-block-focus-color-action-internal": {
-      "key": "{code-block.focus.color.action-internal}",
+    "token-code-block-focus-ring-color-action-internal": {
+      "key": "{code-block.focus-ring.color.action-internal}",
       "$type": "color",
       "$value": "#ffffff",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -32253,21 +32253,21 @@
           "cds-g90": "{carbon.themes.g90.focusInset}",
           "cds-g100": "{carbon.themes.g100.focusInset}"
         },
-        "key": "{code-block.focus.color.action-internal}"
+        "key": "{code-block.focus-ring.color.action-internal}"
       },
-      "name": "token-code-block-focus-color-action-internal",
+      "name": "token-code-block-focus-ring-color-action-internal",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-internal"
       ]
     },
-    "token-code-block-focus-color-action-external": {
-      "key": "{code-block.focus.color.action-external}",
+    "token-code-block-focus-ring-color-action-external": {
+      "key": "{code-block.focus-ring.color.action-external}",
       "$type": "color",
       "$value": "#0f62fe",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -32289,15 +32289,15 @@
           "cds-g90": "{carbon.themes.g90.focus}",
           "cds-g100": "{carbon.themes.g100.focus}"
         },
-        "key": "{code-block.focus.color.action-external}"
+        "key": "{code-block.focus-ring.color.action-external}"
       },
-      "name": "token-code-block-focus-color-action-external",
+      "name": "token-code-block-focus-ring-color-action-external",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-external"
       ]
@@ -52393,8 +52393,8 @@
         "primary"
       ]
     },
-    "token-code-block-focus-color-action-internal": {
-      "key": "{code-block.focus.color.action-internal}",
+    "token-code-block-focus-ring-color-action-internal": {
+      "key": "{code-block.focus-ring.color.action-internal}",
       "$type": "color",
       "$value": "#ffffff",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -52416,21 +52416,21 @@
           "cds-g90": "{carbon.themes.g90.focusInset}",
           "cds-g100": "{carbon.themes.g100.focusInset}"
         },
-        "key": "{code-block.focus.color.action-internal}"
+        "key": "{code-block.focus-ring.color.action-internal}"
       },
-      "name": "token-code-block-focus-color-action-internal",
+      "name": "token-code-block-focus-ring-color-action-internal",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-internal"
       ]
     },
-    "token-code-block-focus-color-action-external": {
-      "key": "{code-block.focus.color.action-external}",
+    "token-code-block-focus-ring-color-action-external": {
+      "key": "{code-block.focus-ring.color.action-external}",
       "$type": "color",
       "$value": "#0f62fe",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -52452,15 +52452,15 @@
           "cds-g90": "{carbon.themes.g90.focus}",
           "cds-g100": "{carbon.themes.g100.focus}"
         },
-        "key": "{code-block.focus.color.action-external}"
+        "key": "{code-block.focus-ring.color.action-external}"
       },
-      "name": "token-code-block-focus-color-action-external",
+      "name": "token-code-block-focus-ring-color-action-external",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-external"
       ]
@@ -72556,8 +72556,8 @@
         "primary"
       ]
     },
-    "token-code-block-focus-color-action-internal": {
-      "key": "{code-block.focus.color.action-internal}",
+    "token-code-block-focus-ring-color-action-internal": {
+      "key": "{code-block.focus-ring.color.action-internal}",
       "$type": "color",
       "$value": "#161616",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -72579,21 +72579,21 @@
           "cds-g90": "{carbon.themes.g90.focusInset}",
           "cds-g100": "{carbon.themes.g100.focusInset}"
         },
-        "key": "{code-block.focus.color.action-internal}"
+        "key": "{code-block.focus-ring.color.action-internal}"
       },
-      "name": "token-code-block-focus-color-action-internal",
+      "name": "token-code-block-focus-ring-color-action-internal",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-internal"
       ]
     },
-    "token-code-block-focus-color-action-external": {
-      "key": "{code-block.focus.color.action-external}",
+    "token-code-block-focus-ring-color-action-external": {
+      "key": "{code-block.focus-ring.color.action-external}",
       "$type": "color",
       "$value": "#ffffff",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -72615,15 +72615,15 @@
           "cds-g90": "{carbon.themes.g90.focus}",
           "cds-g100": "{carbon.themes.g100.focus}"
         },
-        "key": "{code-block.focus.color.action-external}"
+        "key": "{code-block.focus-ring.color.action-external}"
       },
-      "name": "token-code-block-focus-color-action-external",
+      "name": "token-code-block-focus-ring-color-action-external",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-external"
       ]
@@ -92719,8 +92719,8 @@
         "primary"
       ]
     },
-    "token-code-block-focus-color-action-internal": {
-      "key": "{code-block.focus.color.action-internal}",
+    "token-code-block-focus-ring-color-action-internal": {
+      "key": "{code-block.focus-ring.color.action-internal}",
       "$type": "color",
       "$value": "#161616",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -92742,21 +92742,21 @@
           "cds-g90": "{carbon.themes.g90.focusInset}",
           "cds-g100": "{carbon.themes.g100.focusInset}"
         },
-        "key": "{code-block.focus.color.action-internal}"
+        "key": "{code-block.focus-ring.color.action-internal}"
       },
-      "name": "token-code-block-focus-color-action-internal",
+      "name": "token-code-block-focus-ring-color-action-internal",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-internal"
       ]
     },
-    "token-code-block-focus-color-action-external": {
-      "key": "{code-block.focus.color.action-external}",
+    "token-code-block-focus-ring-color-action-external": {
+      "key": "{code-block.focus-ring.color.action-external}",
       "$type": "color",
       "$value": "#ffffff",
       "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -92778,15 +92778,15 @@
           "cds-g90": "{carbon.themes.g90.focus}",
           "cds-g100": "{carbon.themes.g100.focus}"
         },
-        "key": "{code-block.focus.color.action-external}"
+        "key": "{code-block.focus-ring.color.action-external}"
       },
-      "name": "token-code-block-focus-color-action-external",
+      "name": "token-code-block-focus-ring-color-action-external",
       "attributes": {
         "category": "code-block"
       },
       "path": [
         "code-block",
-        "focus",
+        "focus-ring",
         "color",
         "action-external"
       ]

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
@@ -12061,7 +12061,7 @@
     ]
   },
   {
-    "key": "{code-block.focus.color.action-internal}",
+    "key": "{code-block.focus-ring.color.action-internal}",
     "$type": "color",
     "$value": "#ffffff",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12083,21 +12083,21 @@
         "cds-g90": "{carbon.themes.g90.focusInset}",
         "cds-g100": "{carbon.themes.g100.focusInset}"
       },
-      "key": "{code-block.focus.color.action-internal}"
+      "key": "{code-block.focus-ring.color.action-internal}"
     },
-    "name": "token-code-block-focus-color-action-internal",
+    "name": "token-code-block-focus-ring-color-action-internal",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-internal"
     ]
   },
   {
-    "key": "{code-block.focus.color.action-external}",
+    "key": "{code-block.focus-ring.color.action-external}",
     "$type": "color",
     "$value": "#0f62fe",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12119,15 +12119,15 @@
         "cds-g90": "{carbon.themes.g90.focus}",
         "cds-g100": "{carbon.themes.g100.focus}"
       },
-      "key": "{code-block.focus.color.action-external}"
+      "key": "{code-block.focus-ring.color.action-external}"
     },
-    "name": "token-code-block-focus-color-action-external",
+    "name": "token-code-block-focus-ring-color-action-external",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-external"
     ]

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
@@ -12061,7 +12061,7 @@
     ]
   },
   {
-    "key": "{code-block.focus.color.action-internal}",
+    "key": "{code-block.focus-ring.color.action-internal}",
     "$type": "color",
     "$value": "#ffffff",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12083,21 +12083,21 @@
         "cds-g90": "{carbon.themes.g90.focusInset}",
         "cds-g100": "{carbon.themes.g100.focusInset}"
       },
-      "key": "{code-block.focus.color.action-internal}"
+      "key": "{code-block.focus-ring.color.action-internal}"
     },
-    "name": "token-code-block-focus-color-action-internal",
+    "name": "token-code-block-focus-ring-color-action-internal",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-internal"
     ]
   },
   {
-    "key": "{code-block.focus.color.action-external}",
+    "key": "{code-block.focus-ring.color.action-external}",
     "$type": "color",
     "$value": "#0f62fe",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12119,15 +12119,15 @@
         "cds-g90": "{carbon.themes.g90.focus}",
         "cds-g100": "{carbon.themes.g100.focus}"
       },
-      "key": "{code-block.focus.color.action-external}"
+      "key": "{code-block.focus-ring.color.action-external}"
     },
-    "name": "token-code-block-focus-color-action-external",
+    "name": "token-code-block-focus-ring-color-action-external",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-external"
     ]

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
@@ -12061,7 +12061,7 @@
     ]
   },
   {
-    "key": "{code-block.focus.color.action-internal}",
+    "key": "{code-block.focus-ring.color.action-internal}",
     "$type": "color",
     "$value": "#161616",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12083,21 +12083,21 @@
         "cds-g90": "{carbon.themes.g90.focusInset}",
         "cds-g100": "{carbon.themes.g100.focusInset}"
       },
-      "key": "{code-block.focus.color.action-internal}"
+      "key": "{code-block.focus-ring.color.action-internal}"
     },
-    "name": "token-code-block-focus-color-action-internal",
+    "name": "token-code-block-focus-ring-color-action-internal",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-internal"
     ]
   },
   {
-    "key": "{code-block.focus.color.action-external}",
+    "key": "{code-block.focus-ring.color.action-external}",
     "$type": "color",
     "$value": "#ffffff",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12119,15 +12119,15 @@
         "cds-g90": "{carbon.themes.g90.focus}",
         "cds-g100": "{carbon.themes.g100.focus}"
       },
-      "key": "{code-block.focus.color.action-external}"
+      "key": "{code-block.focus-ring.color.action-external}"
     },
-    "name": "token-code-block-focus-color-action-external",
+    "name": "token-code-block-focus-ring-color-action-external",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-external"
     ]

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
@@ -12061,7 +12061,7 @@
     ]
   },
   {
-    "key": "{code-block.focus.color.action-internal}",
+    "key": "{code-block.focus-ring.color.action-internal}",
     "$type": "color",
     "$value": "#161616",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12083,21 +12083,21 @@
         "cds-g90": "{carbon.themes.g90.focusInset}",
         "cds-g100": "{carbon.themes.g100.focusInset}"
       },
-      "key": "{code-block.focus.color.action-internal}"
+      "key": "{code-block.focus-ring.color.action-internal}"
     },
-    "name": "token-code-block-focus-color-action-internal",
+    "name": "token-code-block-focus-ring-color-action-internal",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-internal"
     ]
   },
   {
-    "key": "{code-block.focus.color.action-external}",
+    "key": "{code-block.focus-ring.color.action-external}",
     "$type": "color",
     "$value": "#ffffff",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12119,15 +12119,15 @@
         "cds-g90": "{carbon.themes.g90.focus}",
         "cds-g100": "{carbon.themes.g100.focus}"
       },
-      "key": "{code-block.focus.color.action-external}"
+      "key": "{code-block.focus-ring.color.action-external}"
     },
-    "name": "token-code-block-focus-color-action-external",
+    "name": "token-code-block-focus-ring-color-action-external",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-external"
     ]

--- a/packages/tokens/dist/docs/products/themed-tokens/default.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/default.json
@@ -12067,7 +12067,7 @@
     ]
   },
   {
-    "key": "{code-block.focus.color.action-internal}",
+    "key": "{code-block.focus-ring.color.action-internal}",
     "$type": "color",
     "$value": "#9bc7fd",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12089,21 +12089,21 @@
         "cds-g90": "{carbon.themes.g90.focusInset}",
         "cds-g100": "{carbon.themes.g100.focusInset}"
       },
-      "key": "{code-block.focus.color.action-internal}"
+      "key": "{code-block.focus-ring.color.action-internal}"
     },
-    "name": "token-code-block-focus-color-action-internal",
+    "name": "token-code-block-focus-ring-color-action-internal",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-internal"
     ]
   },
   {
-    "key": "{code-block.focus.color.action-external}",
+    "key": "{code-block.focus-ring.color.action-external}",
     "$type": "color",
     "$value": "#0d69f2",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12125,15 +12125,15 @@
         "cds-g90": "{carbon.themes.g90.focus}",
         "cds-g100": "{carbon.themes.g100.focus}"
       },
-      "key": "{code-block.focus.color.action-external}"
+      "key": "{code-block.focus-ring.color.action-external}"
     },
-    "name": "token-code-block-focus-color-action-external",
+    "name": "token-code-block-focus-ring-color-action-external",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-external"
     ]

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -12067,7 +12067,7 @@
     ]
   },
   {
-    "key": "{code-block.focus.color.action-internal}",
+    "key": "{code-block.focus-ring.color.action-internal}",
     "$type": "color",
     "$value": "#9bc7fd",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12089,21 +12089,21 @@
         "cds-g90": "{carbon.themes.g90.focusInset}",
         "cds-g100": "{carbon.themes.g100.focusInset}"
       },
-      "key": "{code-block.focus.color.action-internal}"
+      "key": "{code-block.focus-ring.color.action-internal}"
     },
-    "name": "token-code-block-focus-color-action-internal",
+    "name": "token-code-block-focus-ring-color-action-internal",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-internal"
     ]
   },
   {
-    "key": "{code-block.focus.color.action-external}",
+    "key": "{code-block.focus-ring.color.action-external}",
     "$type": "color",
     "$value": "#0d69f2",
     "comment": "TODO: Remove once global tokens for dark themes are implemented",
@@ -12125,15 +12125,15 @@
         "cds-g90": "{carbon.themes.g90.focus}",
         "cds-g100": "{carbon.themes.g100.focus}"
       },
-      "key": "{code-block.focus.color.action-external}"
+      "key": "{code-block.focus-ring.color.action-external}"
     },
-    "name": "token-code-block-focus-color-action-external",
+    "name": "token-code-block-focus-ring-color-action-external",
     "attributes": {
       "category": "code-block"
     },
     "path": [
       "code-block",
-      "focus",
+      "focus-ring",
       "color",
       "action-external"
     ]

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -306,8 +306,8 @@
   --token-code-block-button-surface-color-hover: var(
     --token-code-block-surface-color-primary
   );
-  --token-code-block-focus-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #2b89ff;
   --token-code-block-foreground-color-faint: #b2b6bd;
   --token-code-block-foreground-color-primary: #d5d7db;
@@ -916,8 +916,8 @@
     --token-code-block-button-surface-color-active: #c6c6c6;
     --token-code-block-button-surface-color-default: #e8e8e8;
     --token-code-block-button-surface-color-hover: #c6c6c6;
-    --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #0f62fe;
     --token-code-block-foreground-color-faint: #525252;
     --token-code-block-foreground-color-primary: #161616;
@@ -1392,8 +1392,8 @@
     --token-code-block-button-surface-color-active: #525252;
     --token-code-block-button-surface-color-default: #333333;
     --token-code-block-button-surface-color-hover: #525252;
-    --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #78a9ff;
     --token-code-block-foreground-color-faint: #c6c6c6;
     --token-code-block-foreground-color-primary: #f4f4f4;
@@ -1862,8 +1862,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -2327,8 +2327,8 @@
   --token-code-block-button-surface-color-active: #525252;
   --token-code-block-button-surface-color-default: #333333;
   --token-code-block-button-surface-color-hover: #525252;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;
@@ -2791,8 +2791,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -3255,8 +3255,8 @@
   --token-code-block-button-surface-color-active: #6f6f6f;
   --token-code-block-button-surface-color-default: #474747;
   --token-code-block-button-surface-color-hover: #6f6f6f;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
@@ -306,8 +306,8 @@
   --token-code-block-button-surface-color-hover: var(
     --token-code-block-surface-color-primary
   );
-  --token-code-block-focus-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #2b89ff;
   --token-code-block-foreground-color-faint: #b2b6bd;
   --token-code-block-foreground-color-primary: #d5d7db;
@@ -916,8 +916,8 @@
     --token-code-block-button-surface-color-active: #c6c6c6;
     --token-code-block-button-surface-color-default: #e8e8e8;
     --token-code-block-button-surface-color-hover: #c6c6c6;
-    --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #0f62fe;
     --token-code-block-foreground-color-faint: #525252;
     --token-code-block-foreground-color-primary: #161616;
@@ -1392,8 +1392,8 @@
     --token-code-block-button-surface-color-active: #525252;
     --token-code-block-button-surface-color-default: #333333;
     --token-code-block-button-surface-color-hover: #525252;
-    --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #78a9ff;
     --token-code-block-foreground-color-faint: #c6c6c6;
     --token-code-block-foreground-color-primary: #f4f4f4;
@@ -1861,8 +1861,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -2325,8 +2325,8 @@
   --token-code-block-button-surface-color-active: #525252;
   --token-code-block-button-surface-color-default: #333333;
   --token-code-block-button-surface-color-hover: #525252;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
@@ -139,8 +139,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -605,8 +605,8 @@
     --token-code-block-button-surface-color-active: #c6c6c6;
     --token-code-block-button-surface-color-default: #e8e8e8;
     --token-code-block-button-surface-color-hover: #c6c6c6;
-    --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #0f62fe;
     --token-code-block-foreground-color-faint: #525252;
     --token-code-block-foreground-color-primary: #161616;
@@ -1081,8 +1081,8 @@
     --token-code-block-button-surface-color-active: #525252;
     --token-code-block-button-surface-color-default: #333333;
     --token-code-block-button-surface-color-hover: #525252;
-    --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #78a9ff;
     --token-code-block-foreground-color-faint: #c6c6c6;
     --token-code-block-foreground-color-primary: #f4f4f4;
@@ -1550,8 +1550,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -2014,8 +2014,8 @@
   --token-code-block-button-surface-color-active: #525252;
   --token-code-block-button-surface-color-default: #333333;
   --token-code-block-button-surface-color-hover: #525252;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
@@ -139,8 +139,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
@@ -139,8 +139,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
@@ -139,8 +139,8 @@
   --token-code-block-button-surface-color-active: #525252;
   --token-code-block-button-surface-color-default: #333333;
   --token-code-block-button-surface-color-hover: #525252;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
@@ -139,8 +139,8 @@
   --token-code-block-button-surface-color-active: #6f6f6f;
   --token-code-block-button-surface-color-default: #474747;
   --token-code-block-button-surface-color-hover: #6f6f6f;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
@@ -139,8 +139,8 @@
   --token-code-block-button-surface-color-active: #2b303c;
   --token-code-block-button-surface-color-default: var(--token-code-block-surface-color-faint);
   --token-code-block-button-surface-color-hover: var(--token-code-block-surface-color-primary);
-  --token-code-block-focus-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #2b89ff;
   --token-code-block-foreground-color-faint: #b2b6bd;
   --token-code-block-foreground-color-primary: #d5d7db;

--- a/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
@@ -312,8 +312,8 @@
     --token-code-block-button-surface-color-hover: var(
       --token-code-block-surface-color-primary
     );
-    --token-code-block-focus-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #2b89ff;
     --token-code-block-foreground-color-faint: #b2b6bd;
     --token-code-block-foreground-color-primary: #d5d7db;
@@ -937,8 +937,8 @@
     --token-code-block-button-surface-color-active: #c6c6c6;
     --token-code-block-button-surface-color-default: #e8e8e8;
     --token-code-block-button-surface-color-hover: #c6c6c6;
-    --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #0f62fe;
     --token-code-block-foreground-color-faint: #525252;
     --token-code-block-foreground-color-primary: #161616;
@@ -1413,8 +1413,8 @@
     --token-code-block-button-surface-color-active: #525252;
     --token-code-block-button-surface-color-default: #333333;
     --token-code-block-button-surface-color-hover: #525252;
-    --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #78a9ff;
     --token-code-block-foreground-color-faint: #c6c6c6;
     --token-code-block-foreground-color-primary: #f4f4f4;
@@ -1884,8 +1884,8 @@
     --token-code-block-button-surface-color-active: #c6c6c6;
     --token-code-block-button-surface-color-default: #e8e8e8;
     --token-code-block-button-surface-color-hover: #c6c6c6;
-    --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #0f62fe;
     --token-code-block-foreground-color-faint: #525252;
     --token-code-block-foreground-color-primary: #161616;
@@ -2355,8 +2355,8 @@
     --token-code-block-button-surface-color-active: #c6c6c6;
     --token-code-block-button-surface-color-default: #e8e8e8;
     --token-code-block-button-surface-color-hover: #c6c6c6;
-    --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #0f62fe;
     --token-code-block-foreground-color-faint: #525252;
     --token-code-block-foreground-color-primary: #161616;
@@ -2831,8 +2831,8 @@
     --token-code-block-button-surface-color-active: #6f6f6f;
     --token-code-block-button-surface-color-default: #474747;
     --token-code-block-button-surface-color-hover: #6f6f6f;
-    --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #78a9ff;
     --token-code-block-foreground-color-faint: #c6c6c6;
     --token-code-block-foreground-color-primary: #f4f4f4;
@@ -3307,8 +3307,8 @@
     --token-code-block-button-surface-color-active: #525252;
     --token-code-block-button-surface-color-default: #333333;
     --token-code-block-button-surface-color-hover: #525252;
-    --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #78a9ff;
     --token-code-block-foreground-color-faint: #c6c6c6;
     --token-code-block-foreground-color-primary: #f4f4f4;

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -393,8 +393,8 @@
   --token-code-block-surface-color-selection: #86ff13;
   --token-code-block-border-color-strong: rgba(178, 182, 189, 0.4);
   --token-code-block-border-color-primary: rgba(178, 182, 189, 0.2);
-  --token-code-block-focus-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-typography-font-size: 0.8125rem;
   --token-code-block-button-surface-color-default: #15181e;
   --token-code-block-button-surface-color-hover: #0d0e12;

--- a/packages/tokens/src/products/shared/code-block.json
+++ b/packages/tokens/src/products/shared/code-block.json
@@ -190,7 +190,7 @@
         }
       }
     },
-    "focus": {
+    "focus-ring": {
       "color": {
         "action-internal": {
           "$type": "color",

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -3690,13 +3690,13 @@ button.hds-button[href]::after {
 .hds-code-block__copy-button.hds-copy-button:focus-visible {
   color: var(--token-code-block-foreground-color-primary);
   background-color: var(--token-code-block-button-surface-color-default);
-  border-color: var(--token-code-block-focus-color-action-internal);
+  border-color: var(--token-code-block-focus-ring-color-action-internal);
 }
 .hds-code-block__height-toggle-button:focus::before, .hds-code-block__height-toggle-button.mock-focus::before, .hds-code-block__height-toggle-button:focus-visible::before,
 .hds-code-block__copy-button.hds-copy-button:focus::before,
 .hds-code-block__copy-button.hds-copy-button.mock-focus::before,
 .hds-code-block__copy-button.hds-copy-button:focus-visible::before {
-  border-color: var(--token-code-block-focus-color-action-external);
+  border-color: var(--token-code-block-focus-ring-color-action-external);
 }
 .hds-code-block__height-toggle-button .hds-icon,
 .hds-code-block__copy-button.hds-copy-button .hds-icon {
@@ -3932,10 +3932,10 @@ button.hds-button[href]::after {
 }
 .hds-code-editor .hds-button:focus, .hds-code-editor .hds-button.mock-focus, .hds-code-editor .hds-button:hover, .hds-code-editor .hds-button.mock-hover {
   background-color: var(--token-code-block-button-surface-color-hover);
-  border-color: var(--token-code-block-focus-color-action-internal);
+  border-color: var(--token-code-block-focus-ring-color-action-internal);
 }
 .hds-code-editor .hds-button:focus::before, .hds-code-editor .hds-button.mock-focus::before, .hds-code-editor .hds-button:hover::before, .hds-code-editor .hds-button.mock-hover::before {
-  border-color: var(--token-code-block-focus-color-action-external);
+  border-color: var(--token-code-block-focus-ring-color-action-external);
 }
 .hds-code-editor .hds-button:focus .hds-button__icon, .hds-code-editor .hds-button.mock-focus .hds-button__icon, .hds-code-editor .hds-button:hover .hds-button__icon, .hds-code-editor .hds-button.mock-hover .hds-button__icon {
   color: var(--token-code-block-foreground-color-primary);

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -397,8 +397,8 @@
   --token-code-block-surface-color-selection: #86ff13;
   --token-code-block-border-color-strong: rgba(178, 182, 189, 0.4);
   --token-code-block-border-color-primary: rgba(178, 182, 189, 0.2);
-  --token-code-block-focus-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-typography-font-size: 0.8125rem;
   --token-code-block-button-surface-color-default: #15181e;
   --token-code-block-button-surface-color-hover: #0d0e12;
@@ -4353,13 +4353,13 @@ button.hds-button[href]::after {
 .hds-code-block__copy-button.hds-copy-button:focus-visible {
   color: var(--token-code-block-foreground-color-primary);
   background-color: var(--token-code-block-button-surface-color-default);
-  border-color: var(--token-code-block-focus-color-action-internal);
+  border-color: var(--token-code-block-focus-ring-color-action-internal);
 }
 .hds-code-block__height-toggle-button:focus::before, .hds-code-block__height-toggle-button.mock-focus::before, .hds-code-block__height-toggle-button:focus-visible::before,
 .hds-code-block__copy-button.hds-copy-button:focus::before,
 .hds-code-block__copy-button.hds-copy-button.mock-focus::before,
 .hds-code-block__copy-button.hds-copy-button:focus-visible::before {
-  border-color: var(--token-code-block-focus-color-action-external);
+  border-color: var(--token-code-block-focus-ring-color-action-external);
 }
 .hds-code-block__height-toggle-button .hds-icon,
 .hds-code-block__copy-button.hds-copy-button .hds-icon {
@@ -4595,10 +4595,10 @@ button.hds-button[href]::after {
 }
 .hds-code-editor .hds-button:focus, .hds-code-editor .hds-button.mock-focus, .hds-code-editor .hds-button:hover, .hds-code-editor .hds-button.mock-hover {
   background-color: var(--token-code-block-button-surface-color-hover);
-  border-color: var(--token-code-block-focus-color-action-internal);
+  border-color: var(--token-code-block-focus-ring-color-action-internal);
 }
 .hds-code-editor .hds-button:focus::before, .hds-code-editor .hds-button.mock-focus::before, .hds-code-editor .hds-button:hover::before, .hds-code-editor .hds-button.mock-hover::before {
-  border-color: var(--token-code-block-focus-color-action-external);
+  border-color: var(--token-code-block-focus-ring-color-action-external);
 }
 .hds-code-editor .hds-button:focus .hds-button__icon, .hds-code-editor .hds-button.mock-focus .hds-button__icon, .hds-code-editor .hds-button:hover .hds-button__icon, .hds-code-editor .hds-button.mock-hover .hds-button__icon {
   color: var(--token-code-block-foreground-color-primary);

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -306,8 +306,8 @@
   --token-code-block-button-surface-color-hover: var(
     --token-code-block-surface-color-primary
   );
-  --token-code-block-focus-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #2b89ff;
   --token-code-block-foreground-color-faint: #b2b6bd;
   --token-code-block-foreground-color-primary: #d5d7db;
@@ -916,8 +916,8 @@
     --token-code-block-button-surface-color-active: #c6c6c6;
     --token-code-block-button-surface-color-default: #e8e8e8;
     --token-code-block-button-surface-color-hover: #c6c6c6;
-    --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #0f62fe;
     --token-code-block-foreground-color-faint: #525252;
     --token-code-block-foreground-color-primary: #161616;
@@ -1392,8 +1392,8 @@
     --token-code-block-button-surface-color-active: #525252;
     --token-code-block-button-surface-color-default: #333333;
     --token-code-block-button-surface-color-hover: #525252;
-    --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #78a9ff;
     --token-code-block-foreground-color-faint: #c6c6c6;
     --token-code-block-foreground-color-primary: #f4f4f4;
@@ -1862,8 +1862,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -2327,8 +2327,8 @@
   --token-code-block-button-surface-color-active: #525252;
   --token-code-block-button-surface-color-default: #333333;
   --token-code-block-button-surface-color-hover: #525252;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;
@@ -2791,8 +2791,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -3255,8 +3255,8 @@
   --token-code-block-button-surface-color-active: #6f6f6f;
   --token-code-block-button-surface-color-default: #474747;
   --token-code-block-button-surface-color-hover: #6f6f6f;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
@@ -306,8 +306,8 @@
   --token-code-block-button-surface-color-hover: var(
     --token-code-block-surface-color-primary
   );
-  --token-code-block-focus-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0d69f2; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #9bc7fd; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #2b89ff;
   --token-code-block-foreground-color-faint: #b2b6bd;
   --token-code-block-foreground-color-primary: #d5d7db;
@@ -916,8 +916,8 @@
     --token-code-block-button-surface-color-active: #c6c6c6;
     --token-code-block-button-surface-color-default: #e8e8e8;
     --token-code-block-button-surface-color-hover: #c6c6c6;
-    --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #0f62fe;
     --token-code-block-foreground-color-faint: #525252;
     --token-code-block-foreground-color-primary: #161616;
@@ -1392,8 +1392,8 @@
     --token-code-block-button-surface-color-active: #525252;
     --token-code-block-button-surface-color-default: #333333;
     --token-code-block-button-surface-color-hover: #525252;
-    --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #78a9ff;
     --token-code-block-foreground-color-faint: #c6c6c6;
     --token-code-block-foreground-color-primary: #f4f4f4;
@@ -1861,8 +1861,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -2325,8 +2325,8 @@
   --token-code-block-button-surface-color-active: #525252;
   --token-code-block-button-surface-color-default: #333333;
   --token-code-block-button-surface-color-hover: #525252;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
@@ -139,8 +139,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -605,8 +605,8 @@
     --token-code-block-button-surface-color-active: #c6c6c6;
     --token-code-block-button-surface-color-default: #e8e8e8;
     --token-code-block-button-surface-color-hover: #c6c6c6;
-    --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #0f62fe;
     --token-code-block-foreground-color-faint: #525252;
     --token-code-block-foreground-color-primary: #161616;
@@ -1081,8 +1081,8 @@
     --token-code-block-button-surface-color-active: #525252;
     --token-code-block-button-surface-color-default: #333333;
     --token-code-block-button-surface-color-hover: #525252;
-    --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-    --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+    --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
     --token-code-block-foreground-color-action: #78a9ff;
     --token-code-block-foreground-color-faint: #c6c6c6;
     --token-code-block-foreground-color-primary: #f4f4f4;
@@ -1550,8 +1550,8 @@
   --token-code-block-button-surface-color-active: #c6c6c6;
   --token-code-block-button-surface-color-default: #e8e8e8;
   --token-code-block-button-surface-color-hover: #c6c6c6;
-  --token-code-block-focus-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #0f62fe; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #0f62fe;
   --token-code-block-foreground-color-faint: #525252;
   --token-code-block-foreground-color-primary: #161616;
@@ -2014,8 +2014,8 @@
   --token-code-block-button-surface-color-active: #525252;
   --token-code-block-button-surface-color-default: #333333;
   --token-code-block-button-surface-color-hover: #525252;
-  --token-code-block-focus-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
-  --token-code-block-focus-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-external: #ffffff; /** TODO: Remove once global tokens for dark themes are implemented */
+  --token-code-block-focus-ring-color-action-internal: #161616; /** TODO: Remove once global tokens for dark themes are implemented */
   --token-code-block-foreground-color-action: #78a9ff;
   --token-code-block-foreground-color-faint: #c6c6c6;
   --token-code-block-foreground-color-primary: #f4f4f4;


### PR DESCRIPTION
### :pushpin: Summary

Small PR that updates the `code-block-focus-color-***` token to `code-block-focus-ring-color-***` for consistency with all the other tokens.

Note: the update to the focus-ring tokens for the `AppHeader` will be done directly in the carbonization PR https://github.com/hashicorp/design-system/pull/3819/

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-6271

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>