### PR TITLE
`CodeBlock` -  Translate height toggle button strings (HDS-6304)

### DIFF
--- a/.changeset/lemon-tires-do.md
+++ b/.changeset/lemon-tires-do.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`CodeBlock` - Translatd strings for height toggle button text

--- a/.changeset/lemon-tires-do.md
+++ b/.changeset/lemon-tires-do.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/code-block -->
-`CodeBlock` - Translatd strings for height toggle button text
+`CodeBlock` - Translated strings for height toggle button text
 <!-- END -->

--- a/.changeset/lemon-tires-do.md
+++ b/.changeset/lemon-tires-do.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
+<!-- START components/code-block -->
 `CodeBlock` - Translatd strings for height toggle button text
+<!-- END -->

--- a/packages/components/src/components/hds/code-block/index.gts
+++ b/packages/components/src/components/hds/code-block/index.gts
@@ -17,6 +17,7 @@ import style from 'ember-style-modifier';
 
 import type { SafeString } from '@ember/template';
 import type { WithBoundArgs } from '@glint/template';
+import hdsT from '../../../helpers/hds-t.ts';
 
 import { HdsCodeBlockLanguageValues } from './types.ts';
 import HdsCodeBlockCopyButton from './copy-button.gts';
@@ -396,7 +397,17 @@ export default class HdsCodeBlock extends Component<HdsCodeBlockSignature> {
         <div class="hds-code-block__overlay-footer">
           <HdsButton
             class="hds-code-block__height-toggle-button"
-            @text={{if this._isExpanded "Show less code" "Show more code"}}
+            @text={{if
+              this._isExpanded
+              (hdsT
+                "hds.components.code-block.height-toggle-button.show-less"
+                default="Show less code"
+              )
+              (hdsT
+                "hds.components.code-block.height-toggle-button.show-more"
+                default="Show more code"
+              )
+            }}
             @color="secondary"
             @icon={{if this._isExpanded "unfold-close" "unfold-open"}}
             @size="small"

--- a/packages/components/translations/hds/components/code-block/en-us.yaml
+++ b/packages/components/translations/hds/components/code-block/en-us.yaml
@@ -1,0 +1,3 @@
+height-toggle-button:
+  show-more: Show more code
+  show-less: Show less code

--- a/packages/components/translations/hds/components/code-block/height-toggle-button/en-us.yaml
+++ b/packages/components/translations/hds/components/code-block/height-toggle-button/en-us.yaml
@@ -1,2 +1,0 @@
-show-more: Show more code
-show-less: Show less code

--- a/packages/components/translations/hds/components/code-block/height-toggle-button/en-us.yaml
+++ b/packages/components/translations/hds/components/code-block/height-toggle-button/en-us.yaml
@@ -1,0 +1,2 @@
+show-more: Show more code
+show-less: Show less code


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR translates previously hard-coded strings in the `CodeBlock` height toggle button.

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-6304](https://hashicorp.atlassian.net/browse/HDS-6304)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6304]: https://hashicorp.atlassian.net/browse/HDS-6304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ