### PR TITLE
SECVULN-44313: Override socks to remediate ip-address alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
       "picomatch": "4.0.4",
       "qs": "6.14.1",
       "serialize-javascript": "7.0.5",
+      "socks": "2.8.9",
       "socket.io-parser": "4.2.6",
       "systeminformation": "5.31.0",
       "undici": "6.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ overrides:
   picomatch: 4.0.4
   qs: 6.14.1
   serialize-javascript: 7.0.5
+  socks: 2.8.9
   socket.io-parser: 4.2.6
   systeminformation: 5.31.0
   undici: 6.24.0
@@ -7934,8 +7935,8 @@ packages:
     resolution: {integrity: sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw==}
     engines: {node: '>=8'}
 
-  ip-address@9.0.5:
-    resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -8462,9 +8463,6 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
-
-  jsbn@1.1.0:
-    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
 
   jscodeshift@0.11.0:
     resolution: {integrity: sha512-SdRK2C7jjs4k/kT2mwtO07KJN9RnjxtKn03d9JVj6c3j9WwaLcFYsICYDnLAzY0hp+wG2nxl+Cm2jWLiNVYb8g==}
@@ -10678,8 +10676,8 @@ packages:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
 
-  socks@2.8.6:
-    resolution: {integrity: sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==}
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sort-object-keys@1.1.3:
@@ -22079,10 +22077,7 @@ snapshots:
 
   invert-kv@3.0.1: {}
 
-  ip-address@9.0.5:
-    dependencies:
-      jsbn: 1.1.0
-      sprintf-js: 1.1.3
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -22751,8 +22746,6 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
-
-  jsbn@1.1.0: {}
 
   jscodeshift@0.11.0(@babel/preset-env@7.26.9(@babel/core@7.28.0)):
     dependencies:
@@ -25399,13 +25392,13 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.1
-      socks: 2.8.6
+      socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
 
-  socks@2.8.6:
+  socks@2.8.9:
     dependencies:
-      ip-address: 9.0.5
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   sort-object-keys@1.1.3: {}


### PR DESCRIPTION
## Summary

Remediate SECVULN-44313 by overriding the transitive `socks` dependency to `2.8.9`, which updates the vulnerable `ip-address@9.0.5` resolution in the Percy toolchain to patched `ip-address@10.2.0`.

## How to review

1. Review the new root `pnpm.overrides.socks` entry in `package.json`.
2. Confirm `pnpm-lock.yaml` now resolves `socks@2.8.9` and no longer contains `ip-address@9.0.5`.
3. Check the validation commands below.

## File-by-file review notes

- `package.json` — adds a root `pnpm.overrides` pin for `socks: 2.8.9` to steer the vulnerable transitive chain onto a patched dependency path.
- `pnpm-lock.yaml` — refreshes the lockfile to replace `socks@2.8.6 -> ip-address@9.0.5` with `socks@2.8.9 -> ip-address@10.2.0`, and removes now-unused `jsbn` lock entries.

## Behavior to verify

- The repo installs cleanly with the updated lockfile.
- The dependency graph no longer includes `ip-address@9.0.5`.
- The change remains scoped to the Percy/showcase transitive dependency chain.

## Validation run

- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile --ignore-scripts`
- Verified `pnpm-lock.yaml` no longer contains `ip-address@9.0.5`

## Risks / edge cases

- This intentionally pins a transitive dependency via `pnpm.overrides`; future Percy dependency updates may make the override unnecessary.
- The affected package is only present through tooling dependencies, so runtime compatibility risk should stay low.

## README / docs updates

- No docs updates were needed for this dependency remediation.

## Jira
- [SECVULN-44313](https://hashicorp.atlassian.net/browse/SECVULN-44313)

[SECVULN-44313]: https://hashicorp.atlassian.net/browse/SECVULN-44313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ