### PR TITLE
SECVULN-44701: Override fast-uri to remediate related findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "brace-expansion@2": "2.0.3",
       "brace-expansion@5": "5.0.6",
       "flatted": "3.4.2",
+      "fast-uri": "3.1.2",
       "follow-redirects": "1.16.0",
       "ember-composable-helpers": "npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11",
       "handlebars": "4.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   brace-expansion@2: 2.0.3
   brace-expansion@5: 5.0.6
   flatted: 3.4.2
+  fast-uri: 3.1.2
   follow-redirects: 1.16.0
   ember-composable-helpers: npm:@nullvoxpopuli/ember-composable-helpers@^5.2.11
   handlebars: 4.7.9
@@ -7070,8 +7071,8 @@ packages:
     resolution: {integrity: sha512-7h9/x25c6AQwdU3mA8MZDUMR3UCy50f237egBrBkuwjnUZSmfu4ptCf91PZSKzON2Uh5VvIHozYKWcPPgcjxIw==}
     engines: {node: 10.* || >= 12.*}
 
-  fast-uri@3.0.5:
-    resolution: {integrity: sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastboot-express-middleware@4.1.2:
     resolution: {integrity: sha512-vnzEBV7gZ3lSoGiqG/7+006nHNA3z+ZnU/5u9jPHtKpjH28yEbvZq6PnAeTu24UR98jZVR0pnFbfX0co+O9PeA==}
@@ -16109,7 +16110,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.5
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20940,7 +20941,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fast-uri@3.0.5: {}
+  fast-uri@3.1.2: {}
 
   fastboot-express-middleware@4.1.2:
     dependencies:


### PR DESCRIPTION
## Summary

Override the transitive `fast-uri` dependency to `3.1.2` so this repo no longer resolves vulnerable `fast-uri@3.0.5`, which closes the grounded `SECVULN-44701` and package-matched sibling `SECVULN-44703` findings together.

## How to review

1. Check `package.json` for the new root `pnpm.overrides` entry for `fast-uri`.
2. Check `pnpm-lock.yaml` to confirm the lockfile now resolves `fast-uri@3.1.2` and that `ajv@8.18.0` points to the patched version.
3. Review the validation section for the lockfile-only checks run for this dependency remediation.

## File-by-file review notes

- `package.json` (around line 37) — adds a root `pnpm.overrides` pin for `fast-uri: 3.1.2` alongside the existing security/dependency overrides.
- `pnpm-lock.yaml` (around lines 18, 7074, 16113, and 20944) — records the override, replaces the `fast-uri@3.0.5` package entry with `fast-uri@3.1.2`, and updates the `ajv@8.18.0` snapshot to consume `fast-uri: 3.1.2`.

## Behavior to verify

- The repo resolves `fast-uri` to `3.1.2` or newer rather than `3.0.5`.
- Both fast-uri GitHub code scanning findings are satisfied by the single patched version.
- No product-code behavior changed beyond the transitive dependency resolution.

## Validation run

- `pnpm install --lockfile-only`
- `git diff --check -- package.json pnpm-lock.yaml`
- `rg -n '"fast-uri": "3\.1\.2"|fast-uri: 3\.1\.2|fast-uri@3\.1\.2' package.json pnpm-lock.yaml`
- Confirmed no `fast-uri@3.0.5` or `fast-uri: 3.0.5` entries remain in `pnpm-lock.yaml`

## Risks / edge cases

- This is a transitive dependency override, so all workspace consumers of the affected dependency chain will use `fast-uri@3.1.2`.
- The main residual risk is upstream compatibility if any consumer relies on vulnerable edge-case URI normalization behavior, though this repo only changed dependency resolution and did not require source changes.
- `pnpm install --lockfile-only` reported pre-existing peer dependency warnings unrelated to this remediation.

## README / docs updates

No README or docs updates were needed because this change only updates dependency resolution for a security remediation.

## Jira
- [SECVULN-44701](https://hashicorp.atlassian.net/browse/SECVULN-44701)
- [SECVULN-44703](https://hashicorp.atlassian.net/browse/SECVULN-44703)

[SECVULN-44701]: https://hashicorp.atlassian.net/browse/SECVULN-44701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ