### PR TITLE
SECVULN-43130: Override dompurify to remediate related SECVULN findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
       "follow-redirects": "1.16.0",
       "ember-composable-helpers": "npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11",
       "handlebars": "4.7.9",
+      "dompurify": "3.4.0",
       "js-yaml@3": "3.14.2",
       "js-yaml@4": "4.1.1",
       "markdown-it": "14.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   follow-redirects: 1.16.0
   ember-composable-helpers: npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11
   handlebars: 4.7.9
+  dompurify: 3.4.0
   js-yaml@3: 3.14.2
   js-yaml@4: 4.1.1
   markdown-it: 14.1.1
@@ -6124,8 +6125,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   domutils@1.7.0:
     resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
@@ -13030,7 +13031,7 @@ snapshots:
       d3-cloud: 1.2.9
       d3-sankey: 0.12.3
       date-fns: 4.1.0
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       html-to-image: 1.11.11
       lodash-es: 4.18.1
       topojson-client: 3.1.0
@@ -18781,7 +18782,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## Summary

Upgrade the repo’s resolved `dompurify` version from `3.3.3` to `3.4.0` so the DOMPurify vulnerabilities tracked by `SECVULN-43130`, `SECVULN-43613`, `SECVULN-43614`, and `SECVULN-43615` are remediated with a minimal transitive dependency change. This is done with a root `pnpm.overrides` entry plus a lockfile refresh, without any direct application code changes.

## How to review

1. Review `package.json` to confirm the new root override for `dompurify`.
2. Review `pnpm-lock.yaml` to confirm the lockfile now resolves `dompurify@3.4.0`, including the `@carbon/charts` dependency path.
3. Check the validation section for the lockfile-only install verification that was run.

## File-by-file review notes

- `package.json` (around line 40) — adds `"dompurify": "3.4.0"` under the existing root `pnpm.overrides` block so the transitive dependency is pinned to a patched release.
- `pnpm-lock.yaml` (around lines 21, 6128, 13034, and 18785) — records the override and updates the resolved package/snapshot entries from `dompurify@3.3.3` to `dompurify@3.4.0`, including the `@carbon/charts` snapshot used by the website workspace.

## Behavior to verify

- The workspace resolves `dompurify` to `3.4.0` instead of `3.3.3`.
- No broader dependency churn or direct app code changes were introduced.
- The website’s charting dependency path still resolves cleanly through the updated lockfile.

## Validation run

- `pnpm install --lockfile-only` ✅
- `pnpm install --lockfile-only --frozen-lockfile` ✅
- Verified the lockfile no longer contains `dompurify@3.3.3` and now resolves `dompurify@3.4.0` under `@carbon/charts` ✅

## Risks / edge cases

- This is a transitive dependency override, so the main residual risk is upstream behavioral drift in DOMPurify as consumed by `@carbon/charts`, though the change is narrowly scoped and no direct repo imports of DOMPurify were found.
- Validation here was focused on dependency resolution rather than a full website build/test pass.

## README / docs updates

No README or docs updates were needed because this change only remediates a transitive dependency version in the manifest and lockfile.

## Jira
- [SECVULN-43130](https://hashicorp.atlassian.net/browse/SECVULN-43130)
- [SECVULN-43613](https://hashicorp.atlassian.net/browse/SECVULN-43613)
- [SECVULN-43614](https://hashicorp.atlassian.net/browse/SECVULN-43614)
- [SECVULN-43615](https://hashicorp.atlassian.net/browse/SECVULN-43615)

[SECVULN-43130]: https://hashicorp.atlassian.net/browse/SECVULN-43130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ