### PR TITLE
SECVULN-45094: Override systeminformation to remediate code scanning alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
       "serialize-javascript": "7.0.5",
       "socks": "2.8.9",
       "socket.io-parser": "4.2.6",
-      "systeminformation": "5.31.0",
+      "systeminformation": "5.31.6",
       "undici": "6.24.0",
       "underscore": "1.13.8",
       "yaml@1": "1.10.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ overrides:
   serialize-javascript: 7.0.5
   socks: 2.8.9
   socket.io-parser: 4.2.6
-  systeminformation: 5.31.0
+  systeminformation: 5.31.6
   undici: 6.24.0
   underscore: 1.13.8
   yaml@1: 1.10.3
@@ -11061,8 +11061,8 @@ packages:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  systeminformation@5.31.0:
-    resolution: {integrity: sha512-z5pjzvC8UnQJ/iu34z+mo3lAeMzTGdArjPQoG5uPyV5XY4BY+M6ZcRTl4XnZqudz6sP713LhWMKv6e0kGFGCgQ==}
+  systeminformation@5.31.6:
+    resolution: {integrity: sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==}
     engines: {node: '>=8.0.0'}
     hasBin: true
 
@@ -15011,7 +15011,7 @@ snapshots:
       '@percy/config': 1.31.1(typescript@5.9.2)
       '@percy/logger': 1.31.1
       '@percy/sdk-utils': 1.31.1
-      systeminformation: 5.31.0
+      systeminformation: 5.31.6
     transitivePeerDependencies:
       - typescript
 
@@ -25923,7 +25923,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  systeminformation@5.31.0: {}
+  systeminformation@5.31.6: {}
 
   tabbable@5.3.3: {}
 


### PR DESCRIPTION
## Summary

Upgrade the root `pnpm` override for `systeminformation` from `5.31.0` to `5.31.6` to remediate GHSA-hvx9-hwr7-wjj9 / SECVULN-45094, and regenerate the lockfile so the vulnerable resolution is removed.

## How to review

1. Check `package.json` for the override bump from `5.31.0` to `5.31.6`.
2. Check `pnpm-lock.yaml` to confirm the lockfile resolves `systeminformation` to `5.31.6` and no `5.31.0` entries remain.
3. Review the validation notes below for the lockfile refresh command that was used.

## File-by-file review notes

- `package.json` — updated the root `pnpm.overrides.systeminformation` pin from `5.31.0` to `5.31.6`.
- `pnpm-lock.yaml` — refreshed override metadata and package snapshots so all `systeminformation` resolutions now point to `5.31.6`.

## Behavior to verify

- The repository no longer resolves `systeminformation@5.31.0`.
- The dependency graph resolves to `systeminformation@5.31.6` or later for the Percy transitive path flagged by code scanning.

## Validation run

- `npx pnpm@10.11.0 install --lockfile-only`
- Confirmed the override in `package.json` is `5.31.6`.
- Confirmed `pnpm-lock.yaml` no longer contains `systeminformation@5.31.0` and now contains `systeminformation@5.31.6`.
- Reviewer reran `npx pnpm@10.11.0 install --lockfile-only` without additional diff.

## Risks / edge cases

- This review did not include a full workspace CI or test run; approval is based on a narrow dependency/lockfile remediation.
- The change intentionally uses the minimum patched version recommended by the alert to keep scope small.

## README / docs updates

- No README or docs updates were needed because this is a dependency remediation only.

## Jira
- [SECVULN-45094](https://hashicorp.atlassian.net/browse/SECVULN-45094)

[SECVULN-45094]: https://hashicorp.atlassian.net/browse/SECVULN-45094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ