### PR TITLE
StepperNav - Remove unneeded classes for interactive step

### DIFF
--- a/.changeset/tender-chefs-learn.md
+++ b/.changeset/tender-chefs-learn.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/stepper/nav -->
+`Stepper::Nav` - Refactored classes for step to removed unneeded interactive classes
+<!-- END -->

--- a/packages/components/src/components/hds/stepper/nav/step.gts
+++ b/packages/components/src/components/hds/stepper/nav/step.gts
@@ -187,14 +187,6 @@ export default class HdsStepperNavStep extends Component<HdsStepperNavStepSignat
 
     classes.push(`hds-stepper-nav__step--${this.status}`);
 
-    if (this.isInteractive) {
-      classes.push('hds-stepper-nav__step--interactive');
-    }
-
-    if (this.isNavInteractive) {
-      classes.push('hds-stepper-nav__step--nav-interactive');
-    }
-
     return classes.join(' ');
   }
 

--- a/packages/components/src/styles/components/stepper/nav.scss
+++ b/packages/components/src/styles/components/stepper/nav.scss
@@ -141,9 +141,12 @@ $progress-bar-animation-duration: 0.25s;
     background-color: var(--token-color-palette-blue-200);
   }
 
-  .hds-stepper-nav__step--complete,
   .hds-stepper-nav__step--active {
     .hds-stepper-nav__step-button {
+      .hds-stepper-nav__step-title {
+        color: var(--token-color-foreground-action);
+      }
+
       @include hds-focus-ring-with-pseudo-element(
         $top: -3px,
         $right: -1px,
@@ -152,15 +155,18 @@ $progress-bar-animation-duration: 0.25s;
         $radius: 0 0 var(--token-border-radius-medium) var(--token-border-radius-medium)
       );
     }
-
-    .hds-stepper-nav__step-title {
-      color: var(--token-color-foreground-action);
-    }
   }
 
   .hds-stepper-nav__step--complete {
     .hds-stepper-nav__step-button {
       cursor: pointer;
+
+      .hds-stepper-nav__step-title {
+        color: var(--token-color-foreground-action);
+        text-decoration: underline;
+        text-decoration-skip-ink: none;
+        text-underline-position: from-font;
+      }
 
       &:hover,
       &.mock-hover {
@@ -171,6 +177,14 @@ $progress-bar-animation-duration: 0.25s;
         }
       }
 
+      @include hds-focus-ring-with-pseudo-element(
+        $top: -3px,
+        $right: -1px,
+        $bottom: -1px,
+        $left: -1px,
+        $radius: 0 0 var(--token-border-radius-medium) var(--token-border-radius-medium)
+      );
+
       &:active,
       &.mock-active {
         background-color: var(--token-color-surface-interactive-active);
@@ -179,12 +193,6 @@ $progress-bar-animation-duration: 0.25s;
           color: var(--token-color-foreground-action-active);
         }
       }
-    }
-
-    .hds-stepper-nav__step-title {
-      text-decoration: underline;
-      text-decoration-skip-ink: none;
-      text-underline-position: from-font;
     }
   }
 }

--- a/packages/components/src/styles/components/stepper/nav.scss
+++ b/packages/components/src/styles/components/stepper/nav.scss
@@ -141,57 +141,50 @@ $progress-bar-animation-duration: 0.25s;
     background-color: var(--token-color-palette-blue-200);
   }
 
-  .hds-stepper-nav__step--complete .hds-stepper-nav__step-title,
-  .hds-stepper-nav__step--active .hds-stepper-nav__step-title {
-    color: var(--token-color-foreground-action);
+  .hds-stepper-nav__step--complete,
+  .hds-stepper-nav__step--active {
+    .hds-stepper-nav__step-button {
+      @include hds-focus-ring-with-pseudo-element(
+        $top: -3px,
+        $right: -1px,
+        $bottom: -1px,
+        $left: -1px,
+        $radius: 0 0 var(--token-border-radius-medium) var(--token-border-radius-medium)
+      );
+    }
+
+    .hds-stepper-nav__step-title {
+      color: var(--token-color-foreground-action);
+    }
   }
 
-  .hds-stepper-nav__step--complete .hds-stepper-nav__step-title {
-    text-decoration: underline;
-    text-decoration-skip-ink: none;
-    text-underline-position: from-font;
-  }
+  .hds-stepper-nav__step--complete {
+    .hds-stepper-nav__step-button {
+      cursor: pointer;
 
-  .hds-stepper-nav__step--active .hds-stepper-nav__step-button {
-    @include hds-focus-ring-with-pseudo-element(
-      $top: -3px,
-      $right: -1px,
-      $bottom: -1px,
-      $left: -1px,
-      $radius: 0 0 var(--token-border-radius-medium) var(--token-border-radius-medium)
-    );
-  }
-}
+      &:hover,
+      &.mock-hover {
+        background-color: var(--token-color-surface-interactive-hover);
 
-// INTERACTIVE
+        .hds-stepper-nav__step-title {
+          color: var(--token-color-foreground-action-hover);
+        }
+      }
 
-.hds-stepper-nav__step--interactive {
-  .hds-stepper-nav__step-button {
-    @include hds-focus-ring-with-pseudo-element(
-      $top: -3px,
-      $right: -1px,
-      $bottom: -1px,
-      $left: -1px,
-      $radius: 0 0 6px 6px
-    );
-    cursor: pointer;
+      &:active,
+      &.mock-active {
+        background-color: var(--token-color-surface-interactive-active);
 
-    &:hover,
-    &.mock-hover {
-      background-color: var(--token-color-surface-interactive-hover);
-
-      .hds-stepper-nav__step-title {
-        color: var(--token-color-foreground-action-hover);
+        .hds-stepper-nav__step-title {
+          color: var(--token-color-foreground-action-active);
+        }
       }
     }
 
-    &:active,
-    &.mock-active {
-      background-color: var(--token-color-surface-interactive-active);
-
-      .hds-stepper-nav__step-title {
-        color: var(--token-color-foreground-action-active);
-      }
+    .hds-stepper-nav__step-title {
+      text-decoration: underline;
+      text-decoration-skip-ink: none;
+      text-underline-position: from-font;
     }
   }
 }
@@ -202,7 +195,7 @@ $progress-bar-animation-duration: 0.25s;
 // and have those styles be added based on interaction with step buttons instead.
 
 @each $status in $hds-stepper-indicator-step-statuses {
-  .hds-stepper-nav__step--nav-interactive {
+  .hds-stepper-nav--interactive .hds-stepper-nav__step {
     .hds-stepper-nav__step-button:hover,
     .hds-stepper-nav__step-button.mock-hover {
       .hds-stepper-indicator-step--status-#{$status} {
@@ -218,28 +211,6 @@ $progress-bar-animation-duration: 0.25s;
           path {
             fill: map.get($hds-stepper-indicator-step-status-props, $status, "fill-color-default");
             stroke: map.get($hds-stepper-indicator-step-status-props, $status, "stroke-color-default");
-          }
-        }
-      }
-    }
-
-    &.hds-stepper-nav__step--interactive {
-      .hds-stepper-nav__step-button:hover,
-      .hds-stepper-nav__step-button.mock-hover {
-        .hds-stepper-indicator-step--status-#{$status} {
-          &.hds-stepper-indicator-step {
-            cursor: pointer;
-          }
-
-          .hds-stepper-indicator-step__status {
-            color: map.get($hds-stepper-indicator-step-status-props, $status, "text-color-hover");
-          }
-
-          .hds-stepper-indicator-step__svg-hexagon {
-            path {
-              fill: map.get($hds-stepper-indicator-step-status-props, $status, "fill-color-hover");
-              stroke: map.get($hds-stepper-indicator-step-status-props, $status, "stroke-color-hover");
-            }
           }
         }
       }
@@ -265,7 +236,27 @@ $progress-bar-animation-duration: 0.25s;
       }
     }
 
-    &.hds-stepper-nav__step--interactive {
+    &.hds-stepper-nav__step--complete {
+      .hds-stepper-nav__step-button:hover,
+      .hds-stepper-nav__step-button.mock-hover {
+        .hds-stepper-indicator-step--status-#{$status} {
+          &.hds-stepper-indicator-step {
+            cursor: pointer;
+          }
+
+          .hds-stepper-indicator-step__status {
+            color: map.get($hds-stepper-indicator-step-status-props, $status, "text-color-hover");
+          }
+
+          .hds-stepper-indicator-step__svg-hexagon {
+            path {
+              fill: map.get($hds-stepper-indicator-step-status-props, $status, "fill-color-hover");
+              stroke: map.get($hds-stepper-indicator-step-status-props, $status, "stroke-color-hover");
+            }
+          }
+        }
+      }
+
       .hds-stepper-nav__step-button:active,
       .hds-stepper-nav__step-button.mock-active {
         .hds-stepper-indicator-step--status-#{$status} {
@@ -324,7 +315,7 @@ $progress-bar-animation-duration: 0.25s;
     padding: 0;
   }
 
-  .hds-stepper-nav--interactive .hds-stepper-nav__step--interactive .hds-stepper-nav__step-button,
+  .hds-stepper-nav--interactive .hds-stepper-nav__step--complete .hds-stepper-nav__step-button,
   .hds-stepper-nav--interactive .hds-stepper-nav__step--active .hds-stepper-nav__step-button {
     @include hds-focus-ring-with-pseudo-element($top: -1px, $right: -1px, $bottom: -1px, $left: -1px, $radius: 0);
   }

--- a/showcase/app/templates/application.gts
+++ b/showcase/app/templates/application.gts
@@ -57,7 +57,9 @@ export default class Application extends Component {
     {{pageTitle "HDS Showcase"}}
 
     {{#if this.isFrameless}}
-      {{outlet}}
+      <main {{this.handleInitialStateClasses}}>
+        {{outlet}}
+      </main>
     {{else}}
       <header class="shw-page-header">
         <LinkTo

--- a/showcase/app/templates/page-components/stepper/frameless/demo-responsiveness.gts
+++ b/showcase/app/templates/page-components/stepper/frameless/demo-responsiveness.gts
@@ -12,19 +12,34 @@ import { HdsStepperNav } from '@hashicorp/design-system-components/components';
 const PageComponentsStepperNavFramelessDemoResponsiveness: TemplateOnlyComponent =
   <template>
     <div {{style padding="24px"}}>
-      <HdsStepperNav @currentStep={{1}} @ariaLabel="Label" as |S|>
-        <S.Step>
-          <:title>Title</:title>
-          <:description>Description</:description>
+      <HdsStepperNav @currentStep={{4}} @ariaLabel="Label" as |S|>
+        <S.Step mock-state-value="default" mock-state-selector="button">
+          <:title>Completed step</:title>
+          <:description>Default</:description>
+        </S.Step>
+        <S.Step mock-state-value="focus" mock-state-selector="button">
+          <:title>Completed step</:title>
+          <:description>Focus</:description>
+        </S.Step>
+        <S.Step mock-state-value="hover" mock-state-selector="button">
+          <:title>Completed step</:title>
+          <:description>Hover</:description>
+        </S.Step>
+        <S.Step mock-state-value="active" mock-state-selector="button">
+          <:title>Completed step</:title>
+          <:description>Active</:description>
+        </S.Step>
+        <S.Step mock-state-value="focus" mock-state-selector="button">
+          <:title>Active step</:title>
+          <:description>Focus</:description>
         </S.Step>
         <S.Step>
-          <:title>Title</:title>
-          <:description>Description</:description>
+          <:title>Incomplete step</:title>
+          <:description>Default</:description>
         </S.Step>
-        <S.Step>
-          <:title>Title</:title>
-          <:description>Description</:description>
-        </S.Step>
+        <S.Panel />
+        <S.Panel />
+        <S.Panel />
         <S.Panel />
         <S.Panel />
         <S.Panel />

--- a/showcase/tests/integration/components/hds/stepper/nav-step-test.gts
+++ b/showcase/tests/integration/components/hds/stepper/nav-step-test.gts
@@ -119,9 +119,6 @@ module('Integration | Component | hds/stepper/nav/step', function (hooks) {
     await createNavStep({});
     assert.dom('.hds-stepper-nav__step').hasAttribute('role', 'presentation');
     assert
-      .dom('.hds-stepper-nav__step')
-      .hasClass('hds-stepper-nav__step--nav-interactive');
-    assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--is-interactive');
     assert
@@ -132,9 +129,6 @@ module('Integration | Component | hds/stepper/nav/step', function (hooks) {
   test('it sets the step to non-interactive when the @isNavInteractive argument is provided to the parent', async function (assert) {
     await createNavStep({ isNavInteractive: false });
     assert.dom('.hds-stepper-nav__step').hasNoAttribute('role');
-    assert
-      .dom('.hds-stepper-nav__step')
-      .hasNoClass('hds-stepper-nav__step--interactive');
     assert
       .dom('.hds-stepper-indicator-step')
       .hasNoClass('hds-stepper-indicator-step--is-interactive');

--- a/showcase/tests/integration/components/hds/stepper/nav-test.gts
+++ b/showcase/tests/integration/components/hds/stepper/nav-test.gts
@@ -155,18 +155,12 @@ module('Integration | Component | hds/stepper/nav', function (hooks) {
   test('it sets the steps to interactive when the @isInteractive argument is not provided', async function (assert) {
     await createStepperNav({});
     assert.dom('.hds-stepper-nav__list').hasAttribute('role', 'tablist');
-    assert
-      .dom('[data-test="step-1"]')
-      .hasClass('hds-stepper-nav__step--nav-interactive');
     assert.dom('.hds-stepper-nav__panel').hasAttribute('role', 'tabpanel');
   });
 
   test('it sets the steps to non-interactive when the @isInteractive argument is provided', async function (assert) {
     await createStepperNav({ isInteractive: false });
     assert.dom('.hds-stepper-nav__list').hasNoAttribute('role');
-    assert
-      .dom('[data-test="step-1"]')
-      .hasNoClass('hds-stepper-nav__step--nav-interactive');
     assert.dom('.hds-stepper-nav__panel').hasNoAttribute('role');
   });
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would refactor the `Stepper::Nav::Step` to remove classes `hds-stepper-nav__step--nav-interactive` and `hds-stepper-nav__step--interactive`. Their need has been replaced by updating the sass selectors for the interactive steps.

[Preview](https://hds-showcase-git-dchyun-stepper-nav-selector-clean-up-hashicorp.vercel.app/components/stepper/nav)

### :hammer_and_wrench: Detailed description

In the `StepperNav::Step` component there are various classes added to the step when the parent nav has `isInteractive={{true}}`

- `hds-stepper-nav__step--nav-interactive`
  - Added to all steps, regardless of status, that are inside a nav where `@isInteractive={{true}}`
  - See the sass comment, this is needed to override the interactive styles that come from the `StepIndicator` which we don't need unless the step is completed.
- `hds-stepper-nav__step--interactive`
  - Added if the step is inside a nav with `@isInteractive={{true}}` and the step status is complete

These classes are not needed and have been replaced with nested selectors in the sass instead
- `hds-stepper-nav__step--nav-interactive`
  - Replaced with the selector `.hds-stepper-nav--interactive .hds-stepper-nav__step`
- `hds-stepper-nav__step--interactive`
  - Rplaced with the selector `.hds-stepper-nav--interactive .hds-stepper-nav__step--complete`

These classes have been removed from the template, styles, and tests. Visually the stepper should be unchanged.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6292](https://hashicorp.atlassian.net/browse/HDS-6292)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6292]: https://hashicorp.atlassian.net/browse/HDS-6292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ