### PR TITLE
`Dropdown` - Fix alignment between text and badge in `ListItemInteractive`

### DIFF
--- a/.changeset/grumpy-mangos-jog.md
+++ b/.changeset/grumpy-mangos-jog.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/dropdown -->
+`Dropdown` - Fixed vertical alignment between text and `Badge` in `DropdownListItemInteractive`
+<!-- END -->

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -454,6 +454,10 @@ $hds-dropdown-toggle-border-radius: $hds-button-border-radius;
   display: block;
   flex: 1;
   text-align: left; // the button element was centering text
+
+  .hds-badge {
+    vertical-align: bottom; // align badge to the text baseline
+  }
 }
 
 .hds-dropdown-list-item--color-action {


### PR DESCRIPTION
### :pushpin: Summary

Originally caught in #3814, this PR would fix the vertical alignment in the `DropdownListItemInteractive` between the text and the `Badge`.

### :hammer_and_wrench: Detailed description

Currently in the `DropdownListItemInteractive`, the text and `Badge` are not vertically aligned. This is because the height of the badge is smaller than the height of the text, and they are not using any flexbox for alignment.

In this PR the badge text has been aligned by setting `vertical-align: bottom` on the badge. A flexbox was not able to be used because the badge is intended to stay inline with the text as it wraps to multiple lines.

<img width="540" height="143" alt="Screenshot 2026-05-26 at 4 54 18 PM" src="https://github.com/user-attachments/assets/b2e49527-52ee-4a2c-a24f-7ac35aef5f70" />

### :camera_flash: Screenshots

**Before**
<img width="986" height="202" alt="Screenshot 2026-05-26 at 4 44 43 PM" src="https://github.com/user-attachments/assets/b104b912-463e-4d1f-add3-30b8ec260e01" />

**After**
<img width="976" height="174" alt="Screenshot 2026-05-26 at 4 45 16 PM" src="https://github.com/user-attachments/assets/dc980be5-d8a6-4c55-94b0-95a3469527cc" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6295](https://hashicorp.atlassian.net/browse/HDS-6295)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6295]: https://hashicorp.atlassian.net/browse/HDS-6295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ