### PR TITLE
[Project Solar / Phase 1 / Follow up] Add "column-stacked" layout to `ShwCarbonizationComparisonGrid` in showcase for carbonization pages

### DIFF
--- a/showcase/app/components/page-carbonization/components/app-side-nav/index.gts
+++ b/showcase/app/components/page-carbonization/components/app-side-nav/index.gts
@@ -33,7 +33,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
   <section>
     <ShwTextH2>Content</ShwTextH2>
 
-    <ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @layout="column-stacked">
       <:theming>
         <div class="shw-component-sim-app-side-nav-root-container">
           <HdsAppSideNav @isResponsive={{false}}>
@@ -52,7 +52,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwTextH3>Yielded content</ShwTextH3>
 
-    <ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @layout="column-stacked">
       <:label>With product icons using text color</:label>
       <:theming>
         <div class="shw-component-sim-app-side-nav-root-container">
@@ -109,7 +109,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
       </:reference>
     </ShwCarbonizationComparisonGrid>
 
-    <ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @layout="column-stacked">
       <:label>With back link</:label>
       <:theming>
         <div class="shw-component-sim-app-side-nav-root-container">
@@ -155,7 +155,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwTextH2>HdsAppSideNavList</ShwTextH2>
 
-    <ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @layout="column-stacked">
       <:theming>
         <div class="shw-component-sim-app-side-nav-body">
           <HdsAppSideNavList aria-label="Multiple items" as |SNL|>
@@ -205,7 +205,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwTextH3>AppSideNavListTitle</ShwTextH3>
 
-    <ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @layout="column-stacked">
       <:theming>
         <ul class="shw-component-sim-app-side-nav-body">
           <HdsAppSideNavListTitle>Group title</HdsAppSideNavListTitle>
@@ -222,7 +222,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwTextH3>AppSideNavListLink</ShwTextH3>
 
-    <ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @layout="column-stacked">
       <:theming>
         <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
           <HdsAppSideNavListLink @text="Boundary" @href="#" />
@@ -255,7 +255,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
     <ShwTextH4>States</ShwTextH4>
 
     {{#each STATES as |state|}}
-      <ShwCarbonizationComparisonGrid>
+      <ShwCarbonizationComparisonGrid @layout="column-stacked">
         <:label>{{state}}</:label>
         <:theming>
           <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
@@ -280,7 +280,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
     <ShwTextH4>States with @isActive=true</ShwTextH4>
 
     {{#each STATES as |state|}}
-      <ShwCarbonizationComparisonGrid>
+      <ShwCarbonizationComparisonGrid @layout="column-stacked">
         <:label>{{state}}</:label>
         <:theming>
           <ul class="shw-component-sim-app-side-nav-list-link-wrapper">
@@ -308,7 +308,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwTextH4>Base</ShwTextH4>
 
-    <ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @layout="column-stacked">
       <:theming>
         <ul class="shw-component-sim-app-side-nav-body">
           <HdsAppSideNavListBackLink @text="Back to parent page" @href="#" />
@@ -326,7 +326,7 @@ const AppSideNavCarbonizationIndex: TemplateOnlyComponent = <template>
     <ShwTextH4>States</ShwTextH4>
 
     {{#each STATES as |state|}}
-      <ShwCarbonizationComparisonGrid>
+      <ShwCarbonizationComparisonGrid @layout="column-stacked">
         <:label>{{state}}</:label>
         <:theming>
           <ul class="shw-component-sim-app-side-nav-body">

--- a/showcase/app/components/page-carbonization/components/application-state/index.gts
+++ b/showcase/app/components/page-carbonization/components/application-state/index.gts
@@ -22,7 +22,7 @@ const ApplicationStateCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid
       @label="With icon and error code"
-      @layout="side-by-side"
+      @layout="column-stacked"
     >
       <:theming>
         <CodeFragmentWithActionVariants

--- a/showcase/app/components/page-carbonization/components/card/index.gts
+++ b/showcase/app/components/page-carbonization/components/card/index.gts
@@ -41,14 +41,14 @@ const CardCarbonizationIndex: TemplateOnlyComponent = <template>
     <ShwCarbonizationComparisonGrid>
       <:theming>
         <HdsCardContainer>
-          <div {{style width="200px" height="150px"}}>
+          <div {{style width="100px" height="150px"}}>
             <HdsTextBody>Card content</HdsTextBody>
           </div>
         </HdsCardContainer>
       </:theming>
       <:reference>
         <cds-tile>
-          <div {{style width="200px" height="150px"}}>
+          <div {{style width="100%" height="150px"}}>
             Card content
           </div>
         </cds-tile>
@@ -67,7 +67,6 @@ const CardCarbonizationIndex: TemplateOnlyComponent = <template>
               <HdsCardContainer @level={{level}}>
                 <ShwPlaceholder
                   @text={{level}}
-                  @width="200"
                   @height="100"
                   @background="transparent"
                 />
@@ -93,7 +92,6 @@ const CardCarbonizationIndex: TemplateOnlyComponent = <template>
               <HdsCardContainer @level={{level}} @hasBorder={{true}}>
                 <ShwPlaceholder
                   @text={{level}}
-                  @width="200"
                   @height="100"
                   @background="transparent"
                 />
@@ -119,7 +117,6 @@ const CardCarbonizationIndex: TemplateOnlyComponent = <template>
               <HdsCardContainer @level={{level}}>
                 <ShwPlaceholder
                   @text={{level}}
-                  @width="200"
                   @height="100"
                   @background="transparent"
                 />
@@ -141,7 +138,6 @@ const CardCarbonizationIndex: TemplateOnlyComponent = <template>
               <HdsCardContainer @levelHover={{level}} mock-state-value="hover">
                 <ShwPlaceholder
                   @text={{level}}
-                  @width="200"
                   @height="100"
                   @background="transparent"
                 />
@@ -166,7 +162,6 @@ const CardCarbonizationIndex: TemplateOnlyComponent = <template>
               >
                 <ShwPlaceholder
                   @text={{level}}
-                  @width="200"
                   @height="100"
                   @background="transparent"
                 />
@@ -193,7 +188,6 @@ const CardCarbonizationIndex: TemplateOnlyComponent = <template>
             >
               <ShwPlaceholder
                 @text="Lorem ipsum"
-                @width="200"
                 @height="100"
                 @background="transparent"
               />
@@ -218,7 +212,6 @@ const CardCarbonizationIndex: TemplateOnlyComponent = <template>
               <HdsCardContainer @level="mid" @background={{background}}>
                 <ShwPlaceholder
                   @text={{background}}
-                  @width="200"
                   @height="100"
                   @background="transparent"
                 />

--- a/showcase/app/components/page-carbonization/components/code-block/index.gts
+++ b/showcase/app/components/page-carbonization/components/code-block/index.gts
@@ -345,15 +345,14 @@ export default class CodeBlockCarbonizationIndex extends Component {
 
       <ShwCarbonizationComparisonGrid @layout="side-by-side">
         <:theming>
-          <ShwFlex as |SF|>
-            <SF.Item {{style width="500px"}}>
-              <HdsCodeBlock
-                @language="go"
-                @hasLineNumbers={{false}}
-                @highlightLines="2, 4"
-                @hasCopyButton={{true}}
-                @ariaLabel="Highlight lines 2 & 4, hasLineNumbers=false"
-                @value="{
+          {{! template-lint-disable no-whitespace-for-layout }}
+          <HdsCodeBlock
+            @language="go"
+            @hasLineNumbers={{false}}
+            @highlightLines="2, 4"
+            @hasCopyButton={{true}}
+            @ariaLabel="Highlight lines 2 & 4, hasLineNumbers=false"
+            @value="{
   'result': [
     {
       'expressions': [
@@ -369,16 +368,22 @@ export default class CodeBlockCarbonizationIndex extends Component {
     }
   ]
 }"
-              />
-            </SF.Item>
-            <SF.Item {{style width="500px"}}>
-              {{! template-lint-disable no-whitespace-for-layout }}
-              <HdsCodeBlock
-                @language="ruby"
-                @highlightLines="10-12"
-                @hasCopyButton={{true}}
-                @ariaLabel="Highlight lines 10-12"
-                @value="{
+          />
+          {{! template-lint-enable no-whitespace-for-layout }}
+        </:theming>
+        <:reference as |R|>
+          <R.NoEquivalent @isCompact={{true}} />
+        </:reference>
+      </ShwCarbonizationComparisonGrid>
+      <ShwCarbonizationComparisonGrid @layout="side-by-side">
+        <:theming>
+          {{! template-lint-disable no-whitespace-for-layout }}
+          <HdsCodeBlock
+            @language="ruby"
+            @highlightLines="10-12"
+            @hasCopyButton={{true}}
+            @ariaLabel="Highlight lines 10-12"
+            @value="{
   'result': [
     {
       'expressions': [
@@ -394,10 +399,8 @@ export default class CodeBlockCarbonizationIndex extends Component {
     }
   ]
 }"
-              />
-              {{! template-lint-enable no-whitespace-for-layout }}
-            </SF.Item>
-          </ShwFlex>
+          />
+          {{! template-lint-enable no-whitespace-for-layout }}
         </:theming>
         <:reference as |R|>
           <R.NoEquivalent @isCompact={{true}} />

--- a/showcase/app/components/page-carbonization/components/code-editor/index.gts
+++ b/showcase/app/components/page-carbonization/components/code-editor/index.gts
@@ -61,7 +61,7 @@ export default class CodeEditorCarbonizationIndex extends Component {
 
       <ShwTextH2>Content</ShwTextH2>
 
-      <ShwCarbonizationComparisonGrid @layout="side-by-side">
+      <ShwCarbonizationComparisonGrid @layout="column-stacked">
         <:theming>
           <ShwFlex @direction="column" as |SF|>
             <SF.Item>
@@ -104,7 +104,7 @@ export default class CodeEditorCarbonizationIndex extends Component {
 
       <ShwTextH2>Title and Description</ShwTextH2>
 
-      <ShwCarbonizationComparisonGrid @layout="side-by-side">
+      <ShwCarbonizationComparisonGrid @layout="column-stacked">
         <:theming>
           <ShwFlex @direction="column" as |SF|>
             <SF.Item>
@@ -134,7 +134,7 @@ export default class CodeEditorCarbonizationIndex extends Component {
 
       <ShwTextH2>Copy Button</ShwTextH2>
 
-      <ShwCarbonizationComparisonGrid @layout="side-by-side">
+      <ShwCarbonizationComparisonGrid @layout="column-stacked">
         <:theming>
           <ShwFlex @direction="column" as |SF|>
             <SF.Item>
@@ -161,7 +161,7 @@ export default class CodeEditorCarbonizationIndex extends Component {
 
       <ShwTextH2>Fullscreen Toggle</ShwTextH2>
 
-      <ShwCarbonizationComparisonGrid @layout="side-by-side">
+      <ShwCarbonizationComparisonGrid @layout="column-stacked">
         <:theming>
           <ShwFlex @direction="column" as |SF|>
             <SF.Item>
@@ -183,7 +183,7 @@ export default class CodeEditorCarbonizationIndex extends Component {
 
       <ShwTextH2>Complex content</ShwTextH2>
 
-      <ShwCarbonizationComparisonGrid @layout="side-by-side">
+      <ShwCarbonizationComparisonGrid @layout="column-stacked">
         <:theming>
           <ShwFlex @direction="column" as |SF|>
             <SF.Item>
@@ -219,7 +219,7 @@ export default class CodeEditorCarbonizationIndex extends Component {
 
       <ShwTextH2>Linting</ShwTextH2>
 
-      <ShwCarbonizationComparisonGrid @layout="side-by-side">
+      <ShwCarbonizationComparisonGrid @layout="column-stacked">
         <:theming>
           <ShwFlex @direction="column" as |SF|>
             <SF.Item>

--- a/showcase/app/components/page-carbonization/components/copy/snippet/index.gts
+++ b/showcase/app/components/page-carbonization/components/copy/snippet/index.gts
@@ -119,7 +119,7 @@ export default class CopySnippetCarbonizationIndex extends Component {
 
       <ShwCarbonizationComparisonGrid @layout="side-by-side">
         <:theming>
-          <div {{style width="500px"}}>
+          <div {{style width="100%"}}>
             <HdsCopySnippet
               @textToCopy="fbrct1ed-fgr35h-tyng89-wed4r"
               @isFullWidth={{true}}

--- a/showcase/app/components/page-carbonization/foundations/focus-ring/index.gts
+++ b/showcase/app/components/page-carbonization/foundations/focus-ring/index.gts
@@ -206,7 +206,7 @@ const FocusRingCarbonizationIndex: TemplateOnlyComponent = <template>
     <ShwDivider @level={{2}} />
 
     <ShwTextH4 @tag="h3">AppHeader</ShwTextH4>
-    <ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @layout="column-stacked">
       <:theming>
         <div mock-state-value="focus" mock-state-selector="button, a">
           <HdsAppHeader @hasA11yRefocus={{false}}>

--- a/showcase/app/components/page-carbonization/utilities/dialog-primitive/index.gts
+++ b/showcase/app/components/page-carbonization/utilities/dialog-primitive/index.gts
@@ -30,6 +30,7 @@ const DialogPrimitiveCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid
       @label="Header + Description + Body + Footer"
+      @layout="column-stacked"
     >
       <:theming>
         <HdsDialogPrimitiveWrapper open>
@@ -166,7 +167,10 @@ const DialogPrimitiveCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwTextH2>DialogPrimitiveFooter</ShwTextH2>
 
-    <ShwCarbonizationComparisonGrid @label="One action">
+    <ShwCarbonizationComparisonGrid
+      @label="One action"
+      @layout="column-stacked"
+    >
       <:theming>
         <div class="hds-dialog-primitive__wrapper-footer">
           <HdsDialogPrimitiveFooter>
@@ -176,7 +180,10 @@ const DialogPrimitiveCarbonizationIndex: TemplateOnlyComponent = <template>
       </:theming>
     </ShwCarbonizationComparisonGrid>
 
-    <ShwCarbonizationComparisonGrid @label="Two actions">
+    <ShwCarbonizationComparisonGrid
+      @label="Two actions"
+      @layout="column-stacked"
+    >
       <:theming>
         <div class="hds-dialog-primitive__wrapper-footer">
           <HdsDialogPrimitiveFooter>
@@ -189,7 +196,10 @@ const DialogPrimitiveCarbonizationIndex: TemplateOnlyComponent = <template>
       </:theming>
     </ShwCarbonizationComparisonGrid>
 
-    <ShwCarbonizationComparisonGrid @label="Three actions">
+    <ShwCarbonizationComparisonGrid
+      @label="Three actions"
+      @layout="column-stacked"
+    >
       <:theming>
         <div class="hds-dialog-primitive__wrapper-footer">
           <HdsDialogPrimitiveFooter>
@@ -213,7 +223,10 @@ const DialogPrimitiveCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwTextH2>DialogPrimitiveOverlay</ShwTextH2>
 
-    <ShwCarbonizationComparisonGrid @label="Overlay element">
+    <ShwCarbonizationComparisonGrid
+      @label="Overlay element"
+      @layout="column-stacked"
+    >
       <:theming>
         <div class="shw-utility-dialog-primitive-overlay-container">
           <div class="shw-utility-dialog-primitive-overlay-mock-content">

--- a/showcase/app/components/shw/carbonization/comparison-grid/index.gts
+++ b/showcase/app/components/shw/carbonization/comparison-grid/index.gts
@@ -12,7 +12,7 @@ export interface ShwCarbonizationComparisonGridSignature {
     label?: string;
     hideThemeLabels?: boolean;
     hideCarbonLabels?: boolean;
-    layout?: 'row' | 'column' | 'side-by-side';
+    layout?: 'row' | 'column' | 'column-stacked' | 'side-by-side';
   };
   Blocks: {
     label: [];

--- a/showcase/app/styles/showcase-components/carbonization/comparison-grid.scss
+++ b/showcase/app/styles/showcase-components/carbonization/comparison-grid.scss
@@ -33,6 +33,16 @@
   grid-template-columns: 1fr;
 }
 
+.shw-carbonization-comparison-grid--column-stacked {
+  grid-template-areas:
+    "hds cds-g0 cds-g10"
+    "--- cwc-g0 cwc-g10"
+    "--- cds-g90 cds-g100"
+    "--- cwc-g90 cwc-g100";
+  grid-template-rows: auto auto auto auto;
+  grid-template-columns: repeat(3, 1fr);
+}
+
 .shw-carbonization-comparison-grid--side-by-side {
   grid-template-areas:
     "hds cds-g0 cwc-g0"


### PR DESCRIPTION
### :pushpin: Summary

Small PR that
- adds `column-stacked` layout variant to `ShwCarbonizationComparisonGrid`
- updates some carbonization showcase pages to improve layout/presentation

***

### :eyes: Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>