### PR TITLE
SECVULN-45592: Override qs to remediate code scanning alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
       "path-to-regexp@0": "0.1.13",
       "path-to-regexp@8": "8.4.2",
       "picomatch": "4.0.4",
-      "qs": "6.14.1",
+      "qs": "6.15.2",
       "serialize-javascript": "7.0.5",
       "socks": "2.8.9",
       "socket.io-parser": "4.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ overrides:
   path-to-regexp@0: 0.1.13
   path-to-regexp@8: 8.4.2
   picomatch: 4.0.4
-  qs: 6.14.1
+  qs: 6.15.2
   serialize-javascript: 7.0.5
   socks: 2.8.9
   socket.io-parser: 4.2.6
@@ -10157,8 +10157,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   querystringify@2.2.0:
@@ -17289,7 +17289,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.2
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -21072,7 +21072,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -24713,7 +24713,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.14.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -26346,7 +26346,7 @@ snapshots:
       faye-websocket: 0.11.4
       livereload-js: 3.4.1
       object-assign: 4.1.1
-      qs: 6.14.1
+      qs: 6.15.2
     transitivePeerDependencies:
       - supports-color
 
@@ -26778,7 +26778,7 @@ snapshots:
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
-      qs: 6.14.1
+      qs: 6.15.2
 
   use@3.1.1: {}
 


### PR DESCRIPTION
## Summary

Upgrade the repo-wide `qs` override from `6.14.1` to `6.15.2` so the lockfile no longer resolves the version flagged by SECVULN-45592 / GHSA-q8mj-m7cp-5q26.

## How to review

1. Check `package.json` to confirm the root `pnpm.overrides.qs` entry moved to `6.15.2`.
2. Check `pnpm-lock.yaml` to confirm the override and all resolved `qs` entries now point to `6.15.2`.
3. Review the validation notes below for the lockfile-only verification.

## File-by-file review notes

- `package.json` — bumps the root `pnpm.overrides.qs` pin from `6.14.1` to `6.15.2`.
- `pnpm-lock.yaml` — refreshes the lockfile entries and snapshots so transitive consumers resolve `qs@6.15.2` instead of `6.14.1`.

## Behavior to verify

- The workspace resolves `qs@6.15.2` or later everywhere.
- `pnpm-lock.yaml` no longer contains `qs@6.14.1`.
- No runtime or API behavior changes are expected beyond the patched transitive dependency.

## Validation run

- `pnpm install --lockfile-only --frozen-lockfile`
- Verified `pnpm-lock.yaml` contains no `6.14.1` entries
- Verified `pnpm-lock.yaml` contains `qs@6.15.2`

## Risks / edge cases

- This remains a manual root override, so future `qs` security bumps will still need explicit maintenance.
- Validation here was limited to lockfile/dependency resolution for this dependency-only change.

## README / docs updates

- No docs updates were needed because this is an internal security dependency override and lockfile refresh with no user-facing API change.

## Jira
- [SECVULN-45592](https://hashicorp.atlassian.net/browse/SECVULN-45592)

[SECVULN-45592]: https://hashicorp.atlassian.net/browse/SECVULN-45592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ