### PR TITLE
Remediate fast-uri vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "brace-expansion@2": "2.0.3",
       "brace-expansion@5": "5.0.6",
       "flatted": "3.4.2",
+      "fast-uri": "3.1.2",
       "follow-redirects": "1.16.0",
       "ember-composable-helpers": "npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11",
       "handlebars": "4.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   brace-expansion@2: 2.0.3
   brace-expansion@5: 5.0.6
   flatted: 3.4.2
+  fast-uri: 3.1.2
   follow-redirects: 1.16.0
   ember-composable-helpers: npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11
   handlebars: 4.7.9
@@ -7069,8 +7070,8 @@ packages:
     resolution: {integrity: sha512-7h9/x25c6AQwdU3mA8MZDUMR3UCy50f237egBrBkuwjnUZSmfu4ptCf91PZSKzON2Uh5VvIHozYKWcPPgcjxIw==}
     engines: {node: 10.* || >= 12.*}
 
-  fast-uri@3.0.5:
-    resolution: {integrity: sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastboot-express-middleware@4.1.2:
     resolution: {integrity: sha512-vnzEBV7gZ3lSoGiqG/7+006nHNA3z+ZnU/5u9jPHtKpjH28yEbvZq6PnAeTu24UR98jZVR0pnFbfX0co+O9PeA==}
@@ -16111,7 +16112,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.5
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20942,7 +20943,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fast-uri@3.0.5: {}
+  fast-uri@3.1.2: {}
 
   fastboot-express-middleware@4.1.2:
     dependencies:


### PR DESCRIPTION
## Summary

Remediate the fast-uri vulnerabilities tracked by SECVULN-44701 and SECVULN-44703 by forcing the transitive dependency to `3.1.2`, which satisfies both advisories.

## How to review

1. Check `package.json` for the root `pnpm.overrides` entry for `fast-uri`.
2. Review `pnpm-lock.yaml` to confirm the lockfile now resolves `fast-uri` to `3.1.2` and no longer references `3.0.5`.

## File-by-file review notes

- `package.json` — adds a root `pnpm.overrides.fast-uri` pin to `3.1.2`, matching existing override practice for transitive security fixes.
- `pnpm-lock.yaml` — regenerates the lockfile so the `ajv@8.18.0` dependency path resolves `fast-uri@3.1.2`.

## Behavior to verify

- The workspace lockfile consistently installs with the override in place.
- `fast-uri@3.0.5` is no longer present and `3.1.2` is used instead.

## Validation run

- `npm install --prefix "$HOME/.local" pnpm@10.11.0`
- `"$HOME/.local/node_modules/.bin/pnpm" install --lockfile-only`
- Verified `pnpm-lock.yaml` contains no `fast-uri@3.0.5` entries
- Verified `pnpm-lock.yaml` contains `fast-uri@3.1.2` entries
- `"$HOME/.local/node_modules/.bin/pnpm" install --frozen-lockfile --ignore-scripts`

## Risks / edge cases

- This is a transitive dependency override, so all workspace consumers will resolve to `fast-uri@3.1.2`.
- Risk is low because this is a patch-level remediation, but the main affected path is tooling that depends on `ajv`.

## README / docs updates

- No README or docs updates were needed because this change only remediates a transitive dependency and updates the lockfile.

## Jira
- [SECVULN-44701](https://hashicorp.atlassian.net/browse/SECVULN-44701)
- [SECVULN-44703](https://hashicorp.atlassian.net/browse/SECVULN-44703)

[SECVULN-44701]: https://hashicorp.atlassian.net/browse/SECVULN-44701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ