### PR TITLE
SECVULN-41237: Override yaml@1 to remediate SECVULN-41237

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
       "systeminformation": "5.31.0",
       "undici": "6.24.0",
       "underscore": "1.13.8",
+      "yaml@1": "1.10.3",
       "yaml@2": "2.8.3"
     },
     "patchedDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ overrides:
   systeminformation: 5.31.0
   undici: 6.24.0
   underscore: 1.13.8
+  yaml@1: 1.10.3
   yaml@2: 2.8.3
 
 patchedDependencies:
@@ -12060,8 +12061,8 @@ packages:
     resolution: {integrity: sha512-ULGbghCLsN8Hs8vfExlqrJIe8Hl2TUjD7/zsIGMP8U+dgRXEsDXk4yydxeZJgdGiimP1XB7zhmhOB4/HyfqOyQ==}
     hasBin: true
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
   yaml@2.8.3:
@@ -18265,7 +18266,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
+      yaml: 1.10.3
 
   cosmiconfig@8.3.6(typescript@5.9.2):
     dependencies:
@@ -27094,7 +27095,7 @@ snapshots:
       commander: 6.2.1
       js-yaml: 3.14.2
 
-  yaml@1.10.2: {}
+  yaml@1.10.3: {}
 
   yaml@2.8.3: {}
 


### PR DESCRIPTION
## Summary

Remediates SECVULN-41237 by pinning the `yaml` 1.x line to the patched `1.10.3` release so the vulnerable `yaml@1.10.2` entry is removed from the pnpm lockfile.

## How to review

1. Check `package.json` to confirm the new `pnpm.overrides` entry for `yaml@1`.
2. Review the `pnpm-lock.yaml` diff to confirm the 1.x lockfile entry and the `cosmiconfig@7.1.0` snapshot now resolve to `yaml@1.10.3`.
3. Verify the change stays limited to the manifest and lockfile.

## File-by-file review notes

- `package.json:48-52` — adds `yaml@1: 1.10.3` alongside the existing security overrides.
- `pnpm-lock.yaml:29-33` — records the new root override for `yaml@1`.
- `pnpm-lock.yaml:12064-12066` — replaces the vulnerable `yaml@1.10.2` package entry with `yaml@1.10.3`.
- `pnpm-lock.yaml:18263-18269` — updates `cosmiconfig@7.1.0` to resolve `yaml: 1.10.3`.
- `pnpm-lock.yaml:27098` — updates the lockfile snapshot key for the patched `yaml` version.

## Behavior to verify

- The repo no longer resolves `yaml@1.10.2` in `pnpm-lock.yaml`.
- The 1.x dependency path used by `cosmiconfig@7.1.0` now resolves to `yaml@1.10.3`.
- No unrelated dependency churn was introduced.

## Validation run

- `node --version`
- `npm --version`
- `/tmp/pnpm-tools/node_modules/.bin/pnpm install --lockfile-only`
- `git diff -- package.json pnpm-lock.yaml`
- `rg -n "yaml@1\.10\.2|yaml@1\.10\.3|yaml@1:" package.json pnpm-lock.yaml`

## Risks / edge cases

- This relies on a root pnpm override for the 1.x line rather than upgrading the upstream package chain, which keeps the change small but means future lockfile refreshes should preserve the override.
- A full lockfile regeneration in this repo can introduce unrelated metadata churn, so the diff was kept intentionally narrow.

## README / docs updates

No README or docs updates were needed because this is a lockfile-focused dependency remediation.

## Jira
- [SECVULN-41237](https://hashicorp.atlassian.net/browse/SECVULN-41237)

[SECVULN-41237]: https://hashicorp.atlassian.net/browse/SECVULN-41237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ