### PR TITLE
Override brace-expansion to remediate SECVULN findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
       "ajv@6": "6.14.0",
       "ajv@8": "8.18.0",
       "basic-ftp": "5.3.1",
+      "brace-expansion@1": "1.1.13",
+      "brace-expansion@2": "2.0.3",
       "brace-expansion@5": "5.0.6",
       "flatted": "3.4.2",
       "ember-composable-helpers": "npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,8 @@ overrides:
   ajv@6: 6.14.0
   ajv@8: 8.18.0
   basic-ftp: 5.3.1
+  brace-expansion@1: 1.1.13
+  brace-expansion@2: 2.0.3
   brace-expansion@5: 5.0.6
   flatted: 3.4.2
   ember-composable-helpers: npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11
@@ -4787,11 +4789,11 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -17194,12 +17196,12 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.0.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -23771,27 +23773,27 @@ snapshots:
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.0.3
 
   minimatch@7.4.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.0.3
 
   minimatch@8.0.7:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.0.3
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.0.3
 
   minimist-options@3.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

Remediate the open `brace-expansion` lockfile vulnerabilities tracked by `SECVULN-41367` and `SECVULN-41368` by pinning patched transitive versions for the affected major lines. This keeps future installs on the fixed versions instead of relying on a one-off lockfile change.

## How to review

1. Review `package.json` to confirm the new `pnpm.overrides` entries for `brace-expansion@1` and `brace-expansion@2`.
2. Review `pnpm-lock.yaml` to confirm the lockfile now resolves `brace-expansion@1.1.13` and `brace-expansion@2.0.3` and updates the dependent `minimatch` snapshots accordingly.

## File-by-file review notes

- `package.json` — adds root `pnpm.overrides` entries for `brace-expansion@1: 1.1.13` and `brace-expansion@2: 2.0.3` next to the existing v5 override.
- `pnpm-lock.yaml` — updates the root overrides block, the `brace-expansion` package/snapshot entries, and the `minimatch` snapshot references so the lockfile no longer points at `1.1.12` or `2.0.2`.

## Behavior to verify

- The repo now pins patched `brace-expansion` versions for the vulnerable major ranges found by GitHub code scanning.
- `pnpm-lock.yaml` no longer contains `brace-expansion@1.1.12` or `brace-expansion@2.0.2`.

## Validation run

- Confirmed the diff is limited to `package.json` and `pnpm-lock.yaml`.
- Searched `pnpm-lock.yaml` and verified patched entries `brace-expansion@1.1.13` and `brace-expansion@2.0.3` are present.
- Searched `pnpm-lock.yaml` and verified vulnerable entries `brace-expansion@1.1.12` and `brace-expansion@2.0.2` are absent.
- Reviewer verdict: approve.
- Could not run a fresh `pnpm` install in the facilitator shell because `pnpm`/`corepack` is unavailable there.

## Risks / edge cases

- Residual risk is low because both updates are patch-level changes within the same major lines.
- Lockfile consistency was reviewed via targeted diff/search rather than a fresh install in the facilitator shell due missing `pnpm` tooling.

## README / docs updates

- No README or docs updates were needed for this dependency remediation.

## Jira
- [SECVULN-41367](https://hashicorp.atlassian.net/browse/SECVULN-41367)
- [SECVULN-41368](https://hashicorp.atlassian.net/browse/SECVULN-41368)

[SECVULN-41367]: https://hashicorp.atlassian.net/browse/SECVULN-41367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ