### PR TITLE
`CopySnippet`, `CopyButton` - Add copy success & error messages (HDS-6294)

### DIFF
--- a/.changeset/nice-rats-admire.md
+++ b/.changeset/nice-rats-admire.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/copy/snippet -->
-`CopySnippet` - Fixed a11y issue by adding `ariaMessageText` parameter to an aria-live region to announce to screen readers when content has been copied
+`CopySnippet` - Fixed a11y issue by adding `@ariaMessageText` argument to an aria-live region to announce to screen readers when content has been copied
 <!-- END -->

--- a/.changeset/nice-rats-admire.md
+++ b/.changeset/nice-rats-admire.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
+<!-- START components/copy/snippet -->
 `CopySnippet` - Fixed a11y issue by adding `ariaMessageText` parameter to an aria-live region to announce to screen readers when content has been copied
+<!-- END -->

--- a/.changeset/nice-rats-admire.md
+++ b/.changeset/nice-rats-admire.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CopySnippet` - Fixed a11y issue by adding `ariaMessageText` parameter to an aria-live region to announce to screen readers when content has been copied

--- a/.changeset/nice-rats-admire.md
+++ b/.changeset/nice-rats-admire.md
@@ -3,5 +3,9 @@
 ---
 
 <!-- START components/copy/snippet -->
-`CopySnippet` - Fixed a11y issue by adding `@ariaMessageText` argument to an aria-live region to announce to screen readers when content has been copied
+`CopySnippet` - Fixed a11y issue by adding `@ariaMessageText` argument to an aria-live region to announce to screen readers when content has been copied. Added handling for copy to clipboard error state in `ariaMessageText`
+<!-- END -->
+
+<!-- START components/copy/button -->
+`CopyButton` - Added handling for copy to clipboard error state in `ariaMessageText`
 <!-- END -->

--- a/packages/components/src/components/hds/copy/button/index.gts
+++ b/packages/components/src/components/hds/copy/button/index.gts
@@ -83,9 +83,16 @@ export default class HdsCopyButton extends Component<HdsCopyButtonSignature> {
     if (this._status === 'success') {
       return (
         this.args.ariaMessageText ??
-        this.hdsIntl.t('hds.components.copy-button.aria-message-text', {
+        this.hdsIntl.t('hds.components.copy-button.aria-message-text.success', {
           default: 'Copied to clipboard',
         })
+      );
+    } else if (this._status === 'error') {
+      return this.hdsIntl.t(
+        'hds.components.copy-button.aria-message-text.error',
+        {
+          default: 'Failed to copy to clipboard',
+        }
       );
     } else {
       return '';

--- a/packages/components/src/components/hds/copy/snippet/index.gts
+++ b/packages/components/src/components/hds/copy/snippet/index.gts
@@ -116,9 +116,19 @@ export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
     if (this._status === 'success') {
       return (
         this.args.ariaMessageText ??
-        this.hdsIntl.t('hds.components.copy-snippet.aria-message-text', {
-          default: 'Copied to clipboard',
-        })
+        this.hdsIntl.t(
+          'hds.components.copy-snippet.aria-message-text.success',
+          {
+            default: 'Copied to clipboard',
+          }
+        )
+      );
+    } else if (this._status === 'error') {
+      return this.hdsIntl.t(
+        'hds.components.copy-snippet.aria-message-text.error',
+        {
+          default: 'Failed to copy to clipboard',
+        }
       );
     } else {
       return '';

--- a/packages/components/src/components/hds/copy/snippet/index.gts
+++ b/packages/components/src/components/hds/copy/snippet/index.gts
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
 import { concat } from '@ember/helper';
+import { service } from '@ember/service';
 
 import { HdsCopySnippetColorValues } from './types.ts';
 import HdsTextCode from '../../text/code.gts';
@@ -17,6 +18,7 @@ import hdsT from '../../../../helpers/hds-t.ts';
 import type { HdsCopySnippetColors } from './types.ts';
 import type { HdsClipboardModifierSignature } from '../../../../modifiers/hds-clipboard.ts';
 import type { HdsIconSignature } from '../../icon/index.gts';
+import type HdsIntlService from '../../../../services/hds-intl';
 
 export const DEFAULT_COLOR = HdsCopySnippetColorValues.Primary;
 export const COLORS: HdsCopySnippetColors[] = Object.values(
@@ -36,11 +38,14 @@ export interface HdsCopySnippetSignature {
     isTruncated?: boolean;
     onSuccess?: HdsClipboardModifierSignature['Args']['Named']['onSuccess'];
     onError?: HdsClipboardModifierSignature['Args']['Named']['onError'];
+    ariaMessageText?: string;
   };
   Element: HTMLButtonElement;
 }
 
 export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
+  @service declare readonly hdsIntl: HdsIntlService;
+
   @tracked private _status = DEFAULT_STATUS;
   @tracked private _timer: ReturnType<typeof setTimeout> | undefined;
 
@@ -107,6 +112,19 @@ export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
     return classes.join(' ');
   }
 
+  get ariaMessageText(): string {
+    if (this._status === 'success') {
+      return (
+        this.args.ariaMessageText ??
+        this.hdsIntl.t('hds.components.copy-snippet.aria-message-text', {
+          default: 'Copied to clipboard',
+        })
+      );
+    } else {
+      return '';
+    }
+  }
+
   onSuccess = (
     args: HdsClipboardModifierSignature['Args']['Named']['onSuccess']
   ): void => {
@@ -162,5 +180,6 @@ export default class HdsCopySnippet extends Component<HdsCopySnippetSignature> {
       </HdsTextCode>
       <HdsIcon @name={{this.icon}} class="hds-copy-snippet__icon" />
     </button>
+    <span class="sr-only" aria-live="polite">{{this.ariaMessageText}}</span>
   </template>
 }

--- a/packages/components/translations/hds/components/copy-button/en-us.yaml
+++ b/packages/components/translations/hds/components/copy-button/en-us.yaml
@@ -1,1 +1,3 @@
-aria-message-text: Copied to clipboard
+aria-message-text:
+  success: Copied to clipboard
+  error: Failed to copy to clipboard

--- a/packages/components/translations/hds/components/copy-snippet/en-us.yaml
+++ b/packages/components/translations/hds/components/copy-snippet/en-us.yaml
@@ -1,2 +1,3 @@
+aria-message-text: Copied to clipboard
 button:
   aria-label: copy {textToCopy}

--- a/packages/components/translations/hds/components/copy-snippet/en-us.yaml
+++ b/packages/components/translations/hds/components/copy-snippet/en-us.yaml
@@ -1,3 +1,5 @@
-aria-message-text: Copied to clipboard
+aria-message-text:
+  success: Copied to clipboard
+  error: Failed to copy to clipboard
 button:
   aria-label: copy {textToCopy}

--- a/showcase/tests/integration/components/hds/copy/button/index-test.gts
+++ b/showcase/tests/integration/components/hds/copy/button/index-test.gts
@@ -282,6 +282,10 @@ module('Integration | Component | hds/copy/button/index', function (hooks) {
     await click('button#test-copy-button');
     assert.false(context.success);
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-error');
+    // Test the copy error message is rendered:
+    assert
+      .dom('#test-copy-button + .sr-only')
+      .hasText('Failed to copy to clipboard');
     await wait(2000); // wait for the status to revert to "idle" automatically
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
   });

--- a/showcase/tests/integration/components/hds/copy/button/index-test.gts
+++ b/showcase/tests/integration/components/hds/copy/button/index-test.gts
@@ -96,6 +96,28 @@ module('Integration | Component | hds/copy/button/index', function (hooks) {
   });
 
   // @ariaMessageText ARGUMENT
+
+  test('it should set a default success message in the aria-live region if a custom message is not passed', async function (assert) {
+    await render(
+      <template>
+        <HdsCopyButton
+          id="test-copy-button"
+          @text="Copy your secret key"
+          @textToCopy="someSecretThingGoesHere"
+        />
+      </template>,
+    );
+    assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
+    // Test the copy success message is not rendered before the button is clicked:
+    assert
+      .dom('#test-copy-button + .sr-only')
+      .doesNotContainText('Copied to clipboard');
+
+    await click('button#test-copy-button');
+    // Test the copy success message is rendered after the button is clicked:
+    assert.dom('#test-copy-button + .sr-only').hasText('Copied to clipboard');
+  });
+
   test('it should set a custom success message in the aria-live region if passed', async function (assert) {
     await render(
       <template>
@@ -222,16 +244,9 @@ module('Integration | Component | hds/copy/button/index', function (hooks) {
       </template>,
     );
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-idle');
-    // Test the copy success message is not rendered before the button is clicked:
-    assert
-      .dom('#test-copy-button + .sr-only')
-      .doesNotContainText('Copied to clipboard');
-
     await click('button#test-copy-button');
     assert.true(context.success);
-    // Test the copy success message is rendered after the button is clicked:
     assert.dom('#test-copy-button').hasClass('hds-copy-button--status-success');
-    assert.dom('#test-copy-button + .sr-only').hasText('Copied to clipboard');
   });
 
   test('it should update the status back to idle after success', async function (assert) {

--- a/showcase/tests/integration/components/hds/copy/snippet/index-test.gts
+++ b/showcase/tests/integration/components/hds/copy/snippet/index-test.gts
@@ -216,6 +216,10 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
     await click('button#test-copy-snippet');
     assert.false(context.success);
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-error');
+    // Test the copy error message is rendered:
+    assert
+      .dom('#test-copy-snippet + .sr-only')
+      .hasText('Failed to copy to clipboard');
     await wait(2000); // wait for the status to revert to "idle" automatically
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
   });

--- a/showcase/tests/integration/components/hds/copy/snippet/index-test.gts
+++ b/showcase/tests/integration/components/hds/copy/snippet/index-test.gts
@@ -47,6 +47,31 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
     assert.dom('#test-copy-snippet').hasAria('label', 'copy this aria label');
   });
 
+  // @ariaMessageText ARGUMENT
+
+  test('it should set a custom success message in the aria-live region if passed', async function (assert) {
+    await render(
+      <template>
+        <HdsCopySnippet
+          id="test-copy-snippet"
+          @textToCopy="someSecretThingGoesHere"
+          @ariaMessageText="Custom success message"
+        />
+      </template>,
+    );
+    assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
+    // Test the copy success message is not rendered before the button is clicked:
+    assert
+      .dom('#test-copy-snippet + .sr-only')
+      .doesNotContainText('Custom success message');
+
+    await click('button#test-copy-snippet');
+    // Test the copy success message is rendered after the button is clicked:
+    assert
+      .dom('#test-copy-snippet + .sr-only')
+      .hasText('Custom success message');
+  });
+
   // VARIANTS
 
   test('it should render the correct default component variation: primary color, idle status', async function (assert) {
@@ -130,11 +155,18 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
       </template>,
     );
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
+    // Test the copy success message is not rendered before the button is clicked:
+    assert
+      .dom('#test-copy-snippet + .sr-only')
+      .doesNotContainText('Copied to clipboard');
+
     await click('button#test-copy-snippet');
     assert.true(context.success);
     assert
       .dom('#test-copy-snippet')
       .hasClass('hds-copy-snippet--status-success');
+    // Test the copy success message is rendered after the button is clicked:
+    assert.dom('#test-copy-snippet + .sr-only').hasText('Copied to clipboard');
   });
 
   test('it should update the status back to idle after success', async function (assert) {

--- a/showcase/tests/integration/components/hds/copy/snippet/index-test.gts
+++ b/showcase/tests/integration/components/hds/copy/snippet/index-test.gts
@@ -49,6 +49,26 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
 
   // @ariaMessageText ARGUMENT
 
+  test('it should set a default success message in the aria-live region if a custom message is not passed', async function (assert) {
+    await render(
+      <template>
+        <HdsCopySnippet
+          id="test-copy-snippet"
+          @textToCopy="someSecretThingGoesHere"
+        />
+      </template>,
+    );
+    assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
+    // Test the copy success message is not rendered before the button is clicked:
+    assert
+      .dom('#test-copy-snippet + .sr-only')
+      .doesNotContainText('Copied to clipboard');
+
+    await click('button#test-copy-snippet');
+    // Test the copy success message is rendered after the button is clicked:
+    assert.dom('#test-copy-snippet + .sr-only').hasText('Copied to clipboard');
+  });
+
   test('it should set a custom success message in the aria-live region if passed', async function (assert) {
     await render(
       <template>
@@ -155,18 +175,11 @@ module('Integration | Component | hds/copy/snippet/index', function (hooks) {
       </template>,
     );
     assert.dom('#test-copy-snippet').hasClass('hds-copy-snippet--status-idle');
-    // Test the copy success message is not rendered before the button is clicked:
-    assert
-      .dom('#test-copy-snippet + .sr-only')
-      .doesNotContainText('Copied to clipboard');
-
     await click('button#test-copy-snippet');
     assert.true(context.success);
     assert
       .dom('#test-copy-snippet')
       .hasClass('hds-copy-snippet--status-success');
-    // Test the copy success message is rendered after the button is clicked:
-    assert.dom('#test-copy-snippet + .sr-only').hasText('Copied to clipboard');
   });
 
   test('it should update the status back to idle after success', async function (assert) {


### PR DESCRIPTION
**Associated Web docs update**s: https://github.com/hashicorp/design-system/pull/3892

---

### :pushpin: Summary

If merged, this PR:

* Adds an `ariaMessageText` argument to the `CopySnippet` used to announce a success message to screen reader users when content is copied.
* Adds error message handeling to both the `CopySnippet` & `CopyButton` to handle the case if copy to clipboard fails

**Note**: Use VoiceOver utility to test. Safari has the best support.

#### To test:

* Open test page in browser: coming up...
* Toggle VoiceOver on/off = Command + F5
* Tab to a `CodeSnippet` example in the Showcase page.
* After tabbing to and focusing a `CopySnippet`, press `return` key to activate it.

**Expected result**: VoiceOver should announce "Copied to clipboard" to let you know the content was copied. (Compare to prod version in which there is no success announcement.)

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-6294](https://hashicorp.atlassian.net/browse/HDS-6294)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6294]: https://hashicorp.atlassian.net/browse/HDS-6294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ