### PR TITLE
Improvements to the showcase pages for `Alert` and `Toast`

### DIFF
--- a/showcase/app/components/page-components/alert/sub-sections/actions.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/actions.gts
@@ -4,60 +4,76 @@
  */
 
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { capitalize } from '@ember/string';
+import { eq, notEq } from 'ember-truth-helpers';
 
 import ShwTextH2 from 'showcase/components/shw/text/h2';
+import ShwTextH3 from 'showcase/components/shw/text/h3';
 import ShwGrid from 'showcase/components/shw/grid';
+import ShwDivider from 'showcase/components/shw/divider';
 
 import { HdsAlert } from '@hashicorp/design-system-components/components';
+import { TYPES } from '@hashicorp/design-system-components/components/hds/alert/index';
 
 const SubSectionActions: TemplateOnlyComponent = <template>
   <ShwTextH2>Actions</ShwTextH2>
 
-  <ShwGrid @columns={{2}} as |SG|>
-    <SG.Item>
-      <HdsAlert @type="inline" @color="warning" as |A|>
-        <A.Title>Action passed as yielded component</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
-        <A.Button @text="Action" @color="secondary" />
-      </HdsAlert>
-    </SG.Item>
+  {{#each TYPES as |type|}}
+    {{#if (notEq type "compact")}}
+      <ShwTextH3>{{capitalize type}}</ShwTextH3>
 
-    <SG.Item>
-      <HdsAlert @type="inline" @color="warning" as |A|>
-        <A.Title>With multiple actions passed as yielded components</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
-        <A.Button @text="Secondary" @color="secondary" />
-        <A.Button @icon="plus" @text="Tertiary" @color="tertiary" />
-        <A.LinkStandalone
-          @icon="plus"
-          @text="Standalone"
-          @href="#"
-          @color="secondary"
-        />
-      </HdsAlert>
-    </SG.Item>
+      <ShwGrid @columns={{if (eq type "page") 1 2}} as |SG|>
+        <SG.Item>
+          <HdsAlert @type={{type}} @color="warning" as |A|>
+            <A.Title>Action passed as yielded component</A.Title>
+            <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
+              elit.</A.Description>
+            <A.Button @text="Action" @color="secondary" />
+          </HdsAlert>
+        </SG.Item>
 
-    <SG.Item>
-      <HdsAlert @type="inline" @color="warning" as |A|>
-        <A.Title>With actions and custom content</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-          sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</A.Description>
-        <A.Button @text="Action" @color="secondary" />
-        <A.LinkStandalone
-          @icon="plus"
-          @text="Action"
-          @href="#"
-          @color="secondary"
-        />
-        <A.Generic>
-          <div
-            class="shw-component-alert-sample-custom-content-after-actions"
-          >This for example could be extra text, specific for a special use
-            case.</div>
-        </A.Generic>
-      </HdsAlert>
-    </SG.Item>
-  </ShwGrid>
+        <SG.Item>
+          <HdsAlert @type={{type}} @color="warning" as |A|>
+            <A.Title>With multiple actions passed as yielded components</A.Title>
+            <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
+              elit.</A.Description>
+            <A.Button @text="Secondary" @color="secondary" />
+            <A.Button @icon="plus" @text="Tertiary" @color="tertiary" />
+            <A.LinkStandalone
+              @icon="plus"
+              @text="Standalone"
+              @href="#"
+              @color="secondary"
+            />
+          </HdsAlert>
+        </SG.Item>
+
+        <SG.Item>
+          <HdsAlert @type={{type}} @color="warning" as |A|>
+            <A.Title>With actions and custom content</A.Title>
+            <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
+              elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+              aliqua.</A.Description>
+            <A.Button @text="Action" @color="secondary" />
+            <A.LinkStandalone
+              @icon="plus"
+              @text="Action"
+              @href="#"
+              @color="secondary"
+            />
+            <A.Generic>
+              <div
+                class="shw-component-alert-sample-custom-content-after-actions"
+              >This for example could be extra text, specific for a special use
+                case.</div>
+            </A.Generic>
+          </HdsAlert>
+        </SG.Item>
+      </ShwGrid>
+    {{/if}}
+  {{/each}}
+
+  <ShwDivider @level={{2}} />
 </template>;
 
 export default SubSectionActions;

--- a/showcase/app/components/page-components/alert/sub-sections/color.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/color.gts
@@ -9,6 +9,7 @@ import { capitalize } from '@ember/string';
 
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 import ShwGrid from 'showcase/components/shw/grid';
+import ShwDivider from 'showcase/components/shw/divider';
 
 import { HdsAlert } from '@hashicorp/design-system-components/components';
 import {
@@ -35,6 +36,8 @@ const SubSectionColor: TemplateOnlyComponent = <template>
       {{/each}}
     {{/each}}
   </ShwGrid>
+
+  <ShwDivider @level={{2}} />
 </template>;
 
 export default SubSectionColor;

--- a/showcase/app/components/page-components/alert/sub-sections/content.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/content.gts
@@ -10,6 +10,7 @@ import ShwTextH3 from 'showcase/components/shw/text/h3';
 import ShwPlaceholder from 'showcase/components/shw/placeholder';
 import ShwGrid from 'showcase/components/shw/grid';
 import ShwFlex from 'showcase/components/shw/flex';
+import ShwDivider from 'showcase/components/shw/divider';
 
 import {
   HdsAlert,
@@ -162,6 +163,8 @@ const SubSectionContent: TemplateOnlyComponent = <template>
       </HdsAlert>
     </SG.Item>
   </ShwGrid>
+
+  <ShwDivider @level={{2}} />
 </template>;
 
 export default SubSectionContent;

--- a/showcase/app/components/page-components/alert/sub-sections/dismiss.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/dismiss.gts
@@ -4,50 +4,63 @@
  */
 
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { capitalize } from '@ember/string';
+import { eq, notEq } from 'ember-truth-helpers';
 
 import ShwTextH2 from 'showcase/components/shw/text/h2';
+import ShwTextH3 from 'showcase/components/shw/text/h3';
 import ShwGrid from 'showcase/components/shw/grid';
 
 import { HdsAlert } from '@hashicorp/design-system-components/components';
 import NOOP from 'showcase/utils/noop';
+import { TYPES } from '@hashicorp/design-system-components/components/hds/alert/index';
 
 const SubSectionDismiss: TemplateOnlyComponent = <template>
   <ShwTextH2>Dismiss</ShwTextH2>
 
-  <ShwGrid @columns={{2}} as |SG|>
-    <SG.Item>
-      <HdsAlert @type="inline" @color="neutral" as |A|>
-        <A.Title>Without the dismiss button (default)</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
-      </HdsAlert>
-    </SG.Item>
+  {{#each TYPES as |type|}}
+    {{#if (notEq type "compact")}}
+      <ShwTextH3>{{capitalize type}}</ShwTextH3>
 
-    <SG.Item>
-      <HdsAlert @type="inline" @color="neutral" @onDismiss={{NOOP}} as |A|>
-        <A.Title>With the dismiss button</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
-      </HdsAlert>
-    </SG.Item>
+      <ShwGrid @columns={{if (eq type "page") 1 2}} as |SG|>
+        <SG.Item>
+          <HdsAlert @type={{type}} @color="neutral" as |A|>
+            <A.Title>Without the dismiss button (default)</A.Title>
+            <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
+              elit.</A.Description>
+          </HdsAlert>
+        </SG.Item>
 
-    <SG.Item>
-      <HdsAlert
-        @type="inline"
-        @color="neutral"
-        @icon={{false}}
-        @onDismiss={{NOOP}}
-        as |A|
-      >
-        <A.Title>With the dismiss button and no icon</A.Title>
-        <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</A.Description>
-      </HdsAlert>
-    </SG.Item>
+        <SG.Item>
+          <HdsAlert @type={{type}} @color="neutral" @onDismiss={{NOOP}} as |A|>
+            <A.Title>With the dismiss button</A.Title>
+            <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
+              elit.</A.Description>
+          </HdsAlert>
+        </SG.Item>
 
-    <SG.Item>
-      <HdsAlert @type="inline" @color="neutral" @onDismiss={{NOOP}} as |A|>
-        <A.Description>With the dismiss button and no title</A.Description>
-      </HdsAlert>
-    </SG.Item>
-  </ShwGrid>
+        <SG.Item>
+          <HdsAlert
+            @type={{type}}
+            @color="neutral"
+            @icon={{false}}
+            @onDismiss={{NOOP}}
+            as |A|
+          >
+            <A.Title>With the dismiss button and no icon</A.Title>
+            <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
+              elit.</A.Description>
+          </HdsAlert>
+        </SG.Item>
+
+        <SG.Item>
+          <HdsAlert @type={{type}} @color="neutral" @onDismiss={{NOOP}} as |A|>
+            <A.Description>With the dismiss button and no title</A.Description>
+          </HdsAlert>
+        </SG.Item>
+      </ShwGrid>
+    {{/if}}
+  {{/each}}
 </template>;
 
 export default SubSectionDismiss;

--- a/showcase/app/components/page-components/alert/sub-sections/icon.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/icon.gts
@@ -7,6 +7,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 import ShwGrid from 'showcase/components/shw/grid';
+import ShwDivider from 'showcase/components/shw/divider';
 
 import { HdsAlert } from '@hashicorp/design-system-components/components';
 
@@ -39,6 +40,8 @@ const SubSectionIcon: TemplateOnlyComponent = <template>
       </HdsAlert>
     </SG.Item>
   </ShwGrid>
+
+  <ShwDivider @level={{2}} />
 </template>;
 
 export default SubSectionIcon;

--- a/showcase/app/components/page-components/alert/sub-sections/type.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/type.gts
@@ -10,6 +10,7 @@ import { capitalize } from '@ember/string';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 import ShwTextBody from 'showcase/components/shw/text/body';
 import ShwFlex from 'showcase/components/shw/flex';
+import ShwDivider from 'showcase/components/shw/divider';
 
 import { HdsAlert } from '@hashicorp/design-system-components/components';
 import { TYPES } from '@hashicorp/design-system-components/components/hds/alert/index';
@@ -28,6 +29,8 @@ const SubSectionType: TemplateOnlyComponent = <template>
       </SF.Item>
     </ShwFlex>
   {{/each}}
+
+  <ShwDivider @level={{2}} />
 </template>;
 
 export default SubSectionType;

--- a/showcase/app/components/page-components/toast/sub-sections/color.gts
+++ b/showcase/app/components/page-components/toast/sub-sections/color.gts
@@ -7,6 +7,7 @@ import { capitalize } from '@ember/string';
 
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 import ShwFlex from 'showcase/components/shw/flex';
+import ShwDivider from 'showcase/components/shw/divider';
 import NOOP from 'showcase/utils/noop';
 
 import { HdsToast } from '@hashicorp/design-system-components/components';
@@ -29,6 +30,8 @@ const SubSectionColor: TemplateOnlyComponent = <template>
       </SF.Item>
     {{/each}}
   </ShwFlex>
+
+  <ShwDivider @level={{2}} />
 </template>;
 
 export default SubSectionColor;

--- a/showcase/app/components/page-components/toast/sub-sections/content.gts
+++ b/showcase/app/components/page-components/toast/sub-sections/content.gts
@@ -8,6 +8,7 @@ import ShwTextH2 from 'showcase/components/shw/text/h2';
 import ShwFlex from 'showcase/components/shw/flex';
 import ShwGrid from 'showcase/components/shw/grid';
 import ShwPlaceholder from 'showcase/components/shw/placeholder';
+import ShwDivider from 'showcase/components/shw/divider';
 import NOOP from 'showcase/utils/noop';
 
 import {
@@ -110,6 +111,8 @@ const SubSectionContent: TemplateOnlyComponent = <template>
       </ShwFlex>
     </SG.Item>
   </ShwGrid>
+
+  <ShwDivider @level={{2}} />
 </template>;
 
 export default SubSectionContent;

--- a/showcase/app/components/page-components/toast/sub-sections/icon.gts
+++ b/showcase/app/components/page-components/toast/sub-sections/icon.gts
@@ -6,6 +6,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 import ShwFlex from 'showcase/components/shw/flex';
+import ShwDivider from 'showcase/components/shw/divider';
 import NOOP from 'showcase/utils/noop';
 
 import { HdsToast } from '@hashicorp/design-system-components/components';
@@ -39,6 +40,8 @@ const SubSectionIcon: TemplateOnlyComponent = <template>
       </HdsToast>
     </SF.Item>
   </ShwFlex>
+
+  <ShwDivider @level={{2}} />
 </template>;
 
 export default SubSectionIcon;


### PR DESCRIPTION
### :pushpin: Summary

Small PR to improve the showcase pages for `Alert` and `Toast` (added `page` variants to `Alert`, and dividers to both).

Inspired by https://github.com/hashicorp/design-system/pull/3809

Previews:
- [Alert](https://hds-showcase-git-showcase-alert-dismiss-hashicorp.vercel.app/components/alert)
- [Toast](https://hds-showcase-git-showcase-alert-dismiss-hashicorp.vercel.app/components/toast)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>