### PR TITLE
[Project Solar / Phase 1 / Components] Update `body-100` Carbon font size and component tokens

### DIFF
--- a/packages/components/src/styles/components/breadcrumb.scss
+++ b/packages/components/src/styles/components/breadcrumb.scss
@@ -145,8 +145,8 @@ $hds-breadcrumb-item-visual-horizontal-padding: 4px;
   // we use the extra vertical padding to force the height of the parent item to be exactly $hds-breadcrumb-item-height
   padding: calc((#{$hds-breadcrumb-item-height} - 1rem) / 2) 0; // line height = 16px / 1rem
   overflow: hidden;
-  font-size: var(--token-typography-body-100-font-size);
-  font-family: var(--token-typography-body-100-font-family);
+  font-size: var(--token-breadcrumb-typography-font-size);
+  font-family: var(--token-typography-font-stack-text);
   line-height: var(--token-breadcrumb-typography-line-height);
   white-space: nowrap;
   text-decoration: underline;

--- a/packages/components/src/styles/components/pagination.scss
+++ b/packages/components/src/styles/components/pagination.scss
@@ -117,6 +117,7 @@ $pagination-nav-control-padding-horizontal: 12px;
 // * Sub-component: Info
 // ---------------------------------------
 .hds-pagination-info {
+  font-size: var(--token-pagination-info-typography-font-size);
   white-space: nowrap;
 }
 
@@ -210,6 +211,11 @@ $pagination-nav-control-padding-horizontal: 12px;
   justify-content: flex-end;
 }
 
+.hds-pagination-nav__arrow-label,
+.hds-pagination-nav__number-content {
+  font-size: var(--token-pagination-nav-control-typography-font-size);
+}
+
 .hds-pagination-nav__number--is-selected {
   position: relative;
   color: var(--token-pagination-nav-control-foreground-color-default);
@@ -259,6 +265,8 @@ $pagination-nav-control-padding-horizontal: 12px;
   align-items: center;
 
   > label {
+    // font styles for this select differ from standard `Form::Select::Base` styles
+    font-size: var(--token-pagination-size-selector-typography-font-size);
     white-space: nowrap;
 
     @include hds-apply-only-if-carbon() {
@@ -274,7 +282,7 @@ $pagination-nav-control-padding-horizontal: 12px;
     margin-left: 12px;
     padding: 0 24px 0 8px;
     // font styles for this select differ from standard `Form::Select::Base` styles
-    font-size: var(--token-typography-body-100-font-size);
+    font-size: var(--token-pagination-size-selector-typography-font-size);
     font-family: var(--token-typography-body-100-font-family);
     line-height: var(--token-typography-body-100-line-height);
     // TODO: Test simplifying value in select.scss

--- a/packages/tokens/dist/docs/products/themed-tokens.json
+++ b/packages/tokens/dist/docs/products/themed-tokens.json
@@ -21530,25 +21530,11 @@
       "$value": "0.8125rem",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "0.875rem",
-        "cds-g10": "0.875rem",
-        "cds-g90": "0.875rem",
-        "cds-g100": "0.875rem"
-      },
       "original": {
         "$type": "font-size",
         "$value": "13",
         "unit": "px",
         "comment": "13px/0.8125rem",
-        "$modes": {
-          "default": "13",
-          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-        },
         "key": "{typography.body-100.font-size}"
       },
       "name": "token-typography-body-100-font-size",
@@ -36395,7 +36381,7 @@
       "$type": "font-size",
       "$value": "0.75rem",
       "$modes": {
-        "default": "0.875rem",
+        "default": "0.8125rem",
         "cds-g0": "0.75rem",
         "cds-g10": "0.75rem",
         "cds-g90": "0.75rem",
@@ -43444,28 +43430,14 @@
     "token-typography-body-100-font-size": {
       "key": "{typography.body-100.font-size}",
       "$type": "font-size",
-      "$value": "0.875rem",
+      "$value": "0.8125rem",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "0.875rem",
-        "cds-g10": "0.875rem",
-        "cds-g90": "0.875rem",
-        "cds-g100": "0.875rem"
-      },
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$value": "13",
         "unit": "px",
         "comment": "13px/0.8125rem",
-        "$modes": {
-          "default": "13",
-          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-        },
         "key": "{typography.body-100.font-size}"
       },
       "name": "token-typography-body-100-font-size",
@@ -58312,7 +58284,7 @@
       "$type": "font-size",
       "$value": "0.75rem",
       "$modes": {
-        "default": "0.875rem",
+        "default": "0.8125rem",
         "cds-g0": "0.75rem",
         "cds-g10": "0.75rem",
         "cds-g90": "0.75rem",
@@ -65361,28 +65333,14 @@
     "token-typography-body-100-font-size": {
       "key": "{typography.body-100.font-size}",
       "$type": "font-size",
-      "$value": "0.875rem",
+      "$value": "0.8125rem",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "0.875rem",
-        "cds-g10": "0.875rem",
-        "cds-g90": "0.875rem",
-        "cds-g100": "0.875rem"
-      },
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$value": "13",
         "unit": "px",
         "comment": "13px/0.8125rem",
-        "$modes": {
-          "default": "13",
-          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-        },
         "key": "{typography.body-100.font-size}"
       },
       "name": "token-typography-body-100-font-size",
@@ -80229,7 +80187,7 @@
       "$type": "font-size",
       "$value": "0.75rem",
       "$modes": {
-        "default": "0.875rem",
+        "default": "0.8125rem",
         "cds-g0": "0.75rem",
         "cds-g10": "0.75rem",
         "cds-g90": "0.75rem",
@@ -87278,28 +87236,14 @@
     "token-typography-body-100-font-size": {
       "key": "{typography.body-100.font-size}",
       "$type": "font-size",
-      "$value": "0.875rem",
+      "$value": "0.8125rem",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "0.875rem",
-        "cds-g10": "0.875rem",
-        "cds-g90": "0.875rem",
-        "cds-g100": "0.875rem"
-      },
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$value": "13",
         "unit": "px",
         "comment": "13px/0.8125rem",
-        "$modes": {
-          "default": "13",
-          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-        },
         "key": "{typography.body-100.font-size}"
       },
       "name": "token-typography-body-100-font-size",
@@ -102146,7 +102090,7 @@
       "$type": "font-size",
       "$value": "0.75rem",
       "$modes": {
-        "default": "0.875rem",
+        "default": "0.8125rem",
         "cds-g0": "0.75rem",
         "cds-g10": "0.75rem",
         "cds-g90": "0.75rem",
@@ -109195,28 +109139,14 @@
     "token-typography-body-100-font-size": {
       "key": "{typography.body-100.font-size}",
       "$type": "font-size",
-      "$value": "0.875rem",
+      "$value": "0.8125rem",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "0.875rem",
-        "cds-g10": "0.875rem",
-        "cds-g90": "0.875rem",
-        "cds-g100": "0.875rem"
-      },
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$value": "13",
         "unit": "px",
         "comment": "13px/0.8125rem",
-        "$modes": {
-          "default": "13",
-          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-        },
         "key": "{typography.body-100.font-size}"
       },
       "name": "token-typography-body-100-font-size",

--- a/packages/tokens/dist/docs/products/themed-tokens.json
+++ b/packages/tokens/dist/docs/products/themed-tokens.json
@@ -10107,6 +10107,39 @@
         "large"
       ]
     },
+    "token-breadcrumb-typography-font-size": {
+      "key": "{breadcrumb.typography.font-size}",
+      "$type": "font-size",
+      "$value": "0.8125rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "font-size",
+        "$value": "{typography.body-100.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{breadcrumb.typography.font-size}"
+      },
+      "name": "token-breadcrumb-typography-font-size",
+      "attributes": {
+        "category": "breadcrumb"
+      },
+      "path": [
+        "breadcrumb",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-breadcrumb-typography-line-height": {
       "key": "{breadcrumb.typography.line-height}",
       "$type": "number",
@@ -14479,10 +14512,34 @@
       "$value": "0.8125rem",
       "$modes": {
         "default": "0.8125rem",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
@@ -14492,10 +14549,34 @@
         "$value": "{typography.body-100.font-size}",
         "$modes": {
           "default": "{typography.body-100.font-size}",
-          "cds-g0": "{carbon.typography.label01.font-size}",
-          "cds-g10": "{carbon.typography.label01.font-size}",
-          "cds-g90": "{carbon.typography.label01.font-size}",
-          "cds-g100": "{carbon.typography.label01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "comments": {
           "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
@@ -16792,10 +16873,34 @@
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "original": {
         "$type": "font-size",
@@ -16803,10 +16908,34 @@
         "unit": "rem",
         "$modes": {
           "default": "0.8125",
-          "cds-g0": "{carbon.typography.helperText01.font-size}",
-          "cds-g10": "{carbon.typography.helperText01.font-size}",
-          "cds-g90": "{carbon.typography.helperText01.font-size}",
-          "cds-g100": "{carbon.typography.helperText01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "key": "{link.standalone.typography.font-size.small}"
       },
@@ -17614,6 +17743,41 @@
         "spacing"
       ]
     },
+    "token-pagination-nav-control-typography-font-size": {
+      "key": "{pagination.nav.control.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.8125rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{typography.body-100.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.nav.control.typography.font-size}"
+      },
+      "name": "token-pagination-nav-control-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "nav",
+        "control",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-pagination-nav-control-typography-font-weight-active": {
       "key": "{pagination.nav.control.typography.font-weight.active}",
       "$type": "font-weight",
@@ -17741,6 +17905,74 @@
         "surface",
         "color",
         "hover"
+      ]
+    },
+    "token-pagination-info-typography-font-size": {
+      "key": "{pagination.info.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.8125rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{typography.body-100.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.info.typography.font-size}"
+      },
+      "name": "token-pagination-info-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "info",
+        "typography",
+        "font-size"
+      ]
+    },
+    "token-pagination-size-selector-typography-font-size": {
+      "key": "{pagination.size-selector.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.8125rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{typography.body-100.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.size-selector.typography.font-size}"
+      },
+      "name": "token-pagination-size-selector-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "size-selector",
+        "typography",
+        "font-size"
       ]
     },
     "token-pagination-child-spacing-vertical": {
@@ -32010,6 +32242,39 @@
         "large"
       ]
     },
+    "token-breadcrumb-typography-font-size": {
+      "key": "{breadcrumb.typography.font-size}",
+      "$type": "font-size",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "font-size",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{breadcrumb.typography.font-size}"
+      },
+      "name": "token-breadcrumb-typography-font-size",
+      "attributes": {
+        "category": "breadcrumb"
+      },
+      "path": [
+        "breadcrumb",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-breadcrumb-typography-line-height": {
       "key": "{breadcrumb.typography.line-height}",
       "$type": "number",
@@ -36382,27 +36647,77 @@
       "$value": "0.75rem",
       "$modes": {
         "default": "0.8125rem",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "unit": "rem",
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.label01.font-size}",
+        "$value": "0.75",
         "$modes": {
           "default": "{typography.body-100.font-size}",
-          "cds-g0": "{carbon.typography.label01.font-size}",
-          "cds-g10": "{carbon.typography.label01.font-size}",
-          "cds-g90": "{carbon.typography.label01.font-size}",
-          "cds-g100": "{carbon.typography.label01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "comments": {
           "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
         },
+        "unit": "rem",
         "key": "{dialog-primitive.header.tagline.typography.font-size}"
       },
       "name": "token-dialog-primitive-header-tagline-typography-font-size",
@@ -38695,21 +39010,69 @@
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.helperText01.font-size}",
+        "$value": "0.75",
         "unit": "rem",
         "$modes": {
           "default": "0.8125",
-          "cds-g0": "{carbon.typography.helperText01.font-size}",
-          "cds-g10": "{carbon.typography.helperText01.font-size}",
-          "cds-g90": "{carbon.typography.helperText01.font-size}",
-          "cds-g100": "{carbon.typography.helperText01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "key": "{link.standalone.typography.font-size.small}"
       },
@@ -39517,6 +39880,41 @@
         "spacing"
       ]
     },
+    "token-pagination-nav-control-typography-font-size": {
+      "key": "{pagination.nav.control.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.nav.control.typography.font-size}"
+      },
+      "name": "token-pagination-nav-control-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "nav",
+        "control",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-pagination-nav-control-typography-font-weight-active": {
       "key": "{pagination.nav.control.typography.font-weight.active}",
       "$type": "font-weight",
@@ -39644,6 +40042,74 @@
         "surface",
         "color",
         "hover"
+      ]
+    },
+    "token-pagination-info-typography-font-size": {
+      "key": "{pagination.info.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.info.typography.font-size}"
+      },
+      "name": "token-pagination-info-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "info",
+        "typography",
+        "font-size"
+      ]
+    },
+    "token-pagination-size-selector-typography-font-size": {
+      "key": "{pagination.size-selector.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.size-selector.typography.font-size}"
+      },
+      "name": "token-pagination-size-selector-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "size-selector",
+        "typography",
+        "font-size"
       ]
     },
     "token-pagination-child-spacing-vertical": {
@@ -53913,6 +54379,39 @@
         "large"
       ]
     },
+    "token-breadcrumb-typography-font-size": {
+      "key": "{breadcrumb.typography.font-size}",
+      "$type": "font-size",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "font-size",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{breadcrumb.typography.font-size}"
+      },
+      "name": "token-breadcrumb-typography-font-size",
+      "attributes": {
+        "category": "breadcrumb"
+      },
+      "path": [
+        "breadcrumb",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-breadcrumb-typography-line-height": {
       "key": "{breadcrumb.typography.line-height}",
       "$type": "number",
@@ -58285,27 +58784,77 @@
       "$value": "0.75rem",
       "$modes": {
         "default": "0.8125rem",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "unit": "rem",
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.label01.font-size}",
+        "$value": "0.75",
         "$modes": {
           "default": "{typography.body-100.font-size}",
-          "cds-g0": "{carbon.typography.label01.font-size}",
-          "cds-g10": "{carbon.typography.label01.font-size}",
-          "cds-g90": "{carbon.typography.label01.font-size}",
-          "cds-g100": "{carbon.typography.label01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "comments": {
           "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
         },
+        "unit": "rem",
         "key": "{dialog-primitive.header.tagline.typography.font-size}"
       },
       "name": "token-dialog-primitive-header-tagline-typography-font-size",
@@ -60598,21 +61147,69 @@
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.helperText01.font-size}",
+        "$value": "0.75",
         "unit": "rem",
         "$modes": {
           "default": "0.8125",
-          "cds-g0": "{carbon.typography.helperText01.font-size}",
-          "cds-g10": "{carbon.typography.helperText01.font-size}",
-          "cds-g90": "{carbon.typography.helperText01.font-size}",
-          "cds-g100": "{carbon.typography.helperText01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "key": "{link.standalone.typography.font-size.small}"
       },
@@ -61420,6 +62017,41 @@
         "spacing"
       ]
     },
+    "token-pagination-nav-control-typography-font-size": {
+      "key": "{pagination.nav.control.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.nav.control.typography.font-size}"
+      },
+      "name": "token-pagination-nav-control-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "nav",
+        "control",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-pagination-nav-control-typography-font-weight-active": {
       "key": "{pagination.nav.control.typography.font-weight.active}",
       "$type": "font-weight",
@@ -61547,6 +62179,74 @@
         "surface",
         "color",
         "hover"
+      ]
+    },
+    "token-pagination-info-typography-font-size": {
+      "key": "{pagination.info.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.info.typography.font-size}"
+      },
+      "name": "token-pagination-info-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "info",
+        "typography",
+        "font-size"
+      ]
+    },
+    "token-pagination-size-selector-typography-font-size": {
+      "key": "{pagination.size-selector.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.size-selector.typography.font-size}"
+      },
+      "name": "token-pagination-size-selector-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "size-selector",
+        "typography",
+        "font-size"
       ]
     },
     "token-pagination-child-spacing-vertical": {
@@ -75816,6 +76516,39 @@
         "large"
       ]
     },
+    "token-breadcrumb-typography-font-size": {
+      "key": "{breadcrumb.typography.font-size}",
+      "$type": "font-size",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "font-size",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{breadcrumb.typography.font-size}"
+      },
+      "name": "token-breadcrumb-typography-font-size",
+      "attributes": {
+        "category": "breadcrumb"
+      },
+      "path": [
+        "breadcrumb",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-breadcrumb-typography-line-height": {
       "key": "{breadcrumb.typography.line-height}",
       "$type": "number",
@@ -80188,27 +80921,77 @@
       "$value": "0.75rem",
       "$modes": {
         "default": "0.8125rem",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "unit": "rem",
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.label01.font-size}",
+        "$value": "0.75",
         "$modes": {
           "default": "{typography.body-100.font-size}",
-          "cds-g0": "{carbon.typography.label01.font-size}",
-          "cds-g10": "{carbon.typography.label01.font-size}",
-          "cds-g90": "{carbon.typography.label01.font-size}",
-          "cds-g100": "{carbon.typography.label01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "comments": {
           "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
         },
+        "unit": "rem",
         "key": "{dialog-primitive.header.tagline.typography.font-size}"
       },
       "name": "token-dialog-primitive-header-tagline-typography-font-size",
@@ -82501,21 +83284,69 @@
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.helperText01.font-size}",
+        "$value": "0.75",
         "unit": "rem",
         "$modes": {
           "default": "0.8125",
-          "cds-g0": "{carbon.typography.helperText01.font-size}",
-          "cds-g10": "{carbon.typography.helperText01.font-size}",
-          "cds-g90": "{carbon.typography.helperText01.font-size}",
-          "cds-g100": "{carbon.typography.helperText01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "key": "{link.standalone.typography.font-size.small}"
       },
@@ -83323,6 +84154,41 @@
         "spacing"
       ]
     },
+    "token-pagination-nav-control-typography-font-size": {
+      "key": "{pagination.nav.control.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.nav.control.typography.font-size}"
+      },
+      "name": "token-pagination-nav-control-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "nav",
+        "control",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-pagination-nav-control-typography-font-weight-active": {
       "key": "{pagination.nav.control.typography.font-weight.active}",
       "$type": "font-weight",
@@ -83450,6 +84316,74 @@
         "surface",
         "color",
         "hover"
+      ]
+    },
+    "token-pagination-info-typography-font-size": {
+      "key": "{pagination.info.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.info.typography.font-size}"
+      },
+      "name": "token-pagination-info-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "info",
+        "typography",
+        "font-size"
+      ]
+    },
+    "token-pagination-size-selector-typography-font-size": {
+      "key": "{pagination.size-selector.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.size-selector.typography.font-size}"
+      },
+      "name": "token-pagination-size-selector-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "size-selector",
+        "typography",
+        "font-size"
       ]
     },
     "token-pagination-child-spacing-vertical": {
@@ -97719,6 +98653,39 @@
         "large"
       ]
     },
+    "token-breadcrumb-typography-font-size": {
+      "key": "{breadcrumb.typography.font-size}",
+      "$type": "font-size",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "font-size",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{breadcrumb.typography.font-size}"
+      },
+      "name": "token-breadcrumb-typography-font-size",
+      "attributes": {
+        "category": "breadcrumb"
+      },
+      "path": [
+        "breadcrumb",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-breadcrumb-typography-line-height": {
       "key": "{breadcrumb.typography.line-height}",
       "$type": "number",
@@ -102091,27 +103058,77 @@
       "$value": "0.75rem",
       "$modes": {
         "default": "0.8125rem",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "unit": "rem",
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.label01.font-size}",
+        "$value": "0.75",
         "$modes": {
           "default": "{typography.body-100.font-size}",
-          "cds-g0": "{carbon.typography.label01.font-size}",
-          "cds-g10": "{carbon.typography.label01.font-size}",
-          "cds-g90": "{carbon.typography.label01.font-size}",
-          "cds-g100": "{carbon.typography.label01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/dialog-primitive.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "comments": {
           "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
         },
+        "unit": "rem",
         "key": "{dialog-primitive.header.tagline.typography.font-size}"
       },
       "name": "token-dialog-primitive-header-tagline-typography-font-size",
@@ -104404,21 +105421,69 @@
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "0.75rem",
-        "cds-g10": "0.75rem",
-        "cds-g90": "0.75rem",
-        "cds-g100": "0.75rem"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "original": {
         "$type": "font-size",
-        "$value": "{carbon.typography.helperText01.font-size}",
+        "$value": "0.75",
         "unit": "rem",
         "$modes": {
           "default": "0.8125",
-          "cds-g0": "{carbon.typography.helperText01.font-size}",
-          "cds-g10": "{carbon.typography.helperText01.font-size}",
-          "cds-g90": "{carbon.typography.helperText01.font-size}",
-          "cds-g100": "{carbon.typography.helperText01.font-size}"
+          "cds-g0": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g10": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g90": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          },
+          "cds-g100": {
+            "$value": "0.75",
+            "unit": "rem",
+            "filePath": "src/products/shared/link/standalone.json",
+            "isSource": true,
+            "$type": "font-size"
+          }
         },
         "key": "{link.standalone.typography.font-size.small}"
       },
@@ -105226,6 +106291,41 @@
         "spacing"
       ]
     },
+    "token-pagination-nav-control-typography-font-size": {
+      "key": "{pagination.nav.control.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.nav.control.typography.font-size}"
+      },
+      "name": "token-pagination-nav-control-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "nav",
+        "control",
+        "typography",
+        "font-size"
+      ]
+    },
     "token-pagination-nav-control-typography-font-weight-active": {
       "key": "{pagination.nav.control.typography.font-weight.active}",
       "$type": "font-weight",
@@ -105353,6 +106453,74 @@
         "surface",
         "color",
         "hover"
+      ]
+    },
+    "token-pagination-info-typography-font-size": {
+      "key": "{pagination.info.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.info.typography.font-size}"
+      },
+      "name": "token-pagination-info-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "info",
+        "typography",
+        "font-size"
+      ]
+    },
+    "token-pagination-size-selector-typography-font-size": {
+      "key": "{pagination.size-selector.typography.font-size}",
+      "$type": "typography",
+      "$value": "0.875rem",
+      "$modes": {
+        "default": "0.8125rem",
+        "cds-g0": "0.875rem",
+        "cds-g10": "0.875rem",
+        "cds-g90": "0.875rem",
+        "cds-g100": "0.875rem"
+      },
+      "original": {
+        "$type": "typography",
+        "$value": "{carbon.typography.bodyCompact01.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        },
+        "key": "{pagination.size-selector.typography.font-size}"
+      },
+      "name": "token-pagination-size-selector-typography-font-size",
+      "attributes": {
+        "category": "pagination"
+      },
+      "path": [
+        "pagination",
+        "size-selector",
+        "typography",
+        "font-size"
       ]
     },
     "token-pagination-child-spacing-vertical": {

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
@@ -14481,7 +14481,7 @@
     "$type": "font-size",
     "$value": "0.75rem",
     "$modes": {
-      "default": "0.875rem",
+      "default": "0.8125rem",
       "cds-g0": "0.75rem",
       "cds-g10": "0.75rem",
       "cds-g90": "0.75rem",
@@ -21530,28 +21530,14 @@
   {
     "key": "{typography.body-100.font-size}",
     "$type": "font-size",
-    "$value": "0.875rem",
+    "$value": "0.8125rem",
     "unit": "px",
     "comment": "13px/0.8125rem",
-    "$modes": {
-      "default": "13",
-      "cds-g0": "0.875rem",
-      "cds-g10": "0.875rem",
-      "cds-g90": "0.875rem",
-      "cds-g100": "0.875rem"
-    },
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$value": "13",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-      },
       "key": "{typography.body-100.font-size}"
     },
     "name": "token-typography-body-100-font-size",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
@@ -10111,6 +10111,39 @@
     ]
   },
   {
+    "key": "{breadcrumb.typography.font-size}",
+    "$type": "font-size",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "font-size",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{breadcrumb.typography.font-size}"
+    },
+    "name": "token-breadcrumb-typography-font-size",
+    "attributes": {
+      "category": "breadcrumb"
+    },
+    "path": [
+      "breadcrumb",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{breadcrumb.typography.line-height}",
     "$type": "number",
     "$value": 1.28572,
@@ -14482,27 +14515,77 @@
     "$value": "0.75rem",
     "$modes": {
       "default": "0.8125rem",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "comments": {
       "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
     },
+    "unit": "rem",
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.label01.font-size}",
+      "$value": "0.75",
       "$modes": {
         "default": "{typography.body-100.font-size}",
-        "cds-g0": "{carbon.typography.label01.font-size}",
-        "cds-g10": "{carbon.typography.label01.font-size}",
-        "cds-g90": "{carbon.typography.label01.font-size}",
-        "cds-g100": "{carbon.typography.label01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "unit": "rem",
       "key": "{dialog-primitive.header.tagline.typography.font-size}"
     },
     "name": "token-dialog-primitive-header-tagline-typography-font-size",
@@ -16795,21 +16878,69 @@
     "unit": "rem",
     "$modes": {
       "default": "0.8125",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.helperText01.font-size}",
+      "$value": "0.75",
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "{carbon.typography.helperText01.font-size}",
-        "cds-g10": "{carbon.typography.helperText01.font-size}",
-        "cds-g90": "{carbon.typography.helperText01.font-size}",
-        "cds-g100": "{carbon.typography.helperText01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "key": "{link.standalone.typography.font-size.small}"
     },
@@ -17618,6 +17749,41 @@
     ]
   },
   {
+    "key": "{pagination.nav.control.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.nav.control.typography.font-size}"
+    },
+    "name": "token-pagination-nav-control-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "nav",
+      "control",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{pagination.nav.control.typography.font-weight.active}",
     "$type": "font-weight",
     "$value": 600,
@@ -17744,6 +17910,74 @@
       "surface",
       "color",
       "hover"
+    ]
+  },
+  {
+    "key": "{pagination.info.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.info.typography.font-size}"
+    },
+    "name": "token-pagination-info-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "info",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
+    "key": "{pagination.size-selector.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.size-selector.typography.font-size}"
+    },
+    "name": "token-pagination-size-selector-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "size-selector",
+      "typography",
+      "font-size"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
@@ -14481,7 +14481,7 @@
     "$type": "font-size",
     "$value": "0.75rem",
     "$modes": {
-      "default": "0.875rem",
+      "default": "0.8125rem",
       "cds-g0": "0.75rem",
       "cds-g10": "0.75rem",
       "cds-g90": "0.75rem",
@@ -21530,28 +21530,14 @@
   {
     "key": "{typography.body-100.font-size}",
     "$type": "font-size",
-    "$value": "0.875rem",
+    "$value": "0.8125rem",
     "unit": "px",
     "comment": "13px/0.8125rem",
-    "$modes": {
-      "default": "13",
-      "cds-g0": "0.875rem",
-      "cds-g10": "0.875rem",
-      "cds-g90": "0.875rem",
-      "cds-g100": "0.875rem"
-    },
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$value": "13",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-      },
       "key": "{typography.body-100.font-size}"
     },
     "name": "token-typography-body-100-font-size",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
@@ -10111,6 +10111,39 @@
     ]
   },
   {
+    "key": "{breadcrumb.typography.font-size}",
+    "$type": "font-size",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "font-size",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{breadcrumb.typography.font-size}"
+    },
+    "name": "token-breadcrumb-typography-font-size",
+    "attributes": {
+      "category": "breadcrumb"
+    },
+    "path": [
+      "breadcrumb",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{breadcrumb.typography.line-height}",
     "$type": "number",
     "$value": 1.28572,
@@ -14482,27 +14515,77 @@
     "$value": "0.75rem",
     "$modes": {
       "default": "0.8125rem",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "comments": {
       "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
     },
+    "unit": "rem",
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.label01.font-size}",
+      "$value": "0.75",
       "$modes": {
         "default": "{typography.body-100.font-size}",
-        "cds-g0": "{carbon.typography.label01.font-size}",
-        "cds-g10": "{carbon.typography.label01.font-size}",
-        "cds-g90": "{carbon.typography.label01.font-size}",
-        "cds-g100": "{carbon.typography.label01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "unit": "rem",
       "key": "{dialog-primitive.header.tagline.typography.font-size}"
     },
     "name": "token-dialog-primitive-header-tagline-typography-font-size",
@@ -16795,21 +16878,69 @@
     "unit": "rem",
     "$modes": {
       "default": "0.8125",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.helperText01.font-size}",
+      "$value": "0.75",
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "{carbon.typography.helperText01.font-size}",
-        "cds-g10": "{carbon.typography.helperText01.font-size}",
-        "cds-g90": "{carbon.typography.helperText01.font-size}",
-        "cds-g100": "{carbon.typography.helperText01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "key": "{link.standalone.typography.font-size.small}"
     },
@@ -17618,6 +17749,41 @@
     ]
   },
   {
+    "key": "{pagination.nav.control.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.nav.control.typography.font-size}"
+    },
+    "name": "token-pagination-nav-control-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "nav",
+      "control",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{pagination.nav.control.typography.font-weight.active}",
     "$type": "font-weight",
     "$value": 600,
@@ -17744,6 +17910,74 @@
       "surface",
       "color",
       "hover"
+    ]
+  },
+  {
+    "key": "{pagination.info.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.info.typography.font-size}"
+    },
+    "name": "token-pagination-info-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "info",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
+    "key": "{pagination.size-selector.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.size-selector.typography.font-size}"
+    },
+    "name": "token-pagination-size-selector-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "size-selector",
+      "typography",
+      "font-size"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
@@ -14481,7 +14481,7 @@
     "$type": "font-size",
     "$value": "0.75rem",
     "$modes": {
-      "default": "0.875rem",
+      "default": "0.8125rem",
       "cds-g0": "0.75rem",
       "cds-g10": "0.75rem",
       "cds-g90": "0.75rem",
@@ -21530,28 +21530,14 @@
   {
     "key": "{typography.body-100.font-size}",
     "$type": "font-size",
-    "$value": "0.875rem",
+    "$value": "0.8125rem",
     "unit": "px",
     "comment": "13px/0.8125rem",
-    "$modes": {
-      "default": "13",
-      "cds-g0": "0.875rem",
-      "cds-g10": "0.875rem",
-      "cds-g90": "0.875rem",
-      "cds-g100": "0.875rem"
-    },
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$value": "13",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-      },
       "key": "{typography.body-100.font-size}"
     },
     "name": "token-typography-body-100-font-size",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
@@ -10111,6 +10111,39 @@
     ]
   },
   {
+    "key": "{breadcrumb.typography.font-size}",
+    "$type": "font-size",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "font-size",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{breadcrumb.typography.font-size}"
+    },
+    "name": "token-breadcrumb-typography-font-size",
+    "attributes": {
+      "category": "breadcrumb"
+    },
+    "path": [
+      "breadcrumb",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{breadcrumb.typography.line-height}",
     "$type": "number",
     "$value": 1.28572,
@@ -14482,27 +14515,77 @@
     "$value": "0.75rem",
     "$modes": {
       "default": "0.8125rem",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "comments": {
       "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
     },
+    "unit": "rem",
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.label01.font-size}",
+      "$value": "0.75",
       "$modes": {
         "default": "{typography.body-100.font-size}",
-        "cds-g0": "{carbon.typography.label01.font-size}",
-        "cds-g10": "{carbon.typography.label01.font-size}",
-        "cds-g90": "{carbon.typography.label01.font-size}",
-        "cds-g100": "{carbon.typography.label01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "unit": "rem",
       "key": "{dialog-primitive.header.tagline.typography.font-size}"
     },
     "name": "token-dialog-primitive-header-tagline-typography-font-size",
@@ -16795,21 +16878,69 @@
     "unit": "rem",
     "$modes": {
       "default": "0.8125",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.helperText01.font-size}",
+      "$value": "0.75",
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "{carbon.typography.helperText01.font-size}",
-        "cds-g10": "{carbon.typography.helperText01.font-size}",
-        "cds-g90": "{carbon.typography.helperText01.font-size}",
-        "cds-g100": "{carbon.typography.helperText01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "key": "{link.standalone.typography.font-size.small}"
     },
@@ -17618,6 +17749,41 @@
     ]
   },
   {
+    "key": "{pagination.nav.control.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.nav.control.typography.font-size}"
+    },
+    "name": "token-pagination-nav-control-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "nav",
+      "control",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{pagination.nav.control.typography.font-weight.active}",
     "$type": "font-weight",
     "$value": 600,
@@ -17744,6 +17910,74 @@
       "surface",
       "color",
       "hover"
+    ]
+  },
+  {
+    "key": "{pagination.info.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.info.typography.font-size}"
+    },
+    "name": "token-pagination-info-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "info",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
+    "key": "{pagination.size-selector.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.size-selector.typography.font-size}"
+    },
+    "name": "token-pagination-size-selector-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "size-selector",
+      "typography",
+      "font-size"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
@@ -14481,7 +14481,7 @@
     "$type": "font-size",
     "$value": "0.75rem",
     "$modes": {
-      "default": "0.875rem",
+      "default": "0.8125rem",
       "cds-g0": "0.75rem",
       "cds-g10": "0.75rem",
       "cds-g90": "0.75rem",
@@ -21530,28 +21530,14 @@
   {
     "key": "{typography.body-100.font-size}",
     "$type": "font-size",
-    "$value": "0.875rem",
+    "$value": "0.8125rem",
     "unit": "px",
     "comment": "13px/0.8125rem",
-    "$modes": {
-      "default": "13",
-      "cds-g0": "0.875rem",
-      "cds-g10": "0.875rem",
-      "cds-g90": "0.875rem",
-      "cds-g100": "0.875rem"
-    },
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$value": "13",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-      },
       "key": "{typography.body-100.font-size}"
     },
     "name": "token-typography-body-100-font-size",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
@@ -10111,6 +10111,39 @@
     ]
   },
   {
+    "key": "{breadcrumb.typography.font-size}",
+    "$type": "font-size",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "font-size",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{breadcrumb.typography.font-size}"
+    },
+    "name": "token-breadcrumb-typography-font-size",
+    "attributes": {
+      "category": "breadcrumb"
+    },
+    "path": [
+      "breadcrumb",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{breadcrumb.typography.line-height}",
     "$type": "number",
     "$value": 1.28572,
@@ -14482,27 +14515,77 @@
     "$value": "0.75rem",
     "$modes": {
       "default": "0.8125rem",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "comments": {
       "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
     },
+    "unit": "rem",
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.label01.font-size}",
+      "$value": "0.75",
       "$modes": {
         "default": "{typography.body-100.font-size}",
-        "cds-g0": "{carbon.typography.label01.font-size}",
-        "cds-g10": "{carbon.typography.label01.font-size}",
-        "cds-g90": "{carbon.typography.label01.font-size}",
-        "cds-g100": "{carbon.typography.label01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "unit": "rem",
       "key": "{dialog-primitive.header.tagline.typography.font-size}"
     },
     "name": "token-dialog-primitive-header-tagline-typography-font-size",
@@ -16795,21 +16878,69 @@
     "unit": "rem",
     "$modes": {
       "default": "0.8125",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "original": {
       "$type": "font-size",
-      "$value": "{carbon.typography.helperText01.font-size}",
+      "$value": "0.75",
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "{carbon.typography.helperText01.font-size}",
-        "cds-g10": "{carbon.typography.helperText01.font-size}",
-        "cds-g90": "{carbon.typography.helperText01.font-size}",
-        "cds-g100": "{carbon.typography.helperText01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "key": "{link.standalone.typography.font-size.small}"
     },
@@ -17618,6 +17749,41 @@
     ]
   },
   {
+    "key": "{pagination.nav.control.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.nav.control.typography.font-size}"
+    },
+    "name": "token-pagination-nav-control-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "nav",
+      "control",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{pagination.nav.control.typography.font-weight.active}",
     "$type": "font-weight",
     "$value": 600,
@@ -17744,6 +17910,74 @@
       "surface",
       "color",
       "hover"
+    ]
+  },
+  {
+    "key": "{pagination.info.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.info.typography.font-size}"
+    },
+    "name": "token-pagination-info-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "info",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
+    "key": "{pagination.size-selector.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.875rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{carbon.typography.bodyCompact01.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.size-selector.typography.font-size}"
+    },
+    "name": "token-pagination-size-selector-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "size-selector",
+      "typography",
+      "font-size"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/themed-tokens/default.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/default.json
@@ -21529,25 +21529,11 @@
     "$value": "0.8125rem",
     "unit": "px",
     "comment": "13px/0.8125rem",
-    "$modes": {
-      "default": "13",
-      "cds-g0": "0.875rem",
-      "cds-g10": "0.875rem",
-      "cds-g90": "0.875rem",
-      "cds-g100": "0.875rem"
-    },
     "original": {
       "$type": "font-size",
       "$value": "13",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-      },
       "key": "{typography.body-100.font-size}"
     },
     "name": "token-typography-body-100-font-size",

--- a/packages/tokens/dist/docs/products/themed-tokens/default.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/default.json
@@ -10107,6 +10107,39 @@
     ]
   },
   {
+    "key": "{breadcrumb.typography.font-size}",
+    "$type": "font-size",
+    "$value": "0.8125rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "font-size",
+      "$value": "{typography.body-100.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{breadcrumb.typography.font-size}"
+    },
+    "name": "token-breadcrumb-typography-font-size",
+    "attributes": {
+      "category": "breadcrumb"
+    },
+    "path": [
+      "breadcrumb",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{breadcrumb.typography.line-height}",
     "$type": "number",
     "$value": 1.2308,
@@ -14478,10 +14511,34 @@
     "$value": "0.8125rem",
     "$modes": {
       "default": "0.8125rem",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "comments": {
       "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
@@ -14491,10 +14548,34 @@
       "$value": "{typography.body-100.font-size}",
       "$modes": {
         "default": "{typography.body-100.font-size}",
-        "cds-g0": "{carbon.typography.label01.font-size}",
-        "cds-g10": "{carbon.typography.label01.font-size}",
-        "cds-g90": "{carbon.typography.label01.font-size}",
-        "cds-g100": "{carbon.typography.label01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
@@ -16791,10 +16872,34 @@
     "unit": "rem",
     "$modes": {
       "default": "0.8125",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "original": {
       "$type": "font-size",
@@ -16802,10 +16907,34 @@
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "{carbon.typography.helperText01.font-size}",
-        "cds-g10": "{carbon.typography.helperText01.font-size}",
-        "cds-g90": "{carbon.typography.helperText01.font-size}",
-        "cds-g100": "{carbon.typography.helperText01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "key": "{link.standalone.typography.font-size.small}"
     },
@@ -17614,6 +17743,41 @@
     ]
   },
   {
+    "key": "{pagination.nav.control.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.8125rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{typography.body-100.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.nav.control.typography.font-size}"
+    },
+    "name": "token-pagination-nav-control-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "nav",
+      "control",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{pagination.nav.control.typography.font-weight.active}",
     "$type": "font-weight",
     "$value": "var(--token-typography-font-weight-medium)",
@@ -17740,6 +17904,74 @@
       "surface",
       "color",
       "hover"
+    ]
+  },
+  {
+    "key": "{pagination.info.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.8125rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{typography.body-100.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.info.typography.font-size}"
+    },
+    "name": "token-pagination-info-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "info",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
+    "key": "{pagination.size-selector.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.8125rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{typography.body-100.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.size-selector.typography.font-size}"
+    },
+    "name": "token-pagination-size-selector-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "size-selector",
+      "typography",
+      "font-size"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -21529,25 +21529,11 @@
     "$value": "0.8125rem",
     "unit": "px",
     "comment": "13px/0.8125rem",
-    "$modes": {
-      "default": "13",
-      "cds-g0": "0.875rem",
-      "cds-g10": "0.875rem",
-      "cds-g90": "0.875rem",
-      "cds-g100": "0.875rem"
-    },
     "original": {
       "$type": "font-size",
       "$value": "13",
       "unit": "px",
       "comment": "13px/0.8125rem",
-      "$modes": {
-        "default": "13",
-        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-      },
       "key": "{typography.body-100.font-size}"
     },
     "name": "token-typography-body-100-font-size",

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -10107,6 +10107,39 @@
     ]
   },
   {
+    "key": "{breadcrumb.typography.font-size}",
+    "$type": "font-size",
+    "$value": "0.8125rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "font-size",
+      "$value": "{typography.body-100.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{breadcrumb.typography.font-size}"
+    },
+    "name": "token-breadcrumb-typography-font-size",
+    "attributes": {
+      "category": "breadcrumb"
+    },
+    "path": [
+      "breadcrumb",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{breadcrumb.typography.line-height}",
     "$type": "number",
     "$value": 1.2308,
@@ -14478,10 +14511,34 @@
     "$value": "0.8125rem",
     "$modes": {
       "default": "0.8125rem",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/dialog-primitive.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "comments": {
       "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
@@ -14491,10 +14548,34 @@
       "$value": "{typography.body-100.font-size}",
       "$modes": {
         "default": "{typography.body-100.font-size}",
-        "cds-g0": "{carbon.typography.label01.font-size}",
-        "cds-g10": "{carbon.typography.label01.font-size}",
-        "cds-g90": "{carbon.typography.label01.font-size}",
-        "cds-g100": "{carbon.typography.label01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/dialog-primitive.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
@@ -16791,10 +16872,34 @@
     "unit": "rem",
     "$modes": {
       "default": "0.8125",
-      "cds-g0": "0.75rem",
-      "cds-g10": "0.75rem",
-      "cds-g90": "0.75rem",
-      "cds-g100": "0.75rem"
+      "cds-g0": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g10": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g90": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      },
+      "cds-g100": {
+        "$value": "0.75",
+        "unit": "rem",
+        "filePath": "src/products/shared/link/standalone.json",
+        "isSource": true,
+        "$type": "font-size"
+      }
     },
     "original": {
       "$type": "font-size",
@@ -16802,10 +16907,34 @@
       "unit": "rem",
       "$modes": {
         "default": "0.8125",
-        "cds-g0": "{carbon.typography.helperText01.font-size}",
-        "cds-g10": "{carbon.typography.helperText01.font-size}",
-        "cds-g90": "{carbon.typography.helperText01.font-size}",
-        "cds-g100": "{carbon.typography.helperText01.font-size}"
+        "cds-g0": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g10": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g90": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        },
+        "cds-g100": {
+          "$value": "0.75",
+          "unit": "rem",
+          "filePath": "src/products/shared/link/standalone.json",
+          "isSource": true,
+          "$type": "font-size"
+        }
       },
       "key": "{link.standalone.typography.font-size.small}"
     },
@@ -17614,6 +17743,41 @@
     ]
   },
   {
+    "key": "{pagination.nav.control.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.8125rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{typography.body-100.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.nav.control.typography.font-size}"
+    },
+    "name": "token-pagination-nav-control-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "nav",
+      "control",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
     "key": "{pagination.nav.control.typography.font-weight.active}",
     "$type": "font-weight",
     "$value": "var(--token-typography-font-weight-medium)",
@@ -17740,6 +17904,74 @@
       "surface",
       "color",
       "hover"
+    ]
+  },
+  {
+    "key": "{pagination.info.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.8125rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{typography.body-100.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.info.typography.font-size}"
+    },
+    "name": "token-pagination-info-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "info",
+      "typography",
+      "font-size"
+    ]
+  },
+  {
+    "key": "{pagination.size-selector.typography.font-size}",
+    "$type": "typography",
+    "$value": "0.8125rem",
+    "$modes": {
+      "default": "0.8125rem",
+      "cds-g0": "0.875rem",
+      "cds-g10": "0.875rem",
+      "cds-g90": "0.875rem",
+      "cds-g100": "0.875rem"
+    },
+    "original": {
+      "$type": "typography",
+      "$value": "{typography.body-100.font-size}",
+      "$modes": {
+        "default": "{typography.body-100.font-size}",
+        "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+        "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+      },
+      "key": "{pagination.size-selector.typography.font-size}"
+    },
+    "name": "token-pagination-size-selector-typography-font-size",
+    "attributes": {
+      "category": "pagination"
+    },
+    "path": [
+      "pagination",
+      "size-selector",
+      "typography",
+      "font-size"
     ]
   },
   {

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -243,6 +243,9 @@
   --token-breadcrumb-truncation-toggle-surface-color-hover: var(
     --token-color-surface-interactive
   );
+  --token-breadcrumb-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-breadcrumb-typography-line-height: 1.2308; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: var(
     --token-color-palette-red-400
@@ -646,6 +649,9 @@
   );
   --token-pagination-bar-border-color: rgba(0, 0, 0, 0);
   --token-pagination-bar-surface-color: var(--token-color-surface-primary);
+  --token-pagination-info-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-pagination-nav-control-foreground-color-active: var(
     --token-color-foreground-action-active
   );
@@ -656,11 +662,17 @@
     --token-color-foreground-action-hover
   );
   --token-pagination-nav-control-height: 36px;
+  --token-pagination-nav-control-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-pagination-nav-control-typography-font-weight-active: var(
     --token-typography-font-weight-medium
   );
   --token-pagination-nav-indicator-height: 2px;
   --token-pagination-nav-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-pagination-size-selector-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-reveal-foreground-color-active: var(
     --token-button-foreground-color-tertiary-active
   );
@@ -1005,6 +1017,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1255,13 +1268,16 @@
     --token-modal-header-tagline-color-warning: #525252;
     --token-pagination-bar-border-color: #c6c6c6;
     --token-pagination-bar-surface-color: #f4f4f4;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #161616;
     --token-pagination-nav-control-foreground-color-default: #161616;
     --token-pagination-nav-control-foreground-color-hover: #161616;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #0043ce;
     --token-reveal-foreground-color-default: #0f62fe;
     --token-reveal-foreground-color-hover: #0043ce;
@@ -1542,6 +1558,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1797,13 +1814,16 @@
     --token-modal-header-tagline-color-warning: #c6c6c6;
     --token-pagination-bar-border-color: #525252;
     --token-pagination-bar-surface-color: #262626;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #f4f4f4;
     --token-pagination-nav-control-foreground-color-default: #f4f4f4;
     --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #a6c8ff;
     --token-reveal-foreground-color-default: #78a9ff;
     --token-reveal-foreground-color-hover: #a6c8ff;
@@ -2083,6 +2103,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2329,13 +2350,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #c6c6c6;
   --token-pagination-bar-surface-color: #f4f4f4;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -2614,6 +2638,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2860,13 +2885,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #525252;
   --token-pagination-bar-surface-color: #262626;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;
@@ -3144,6 +3172,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -3390,13 +3419,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #e0e0e0;
   --token-pagination-bar-surface-color: #ffffff;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -3674,6 +3706,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -3920,13 +3953,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #6f6f6f;
   --token-pagination-bar-surface-color: #393939;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -805,7 +805,6 @@
   --token-typography-body-100-font-family: var(
     --token-typography-font-stack-text
   );
-  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.3846; /** 18px */
   --token-typography-body-200-font-family: var(
     --token-typography-font-stack-text
@@ -1340,7 +1339,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -1883,7 +1881,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2416,7 +2413,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2948,7 +2944,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -3479,7 +3474,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -4010,7 +4004,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -4394,4 +4387,5 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     0.38,
     1.11
   );
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
@@ -243,6 +243,9 @@
   --token-breadcrumb-truncation-toggle-surface-color-hover: var(
     --token-color-surface-interactive
   );
+  --token-breadcrumb-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-breadcrumb-typography-line-height: 1.2308; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: var(
     --token-color-palette-red-400
@@ -646,6 +649,9 @@
   );
   --token-pagination-bar-border-color: rgba(0, 0, 0, 0);
   --token-pagination-bar-surface-color: var(--token-color-surface-primary);
+  --token-pagination-info-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-pagination-nav-control-foreground-color-active: var(
     --token-color-foreground-action-active
   );
@@ -656,11 +662,17 @@
     --token-color-foreground-action-hover
   );
   --token-pagination-nav-control-height: 36px;
+  --token-pagination-nav-control-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-pagination-nav-control-typography-font-weight-active: var(
     --token-typography-font-weight-medium
   );
   --token-pagination-nav-indicator-height: 2px;
   --token-pagination-nav-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-pagination-size-selector-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-reveal-foreground-color-active: var(
     --token-button-foreground-color-tertiary-active
   );
@@ -1005,6 +1017,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1255,13 +1268,16 @@
     --token-modal-header-tagline-color-warning: #525252;
     --token-pagination-bar-border-color: #c6c6c6;
     --token-pagination-bar-surface-color: #f4f4f4;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #161616;
     --token-pagination-nav-control-foreground-color-default: #161616;
     --token-pagination-nav-control-foreground-color-hover: #161616;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #0043ce;
     --token-reveal-foreground-color-default: #0f62fe;
     --token-reveal-foreground-color-hover: #0043ce;
@@ -1542,6 +1558,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1797,13 +1814,16 @@
     --token-modal-header-tagline-color-warning: #c6c6c6;
     --token-pagination-bar-border-color: #525252;
     --token-pagination-bar-surface-color: #262626;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #f4f4f4;
     --token-pagination-nav-control-foreground-color-default: #f4f4f4;
     --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #a6c8ff;
     --token-reveal-foreground-color-default: #78a9ff;
     --token-reveal-foreground-color-hover: #a6c8ff;
@@ -2082,6 +2102,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2328,13 +2349,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #c6c6c6;
   --token-pagination-bar-surface-color: #f4f4f4;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -2612,6 +2636,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2858,13 +2883,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #525252;
   --token-pagination-bar-surface-color: #262626;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
@@ -805,7 +805,6 @@
   --token-typography-body-100-font-family: var(
     --token-typography-font-stack-text
   );
-  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.3846; /** 18px */
   --token-typography-body-200-font-family: var(
     --token-typography-font-stack-text
@@ -1340,7 +1339,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -1883,7 +1881,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2415,7 +2412,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2946,7 +2942,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -3326,4 +3321,5 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     0.38,
     1.11
   );
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
@@ -461,7 +461,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -998,7 +997,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -1541,7 +1539,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2073,7 +2070,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2604,7 +2600,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2983,4 +2978,5 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     0.38,
     1.11
   );
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
@@ -131,6 +131,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -377,13 +378,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #c6c6c6;
   --token-pagination-bar-surface-color: #f4f4f4;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -663,6 +667,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -913,13 +918,16 @@
     --token-modal-header-tagline-color-warning: #525252;
     --token-pagination-bar-border-color: #c6c6c6;
     --token-pagination-bar-surface-color: #f4f4f4;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #161616;
     --token-pagination-nav-control-foreground-color-default: #161616;
     --token-pagination-nav-control-foreground-color-hover: #161616;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #0043ce;
     --token-reveal-foreground-color-default: #0f62fe;
     --token-reveal-foreground-color-hover: #0043ce;
@@ -1200,6 +1208,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1455,13 +1464,16 @@
     --token-modal-header-tagline-color-warning: #c6c6c6;
     --token-pagination-bar-border-color: #525252;
     --token-pagination-bar-surface-color: #262626;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #f4f4f4;
     --token-pagination-nav-control-foreground-color-default: #f4f4f4;
     --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #a6c8ff;
     --token-reveal-foreground-color-default: #78a9ff;
     --token-reveal-foreground-color-hover: #a6c8ff;
@@ -1740,6 +1752,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1986,13 +1999,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #c6c6c6;
   --token-pagination-bar-surface-color: #f4f4f4;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -2270,6 +2286,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2516,13 +2533,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #525252;
   --token-pagination-bar-surface-color: #262626;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/common-tokens.css
@@ -212,4 +212,5 @@
   --token-tag-padding-top: 3px;
   --token-tooltip-focus-offset: -2px;
   --token-tooltip-transition-timing-function: cubic-bezier(0.54, 1.5, 0.38, 1.11);
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
@@ -116,6 +116,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -360,13 +361,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #c6c6c6;
   --token-pagination-bar-surface-color: #f4f4f4;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
@@ -440,7 +440,6 @@
   --token-tooltip-padding-horizontal: 16px;
   --token-tooltip-padding-vertical: 16px;
   --token-typography-body-100-font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', sans-serif;
   --token-typography-body-200-font-size: 0.875rem; /** 14px/0.875rem */

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/common-tokens.css
@@ -212,4 +212,5 @@
   --token-tag-padding-top: 3px;
   --token-tooltip-focus-offset: -2px;
   --token-tooltip-transition-timing-function: cubic-bezier(0.54, 1.5, 0.38, 1.11);
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
@@ -116,6 +116,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -360,13 +361,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #e0e0e0;
   --token-pagination-bar-surface-color: #ffffff;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
@@ -440,7 +440,6 @@
   --token-tooltip-padding-horizontal: 16px;
   --token-tooltip-padding-vertical: 16px;
   --token-typography-body-100-font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', sans-serif;
   --token-typography-body-200-font-size: 0.875rem; /** 14px/0.875rem */

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/common-tokens.css
@@ -212,4 +212,5 @@
   --token-tag-padding-top: 3px;
   --token-tooltip-focus-offset: -2px;
   --token-tooltip-transition-timing-function: cubic-bezier(0.54, 1.5, 0.38, 1.11);
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
@@ -116,6 +116,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -360,13 +361,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #525252;
   --token-pagination-bar-surface-color: #262626;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
@@ -440,7 +440,6 @@
   --token-tooltip-padding-horizontal: 16px;
   --token-tooltip-padding-vertical: 16px;
   --token-typography-body-100-font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', sans-serif;
   --token-typography-body-200-font-size: 0.875rem; /** 14px/0.875rem */

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/common-tokens.css
@@ -212,4 +212,5 @@
   --token-tag-padding-top: 3px;
   --token-tooltip-focus-offset: -2px;
   --token-tooltip-transition-timing-function: cubic-bezier(0.54, 1.5, 0.38, 1.11);
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
@@ -116,6 +116,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -360,13 +361,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #6f6f6f;
   --token-pagination-bar-surface-color: #393939;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
@@ -440,7 +440,6 @@
   --token-tooltip-padding-horizontal: 16px;
   --token-tooltip-padding-vertical: 16px;
   --token-typography-body-100-font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', sans-serif;
   --token-typography-body-200-font-size: 0.875rem; /** 14px/0.875rem */

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/common-tokens.css
@@ -212,4 +212,5 @@
   --token-tag-padding-top: 3px;
   --token-tooltip-focus-offset: -2px;
   --token-tooltip-transition-timing-function: cubic-bezier(0.54, 1.5, 0.38, 1.11);
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
@@ -116,6 +116,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: var(--token-color-foreground-faint);
   --token-breadcrumb-truncation-toggle-surface-color-active: var(--token-color-surface-interactive-active);
   --token-breadcrumb-truncation-toggle-surface-color-hover: var(--token-color-surface-interactive);
+  --token-breadcrumb-typography-font-size: var(--token-typography-body-100-font-size);
   --token-breadcrumb-typography-line-height: 1.2308; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: var(--token-color-palette-red-400);
   --token-button-border-color-critical-default: var(--token-color-palette-red-300);
@@ -360,13 +361,16 @@
   --token-modal-header-tagline-color-warning: var(--token-color-foreground-warning-on-surface);
   --token-pagination-bar-border-color: rgba(0, 0, 0, 0);
   --token-pagination-bar-surface-color: var(--token-color-surface-primary);
+  --token-pagination-info-typography-font-size: var(--token-typography-body-100-font-size);
   --token-pagination-nav-control-foreground-color-active: var(--token-color-foreground-action-active);
   --token-pagination-nav-control-foreground-color-default: var(--token-color-foreground-action);
   --token-pagination-nav-control-foreground-color-hover: var(--token-color-foreground-action-hover);
   --token-pagination-nav-control-height: 36px;
+  --token-pagination-nav-control-typography-font-size: var(--token-typography-body-100-font-size);
   --token-pagination-nav-control-typography-font-weight-active: var(--token-typography-font-weight-medium);
   --token-pagination-nav-indicator-height: 2px;
   --token-pagination-nav-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-pagination-size-selector-typography-font-size: var(--token-typography-body-100-font-size);
   --token-reveal-foreground-color-active: var(--token-button-foreground-color-tertiary-active);
   --token-reveal-foreground-color-default: var(--token-button-foreground-color-tertiary-default);
   --token-reveal-foreground-color-hover: var(--token-button-foreground-color-tertiary-hover);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
@@ -440,7 +440,6 @@
   --token-tooltip-padding-horizontal: 12px;
   --token-tooltip-padding-vertical: 8px;
   --token-typography-body-100-font-family: var(--token-typography-font-stack-text);
-  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.3846; /** 18px */
   --token-typography-body-200-font-family: var(--token-typography-font-stack-text);
   --token-typography-body-200-font-size: 0.875rem; /** 14px/0.875rem */

--- a/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
@@ -245,6 +245,9 @@
     --token-breadcrumb-truncation-toggle-surface-color-hover: var(
       --token-color-surface-interactive
     );
+    --token-breadcrumb-typography-font-size: var(
+      --token-typography-body-100-font-size
+    );
     --token-breadcrumb-typography-line-height: 1.2308; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: var(
       --token-color-palette-red-400
@@ -662,6 +665,9 @@
     );
     --token-pagination-bar-border-color: rgba(0, 0, 0, 0);
     --token-pagination-bar-surface-color: var(--token-color-surface-primary);
+    --token-pagination-info-typography-font-size: var(
+      --token-typography-body-100-font-size
+    );
     --token-pagination-nav-control-foreground-color-active: var(
       --token-color-foreground-action-active
     );
@@ -672,11 +678,17 @@
       --token-color-foreground-action-hover
     );
     --token-pagination-nav-control-height: 36px;
+    --token-pagination-nav-control-typography-font-size: var(
+      --token-typography-body-100-font-size
+    );
     --token-pagination-nav-control-typography-font-weight-active: var(
       --token-typography-font-weight-medium
     );
     --token-pagination-nav-indicator-height: 2px;
     --token-pagination-nav-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-pagination-size-selector-typography-font-size: var(
+      --token-typography-body-100-font-size
+    );
     --token-reveal-foreground-color-active: var(
       --token-button-foreground-color-tertiary-active
     );
@@ -1028,6 +1040,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1278,13 +1291,16 @@
     --token-modal-header-tagline-color-warning: #525252;
     --token-pagination-bar-border-color: #c6c6c6;
     --token-pagination-bar-surface-color: #f4f4f4;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #161616;
     --token-pagination-nav-control-foreground-color-default: #161616;
     --token-pagination-nav-control-foreground-color-hover: #161616;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #0043ce;
     --token-reveal-foreground-color-default: #0f62fe;
     --token-reveal-foreground-color-hover: #0043ce;
@@ -1565,6 +1581,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1820,13 +1837,16 @@
     --token-modal-header-tagline-color-warning: #c6c6c6;
     --token-pagination-bar-border-color: #525252;
     --token-pagination-bar-surface-color: #262626;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #f4f4f4;
     --token-pagination-nav-control-foreground-color-default: #f4f4f4;
     --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #a6c8ff;
     --token-reveal-foreground-color-default: #78a9ff;
     --token-reveal-foreground-color-hover: #a6c8ff;
@@ -2107,6 +2127,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2357,13 +2378,16 @@
     --token-modal-header-tagline-color-warning: #525252;
     --token-pagination-bar-border-color: #c6c6c6;
     --token-pagination-bar-surface-color: #f4f4f4;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #161616;
     --token-pagination-nav-control-foreground-color-default: #161616;
     --token-pagination-nav-control-foreground-color-hover: #161616;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #0043ce;
     --token-reveal-foreground-color-default: #0f62fe;
     --token-reveal-foreground-color-hover: #0043ce;
@@ -2644,6 +2668,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2894,13 +2919,16 @@
     --token-modal-header-tagline-color-warning: #525252;
     --token-pagination-bar-border-color: #e0e0e0;
     --token-pagination-bar-surface-color: #ffffff;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #161616;
     --token-pagination-nav-control-foreground-color-default: #161616;
     --token-pagination-nav-control-foreground-color-hover: #161616;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #0043ce;
     --token-reveal-foreground-color-default: #0f62fe;
     --token-reveal-foreground-color-hover: #0043ce;
@@ -3181,6 +3209,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -3436,13 +3465,16 @@
     --token-modal-header-tagline-color-warning: #c6c6c6;
     --token-pagination-bar-border-color: #6f6f6f;
     --token-pagination-bar-surface-color: #393939;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #f4f4f4;
     --token-pagination-nav-control-foreground-color-default: #f4f4f4;
     --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #a6c8ff;
     --token-reveal-foreground-color-default: #78a9ff;
     --token-reveal-foreground-color-hover: #a6c8ff;
@@ -3723,6 +3755,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -3978,13 +4011,16 @@
     --token-modal-header-tagline-color-warning: #c6c6c6;
     --token-pagination-bar-border-color: #525252;
     --token-pagination-bar-surface-color: #262626;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #f4f4f4;
     --token-pagination-nav-control-foreground-color-default: #f4f4f4;
     --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #a6c8ff;
     --token-reveal-foreground-color-default: #78a9ff;
     --token-reveal-foreground-color-hover: #a6c8ff;

--- a/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
@@ -826,7 +826,6 @@
     --token-typography-body-100-font-family: var(
       --token-typography-font-stack-text
     );
-    --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.3846; /** 18px */
     --token-typography-body-200-font-family: var(
       --token-typography-font-stack-text
@@ -1363,7 +1362,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -1906,7 +1904,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2444,7 +2441,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2982,7 +2978,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -3525,7 +3520,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -4068,7 +4062,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -4434,5 +4427,6 @@
       0.38,
       1.11
     );
+    --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
   }
 }

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -320,6 +320,7 @@
   --token-badge-icon-size-small: 12px;
   --token-badge-icon-size-medium: 16px;
   --token-badge-icon-size-large: 16px;
+  --token-breadcrumb-typography-font-size: 0.8125rem;
   --token-breadcrumb-typography-line-height: 1.2308; /** 16px = 1.2308 */
   --token-breadcrumb-divider-color: #c2c5cb;
   --token-breadcrumb-link-foreground-color-default: #656a76;
@@ -566,10 +567,13 @@
   --token-pagination-nav-control-foreground-color-hover: #0c56e9;
   --token-pagination-nav-control-foreground-color-active: #0046d1;
   --token-pagination-nav-control-icon-spacing: 6px;
+  --token-pagination-nav-control-typography-font-size: 0.8125rem;
   --token-pagination-nav-control-typography-font-weight-active: var(--token-typography-font-weight-medium);
   --token-pagination-nav-indicator-height: 2px;
   --token-pagination-nav-indicator-spacing: 6px;
   --token-pagination-nav-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-pagination-info-typography-font-size: 0.8125rem;
+  --token-pagination-size-selector-typography-font-size: 0.8125rem;
   --token-pagination-child-spacing-vertical: 8px;
   --token-pagination-child-spacing-horizontal: 20px;
   --token-reveal-foreground-color-default: #1060ff;

--- a/packages/tokens/src/products/shared/breadcrumb.json
+++ b/packages/tokens/src/products/shared/breadcrumb.json
@@ -1,6 +1,17 @@
 {
   "breadcrumb": {
     "typography": {
+      "font-size": {
+        "$type": "font-size",
+        "$value": "{typography.body-100.font-size}",
+        "$modes": {
+          "default": "{typography.body-100.font-size}",
+          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+        }
+      },
       "line-height": {
         "$type": "number",
         "$value": 1.2308,

--- a/packages/tokens/src/products/shared/dialog-primitive.json
+++ b/packages/tokens/src/products/shared/dialog-primitive.json
@@ -47,10 +47,22 @@
             "$value": "{typography.body-100.font-size}",
             "$modes": {
               "default": "{typography.body-100.font-size}",
-              "cds-g0": "{carbon.typography.label01.font-size}",
-              "cds-g10": "{carbon.typography.label01.font-size}",
-              "cds-g90": "{carbon.typography.label01.font-size}",
-              "cds-g100": "{carbon.typography.label01.font-size}"
+              "cds-g0": {
+                "$value": "0.75",
+                "unit": "rem"
+              },
+              "cds-g10": {
+                "$value": "0.75",
+                "unit": "rem"
+              },
+              "cds-g90": {
+                "$value": "0.75",
+                "unit": "rem"
+              },
+              "cds-g100": {
+                "$value": "0.75",
+                "unit": "rem"
+              }
             },
             "comments": {
               "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"

--- a/packages/tokens/src/products/shared/link/standalone.json
+++ b/packages/tokens/src/products/shared/link/standalone.json
@@ -35,10 +35,22 @@
             "unit": "rem",
             "$modes": {
               "default": "0.8125",
-              "cds-g0": "{carbon.typography.helperText01.font-size}",
-              "cds-g10": "{carbon.typography.helperText01.font-size}",
-              "cds-g90": "{carbon.typography.helperText01.font-size}",
-              "cds-g100": "{carbon.typography.helperText01.font-size}"
+              "cds-g0": {
+                "$value": "0.75",
+                "unit": "rem"
+              },
+              "cds-g10": {
+                "$value": "0.75",
+                "unit": "rem"
+              },
+              "cds-g90": {
+                "$value": "0.75",
+                "unit": "rem"
+              },
+              "cds-g100": {
+                "$value": "0.75",
+                "unit": "rem"
+              }
             }
           },
           "medium": {

--- a/packages/tokens/src/products/shared/pagination.json
+++ b/packages/tokens/src/products/shared/pagination.json
@@ -94,6 +94,17 @@
           }
         },
         "typography": {
+          "font-size": {
+            "$type": "typography",
+            "$value": "{typography.body-100.font-size}",
+            "$modes": {
+              "default": "{typography.body-100.font-size}",
+              "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+              "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+              "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+              "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+            }
+          },
           "font-weight": {
             "active": {
               "$type": "font-weight",
@@ -140,6 +151,36 @@
               "cds-g90": "{carbon.themes.g90.backgroundHover}",
               "cds-g100": "{carbon.themes.g100.backgroundHover}"
             }
+          }
+        }
+      }
+    },
+    "info": {
+      "typography": {
+        "font-size": {
+          "$type": "typography",
+          "$value": "{typography.body-100.font-size}",
+          "$modes": {
+            "default": "{typography.body-100.font-size}",
+            "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+            "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+            "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+            "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
+          }
+        }
+      }
+    },
+    "size-selector": {
+      "typography": {
+        "font-size": {
+          "$type": "typography",
+          "$value": "{typography.body-100.font-size}",
+          "$modes": {
+            "default": "{typography.body-100.font-size}",
+            "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
+            "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
+            "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
+            "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
           }
         }
       }

--- a/packages/tokens/src/products/shared/typography.json
+++ b/packages/tokens/src/products/shared/typography.json
@@ -543,14 +543,7 @@
         "$type": "font-size",
         "$value": "13",
         "unit": "px",
-        "comment": "13px/0.8125rem",
-        "$modes": {
-          "default": "13",
-          "cds-g0": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g10": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g90": "{carbon.typography.bodyCompact01.font-size}",
-          "cds-g100": "{carbon.typography.bodyCompact01.font-size}"
-        }
+        "comment": "13px/0.8125rem"
       },
       "line-height": {
         "$type": "number",

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -2843,8 +2843,8 @@
 .hds-breadcrumb__text {
   padding: calc((28px - 1rem) / 2) 0;
   overflow: hidden;
-  font-size: var(--token-typography-body-100-font-size);
-  font-family: var(--token-typography-body-100-font-family);
+  font-size: var(--token-breadcrumb-typography-font-size);
+  font-family: var(--token-typography-font-stack-text);
   line-height: var(--token-breadcrumb-typography-line-height);
   white-space: nowrap;
   text-decoration: underline;
@@ -7949,6 +7949,7 @@ button.hds-button[href]::after {
 }
 
 .hds-pagination-info {
+  font-size: var(--token-pagination-info-typography-font-size);
   white-space: nowrap;
 }
 
@@ -8039,6 +8040,11 @@ button.hds-button[href]::after {
   justify-content: flex-end;
 }
 
+.hds-pagination-nav__arrow-label,
+.hds-pagination-nav__number-content {
+  font-size: var(--token-pagination-nav-control-typography-font-size);
+}
+
 .hds-pagination-nav__number--is-selected {
   position: relative;
   color: var(--token-pagination-nav-control-foreground-color-default);
@@ -8079,6 +8085,7 @@ button.hds-button[href]::after {
 }
 .hds-pagination-size-selector > label {
   white-space: nowrap;
+  font-size: var(--token-pagination-size-selector-typography-font-size);
 }
 .hds-theme-light .hds-pagination-size-selector > label::after,
 .hds-theme-dark .hds-pagination-size-selector > label::after,
@@ -8090,7 +8097,7 @@ button.hds-button[href]::after {
   height: 28px;
   margin-left: 12px;
   padding: 0 24px 0 8px;
-  font-size: var(--token-typography-body-100-font-size);
+  font-size: var(--token-pagination-size-selector-typography-font-size);
   font-family: var(--token-typography-body-100-font-family);
   line-height: var(--token-typography-body-100-line-height);
   background-position: center right 5px;

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -324,6 +324,7 @@
   --token-badge-icon-size-small: 12px;
   --token-badge-icon-size-medium: 16px;
   --token-badge-icon-size-large: 16px;
+  --token-breadcrumb-typography-font-size: 0.8125rem;
   --token-breadcrumb-typography-line-height: 1.2308; /** 16px = 1.2308 */
   --token-breadcrumb-divider-color: #c2c5cb;
   --token-breadcrumb-link-foreground-color-default: #656a76;
@@ -570,10 +571,13 @@
   --token-pagination-nav-control-foreground-color-hover: #0c56e9;
   --token-pagination-nav-control-foreground-color-active: #0046d1;
   --token-pagination-nav-control-icon-spacing: 6px;
+  --token-pagination-nav-control-typography-font-size: 0.8125rem;
   --token-pagination-nav-control-typography-font-weight-active: var(--token-typography-font-weight-medium);
   --token-pagination-nav-indicator-height: 2px;
   --token-pagination-nav-indicator-spacing: 6px;
   --token-pagination-nav-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-pagination-info-typography-font-size: 0.8125rem;
+  --token-pagination-size-selector-typography-font-size: 0.8125rem;
   --token-pagination-child-spacing-vertical: 8px;
   --token-pagination-child-spacing-horizontal: 20px;
   --token-reveal-foreground-color-default: #1060ff;
@@ -3543,8 +3547,8 @@
 .hds-breadcrumb__text {
   padding: calc((28px - 1rem) / 2) 0;
   overflow: hidden;
-  font-size: var(--token-typography-body-100-font-size);
-  font-family: var(--token-typography-body-100-font-family);
+  font-size: var(--token-breadcrumb-typography-font-size);
+  font-family: var(--token-typography-font-stack-text);
   line-height: var(--token-breadcrumb-typography-line-height);
   white-space: nowrap;
   text-decoration: underline;
@@ -8649,6 +8653,7 @@ button.hds-button[href]::after {
 }
 
 .hds-pagination-info {
+  font-size: var(--token-pagination-info-typography-font-size);
   white-space: nowrap;
 }
 
@@ -8739,6 +8744,11 @@ button.hds-button[href]::after {
   justify-content: flex-end;
 }
 
+.hds-pagination-nav__arrow-label,
+.hds-pagination-nav__number-content {
+  font-size: var(--token-pagination-nav-control-typography-font-size);
+}
+
 .hds-pagination-nav__number--is-selected {
   position: relative;
   color: var(--token-pagination-nav-control-foreground-color-default);
@@ -8779,6 +8789,7 @@ button.hds-button[href]::after {
 }
 .hds-pagination-size-selector > label {
   white-space: nowrap;
+  font-size: var(--token-pagination-size-selector-typography-font-size);
 }
 .hds-theme-light .hds-pagination-size-selector > label::after,
 .hds-theme-dark .hds-pagination-size-selector > label::after,
@@ -8790,7 +8801,7 @@ button.hds-button[href]::after {
   height: 28px;
   margin-left: 12px;
   padding: 0 24px 0 8px;
-  font-size: var(--token-typography-body-100-font-size);
+  font-size: var(--token-pagination-size-selector-typography-font-size);
   font-family: var(--token-typography-body-100-font-family);
   line-height: var(--token-typography-body-100-line-height);
   background-position: center right 5px;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -243,6 +243,9 @@
   --token-breadcrumb-truncation-toggle-surface-color-hover: var(
     --token-color-surface-interactive
   );
+  --token-breadcrumb-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-breadcrumb-typography-line-height: 1.2308; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: var(
     --token-color-palette-red-400
@@ -646,6 +649,9 @@
   );
   --token-pagination-bar-border-color: rgba(0, 0, 0, 0);
   --token-pagination-bar-surface-color: var(--token-color-surface-primary);
+  --token-pagination-info-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-pagination-nav-control-foreground-color-active: var(
     --token-color-foreground-action-active
   );
@@ -656,11 +662,17 @@
     --token-color-foreground-action-hover
   );
   --token-pagination-nav-control-height: 36px;
+  --token-pagination-nav-control-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-pagination-nav-control-typography-font-weight-active: var(
     --token-typography-font-weight-medium
   );
   --token-pagination-nav-indicator-height: 2px;
   --token-pagination-nav-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-pagination-size-selector-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-reveal-foreground-color-active: var(
     --token-button-foreground-color-tertiary-active
   );
@@ -1005,6 +1017,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1255,13 +1268,16 @@
     --token-modal-header-tagline-color-warning: #525252;
     --token-pagination-bar-border-color: #c6c6c6;
     --token-pagination-bar-surface-color: #f4f4f4;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #161616;
     --token-pagination-nav-control-foreground-color-default: #161616;
     --token-pagination-nav-control-foreground-color-hover: #161616;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #0043ce;
     --token-reveal-foreground-color-default: #0f62fe;
     --token-reveal-foreground-color-hover: #0043ce;
@@ -1542,6 +1558,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1797,13 +1814,16 @@
     --token-modal-header-tagline-color-warning: #c6c6c6;
     --token-pagination-bar-border-color: #525252;
     --token-pagination-bar-surface-color: #262626;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #f4f4f4;
     --token-pagination-nav-control-foreground-color-default: #f4f4f4;
     --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #a6c8ff;
     --token-reveal-foreground-color-default: #78a9ff;
     --token-reveal-foreground-color-hover: #a6c8ff;
@@ -2083,6 +2103,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2329,13 +2350,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #c6c6c6;
   --token-pagination-bar-surface-color: #f4f4f4;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -2614,6 +2638,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2860,13 +2885,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #525252;
   --token-pagination-bar-surface-color: #262626;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;
@@ -3144,6 +3172,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -3390,13 +3419,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #e0e0e0;
   --token-pagination-bar-surface-color: #ffffff;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -3674,6 +3706,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -3920,13 +3953,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #6f6f6f;
   --token-pagination-bar-surface-color: #393939;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -805,7 +805,6 @@
   --token-typography-body-100-font-family: var(
     --token-typography-font-stack-text
   );
-  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.3846; /** 18px */
   --token-typography-body-200-font-family: var(
     --token-typography-font-stack-text
@@ -1340,7 +1339,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -1883,7 +1881,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2416,7 +2413,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2948,7 +2944,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -3479,7 +3474,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -4010,7 +4004,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -4394,4 +4387,5 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     0.38,
     1.11
   );
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
@@ -243,6 +243,9 @@
   --token-breadcrumb-truncation-toggle-surface-color-hover: var(
     --token-color-surface-interactive
   );
+  --token-breadcrumb-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-breadcrumb-typography-line-height: 1.2308; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: var(
     --token-color-palette-red-400
@@ -646,6 +649,9 @@
   );
   --token-pagination-bar-border-color: rgba(0, 0, 0, 0);
   --token-pagination-bar-surface-color: var(--token-color-surface-primary);
+  --token-pagination-info-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-pagination-nav-control-foreground-color-active: var(
     --token-color-foreground-action-active
   );
@@ -656,11 +662,17 @@
     --token-color-foreground-action-hover
   );
   --token-pagination-nav-control-height: 36px;
+  --token-pagination-nav-control-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-pagination-nav-control-typography-font-weight-active: var(
     --token-typography-font-weight-medium
   );
   --token-pagination-nav-indicator-height: 2px;
   --token-pagination-nav-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-pagination-size-selector-typography-font-size: var(
+    --token-typography-body-100-font-size
+  );
   --token-reveal-foreground-color-active: var(
     --token-button-foreground-color-tertiary-active
   );
@@ -1005,6 +1017,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1255,13 +1268,16 @@
     --token-modal-header-tagline-color-warning: #525252;
     --token-pagination-bar-border-color: #c6c6c6;
     --token-pagination-bar-surface-color: #f4f4f4;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #161616;
     --token-pagination-nav-control-foreground-color-default: #161616;
     --token-pagination-nav-control-foreground-color-hover: #161616;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #0043ce;
     --token-reveal-foreground-color-default: #0f62fe;
     --token-reveal-foreground-color-hover: #0043ce;
@@ -1542,6 +1558,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1797,13 +1814,16 @@
     --token-modal-header-tagline-color-warning: #c6c6c6;
     --token-pagination-bar-border-color: #525252;
     --token-pagination-bar-surface-color: #262626;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #f4f4f4;
     --token-pagination-nav-control-foreground-color-default: #f4f4f4;
     --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #a6c8ff;
     --token-reveal-foreground-color-default: #78a9ff;
     --token-reveal-foreground-color-hover: #a6c8ff;
@@ -2082,6 +2102,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2328,13 +2349,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #c6c6c6;
   --token-pagination-bar-surface-color: #f4f4f4;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -2612,6 +2636,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2858,13 +2883,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #525252;
   --token-pagination-bar-surface-color: #262626;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
@@ -805,7 +805,6 @@
   --token-typography-body-100-font-family: var(
     --token-typography-font-stack-text
   );
-  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.3846; /** 18px */
   --token-typography-body-200-font-family: var(
     --token-typography-font-stack-text
@@ -1340,7 +1339,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -1883,7 +1881,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2415,7 +2412,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2946,7 +2942,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -3326,4 +3321,5 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     0.38,
     1.11
   );
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
@@ -461,7 +461,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -998,7 +997,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -1541,7 +1539,6 @@
     --token-typography-body-100-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
       ".SFNSText-Regular", sans-serif;
-    --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
     --token-typography-body-100-line-height: 1.28572; /** 18px */
     --token-typography-body-200-font-family:
       "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2073,7 +2070,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2604,7 +2600,6 @@
   --token-typography-body-100-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
     ".SFNSText-Regular", sans-serif;
-  --token-typography-body-100-font-size: 0.875rem; /** 13px/0.8125rem */
   --token-typography-body-100-line-height: 1.28572; /** 18px */
   --token-typography-body-200-font-family:
     "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont,
@@ -2983,4 +2978,5 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     0.38,
     1.11
   );
+  --token-typography-body-100-font-size: 0.8125rem; /** 13px/0.8125rem */
 }

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
@@ -131,6 +131,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -377,13 +378,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #c6c6c6;
   --token-pagination-bar-surface-color: #f4f4f4;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -663,6 +667,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -913,13 +918,16 @@
     --token-modal-header-tagline-color-warning: #525252;
     --token-pagination-bar-border-color: #c6c6c6;
     --token-pagination-bar-surface-color: #f4f4f4;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #161616;
     --token-pagination-nav-control-foreground-color-default: #161616;
     --token-pagination-nav-control-foreground-color-hover: #161616;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #0043ce;
     --token-reveal-foreground-color-default: #0f62fe;
     --token-reveal-foreground-color-hover: #0043ce;
@@ -1200,6 +1208,7 @@
     --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
     --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
     --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+    --token-breadcrumb-typography-font-size: 0.875rem;
     --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
     --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1455,13 +1464,16 @@
     --token-modal-header-tagline-color-warning: #c6c6c6;
     --token-pagination-bar-border-color: #525252;
     --token-pagination-bar-surface-color: #262626;
+    --token-pagination-info-typography-font-size: 0.875rem;
     --token-pagination-nav-control-foreground-color-active: #f4f4f4;
     --token-pagination-nav-control-foreground-color-default: #f4f4f4;
     --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
     --token-pagination-nav-control-height: 40px;
+    --token-pagination-nav-control-typography-font-size: 0.875rem;
     --token-pagination-nav-control-typography-font-weight-active: 600;
     --token-pagination-nav-indicator-height: 4px;
     --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+    --token-pagination-size-selector-typography-font-size: 0.875rem;
     --token-reveal-foreground-color-active: #a6c8ff;
     --token-reveal-foreground-color-default: #78a9ff;
     --token-reveal-foreground-color-hover: #a6c8ff;
@@ -1740,6 +1752,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #0043ce;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -1986,13 +1999,16 @@
   --token-modal-header-tagline-color-warning: #525252;
   --token-pagination-bar-border-color: #c6c6c6;
   --token-pagination-bar-surface-color: #f4f4f4;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #161616;
   --token-pagination-nav-control-foreground-color-default: #161616;
   --token-pagination-nav-control-foreground-color-hover: #161616;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.12);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #0043ce;
   --token-reveal-foreground-color-default: #0f62fe;
   --token-reveal-foreground-color-hover: #0043ce;
@@ -2270,6 +2286,7 @@
   --token-breadcrumb-truncation-toggle-foreground-color-hover: #a6c8ff;
   --token-breadcrumb-truncation-toggle-surface-color-active: rgba(0, 0, 0, 0);
   --token-breadcrumb-truncation-toggle-surface-color-hover: rgba(0, 0, 0, 0);
+  --token-breadcrumb-typography-font-size: 0.875rem;
   --token-breadcrumb-typography-line-height: 1.28572; /** 16px = 1.2308 */
   --token-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --token-button-border-color-critical-default: rgba(0, 0, 0, 0);
@@ -2516,13 +2533,16 @@
   --token-modal-header-tagline-color-warning: #c6c6c6;
   --token-pagination-bar-border-color: #525252;
   --token-pagination-bar-surface-color: #262626;
+  --token-pagination-info-typography-font-size: 0.875rem;
   --token-pagination-nav-control-foreground-color-active: #f4f4f4;
   --token-pagination-nav-control-foreground-color-default: #f4f4f4;
   --token-pagination-nav-control-foreground-color-hover: #f4f4f4;
   --token-pagination-nav-control-height: 40px;
+  --token-pagination-nav-control-typography-font-size: 0.875rem;
   --token-pagination-nav-control-typography-font-weight-active: 600;
   --token-pagination-nav-indicator-height: 4px;
   --token-pagination-nav-surface-color-hover: rgba(141, 141, 141, 0.16);
+  --token-pagination-size-selector-typography-font-size: 0.875rem;
   --token-reveal-foreground-color-active: #a6c8ff;
   --token-reveal-foreground-color-default: #78a9ff;
   --token-reveal-foreground-color-hover: #a6c8ff;


### PR DESCRIPTION
### :pushpin: Summary

This PR follows an exploration of the `body-100` font size for Carbon themes and makes the following changes
- Updates the `body-100` font size token to a hard-coded value of 13px for Carbon themes
- Based on an audit of component's usage of `body-100`
  - Adds new component tokens to set a Carbon value of 12px or 14px
  - Updates existing tokens to reference hard-coded values for 12px instead of the semantic `label01.font-size`

### :hammer_and_wrench: Detailed description

As part of the work on the `AppSideNav` carbonization in #3801 it was found that the font size for both `body100` and `body200` equals 14px for Carbon themes. This is they are mapped to `body01.fontSize` and `bodyCompact01.fontSize` which both are 14px.

To resolve this inconsistency the font size of `body-100` was updated to 13px for Carbon themes. Also based on an analysis of the usage of `body-100` various component tokens were updated.

No visual changes from the existing Carbonization have been made. All updates of 13px -> 14px for Carbon follow what was already handled by default with `body-100` previously. All updates of 13px -> 12px already had existing component tokens which made this update.

- Breadcrumb
  - Added new token `breadcrumb.typography.font-size`
  - Carbon theme font size of 14px
- Dialog primitive
  - Update existing `dialog-primitive.header.tagline.typography.font-size` token to reference hard-coded values instead of `label01`
  - Carbon. theme font size of 12px (unchanged)
- LinkStandalone
  - Update existing `link-standalone,typography.font-size.small` token to reference hard-coded values instead of `helperText01`
  - Carbon. theme font size of 12px (unchanged) 
- Pagination
  - Added new tokens `pagination.nav-control.typography.font-size`, `pagination.info.typography.font-size`, and `pagination.size-selector.typography.font-size`
  - Carbon theme font size of 14px
- Tag
  - Existing token `tag.typography.font-size` sets Carbon theme value of 12px
  - Note: This was not updated to a hard-coded value like the other instances of 12px because the Carbon equivalent component also uses `label01.font-size`

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6305](https://hashicorp.atlassian.net/browse/HDS-6305)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6305]: https://hashicorp.atlassian.net/browse/HDS-6305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ