### PR TITLE
ci: declare contents: read on the 6 remaining workflows

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ci-components-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   conditional-skip:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-compress-images.yml
+++ b/.github/workflows/ci-compress-images.yml
@@ -7,6 +7,12 @@ on:
 env:
   NODE_VERSION: "24.x"
 
+# peter-evans/create-pull-request uses secrets.PAT_TOKEN to open the
+# compression PR; default GITHUB_TOKEN only needs read for the checkout +
+# calibre/image-actions report.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Compress Images & Open PR

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ci-website-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   conditional-skip:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-vercel-alias.yml
+++ b/.github/workflows/create-vercel-alias.yml
@@ -6,6 +6,10 @@ on:
 env:
   NODE_VERSION: "24.x"
 
+# Vercel aliasing uses VERCEL_TOKEN; default GITHUB_TOKEN only needs read.
+permissions:
+  contents: read
+
 jobs:
   create-vercel-alias:
     name: "Create Vercel Alias"

--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -6,6 +6,10 @@ on:
 env:
   NODE_VERSION: "24.x"
 
+# peter-evans/create-pull-request opens the icon-update PR via PAT_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   sync_iconset:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 env:
   NODE_VERSION: "24.x"
 
+# changesets/action and pnpm release-packages use PAT_TOKEN + NPM_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
All six workflows here previously relied on the org default `GITHUB_TOKEN` scope. Every actual write in these workflows already goes through a dedicated secret (`PAT_TOKEN`, `NPM_TOKEN`, `VERCEL_TOKEN`), so the default token can stay read-only:

- **ci-components.yml** + **ci-website.yml** — read-only CI matrices behind a `filter_changed_files.sh` gate.
- **ci-compress-images.yml** — `calibreapp/image-actions` is read-only; the follow-up `peter-evans/create-pull-request` opens the compression PR via `PAT_TOKEN`.
- **open-pull-request-for-icon-update.yml** — Figma export + `peter-evans/create-pull-request` with `PAT_TOKEN`.
- **release.yml** — `changesets/action` and `pnpm release-packages` authenticate via `PAT_TOKEN` + `NPM_TOKEN`.
- **create-vercel-alias.yml** — Vercel aliasing uses `VERCEL_TOKEN` from secrets.

Each file picks up `permissions: contents: read` at the top level; YAML validated locally with `yaml.safe_load`.