### PR TITLE
SECVULN-43130: Override dompurify to remediate SECVULN findings

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files.sh "packages/components" "packages/flight-icons/catalog.json" "showcase" ".github/workflows/ci-components.yml" "packages/tokens"
+        run: ./.github/scripts/filter_changed_files.sh "package.json" "pnpm-lock.yaml" "packages/components" "packages/flight-icons/catalog.json" "showcase" ".github/workflows/ci-components.yml" "packages/tokens"
 
   test:
     name: "Tests"

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: read-files
-        run: ./.github/scripts/filter_changed_files.sh "website" "packages/flight-icons/catalog.json" ".github/workflows/ci-website.yml"
+        run: ./.github/scripts/filter_changed_files.sh "package.json" "pnpm-lock.yaml" "website" "packages/flight-icons/catalog.json" ".github/workflows/ci-website.yml"
 
   lint:
     name: "Lint"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "brace-expansion@1": "1.1.13",
       "brace-expansion@2": "2.0.3",
       "brace-expansion@5": "5.0.6",
+      "dompurify": "3.4.3",
       "flatted": "3.4.2",
       "follow-redirects": "1.16.0",
       "ember-composable-helpers": "npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   brace-expansion@1: 1.1.13
   brace-expansion@2: 2.0.3
   brace-expansion@5: 5.0.6
+  dompurify: 3.4.3
   flatted: 3.4.2
   follow-redirects: 1.16.0
   ember-composable-helpers: npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11
@@ -6124,8 +6125,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.3:
+    resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
 
   domutils@1.7.0:
     resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
@@ -13030,7 +13031,7 @@ snapshots:
       d3-cloud: 1.2.9
       d3-sankey: 0.12.3
       date-fns: 4.1.0
-      dompurify: 3.3.3
+      dompurify: 3.4.3
       html-to-image: 1.11.11
       lodash-es: 4.18.1
       topojson-client: 3.1.0
@@ -18781,7 +18782,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.3:
+  dompurify@3.4.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## Summary

Override the transitive `dompurify` dependency to `3.4.3` so the website's `@carbon/charts` dependency no longer resolves the vulnerable `3.3.3` version flagged by SECVULN-43130 and the related DOMPurify sibling findings.

## How to review

1. Review `package.json` for the new root `pnpm.overrides.dompurify` pin.
2. Review `pnpm-lock.yaml` to confirm the transitive resolution moved from `dompurify@3.3.3` to `dompurify@3.4.3`.
3. Optionally verify the `@carbon/charts` dependency path now resolves the patched version.

## File-by-file review notes

- `package.json` — adds a root `pnpm.overrides` entry forcing `dompurify` to `3.4.3`.
- `pnpm-lock.yaml` — refreshes the lockfile so the `@carbon/charts` dependency path resolves `dompurify@3.4.3` instead of `3.3.3`.

## Behavior to verify

- The repo no longer resolves `dompurify@3.3.3` through `@carbon/charts`.
- The website workspace still installs with the override in place.

## Validation run

- `pnpm install --lockfile-only`
- `pnpm install --ignore-scripts`
- `pnpm -F website lint` *(timed out in this environment)*
- `pnpm -F website test:ember` *(blocked in this environment: Chrome not installed)*
- `pnpm -F website build` *(reported FastBoot/runtime errors in this environment; not clearly attributable to the dependency override)*

## Risks / edge cases

- This is a transitive dependency override rather than a direct dependency update, so future dependency refreshes should preserve the override until upstream resolution changes.
- Full website validation is partially environment-limited here, so follow-up verification in a browser-equipped environment may still be useful.

## README / docs updates

- No README or docs updates were needed for this dependency-only security remediation.

## Jira
- [SECVULN-43130](https://hashicorp.atlassian.net/browse/SECVULN-43130)

[SECVULN-43130]: https://hashicorp.atlassian.net/browse/SECVULN-43130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ