### PR TITLE
Update changeset file from `minor` to `patch`

### DIFF
--- a/.changeset/twelve-bottles-rhyme.md
+++ b/.changeset/twelve-bottles-rhyme.md
@@ -1,5 +1,5 @@
 ---
-"@hashicorp/design-system-components": minor
+"@hashicorp/design-system-components": patch
 ---
 
 <!-- START components/app-footer -->


### PR DESCRIPTION
### :pushpin: Summary

In https://github.com/hashicorp/design-system/pull/3856 the changeset semversion was set to `minor`. After discussion within the HDS Engineering sync, we have agreed that these changes are not introducing new functionalities, so they should be considered a `patch`.

***

### :eyes: Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>