### PR TITLE
SECVULN-45694: Override tmp to remediate related findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
       "socks": "2.8.9",
       "socket.io-parser": "4.2.6",
       "systeminformation": "5.31.6",
+      "tmp": "0.2.6",
       "undici": "6.24.0",
       "underscore": "1.13.8",
       "yaml@1": "1.10.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   socks: 2.8.9
   socket.io-parser: 4.2.6
   systeminformation: 5.31.6
+  tmp: 0.2.6
   undici: 6.24.0
   underscore: 1.13.8
   yaml@1: 1.10.3
@@ -11361,20 +11362,8 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tmp@0.0.28:
-    resolution: {integrity: sha512-c2mmfiBmND6SOVxzogm1oda0OJ1HZVIk/5n26N59dDTh80MUeavpiCls4PGAdkX1PFkKokLpcf7prSjCeXLsJg==}
-    engines: {node: '>=0.4.0'}
-
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
-
-  tmp@0.1.0:
-    resolution: {integrity: sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==}
-    engines: {node: '>=6'}
-
-  tmp@0.2.3:
-    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -17805,7 +17794,7 @@ snapshots:
       resolve-path: 1.4.0
       rimraf: 3.0.2
       sane: 4.1.0
-      tmp: 0.0.33
+      tmp: 0.2.6
       tree-sync: 2.1.0
       underscore.string: 3.3.6
       watch-detector: 1.0.2
@@ -17926,7 +17915,7 @@ snapshots:
 
   can-symlink@1.0.0:
     dependencies:
-      tmp: 0.0.28
+      tmp: 0.2.6
 
   caniuse-api@3.0.0:
     dependencies:
@@ -20415,7 +20404,7 @@ snapshots:
       globby: 11.1.0
       ora: 5.4.1
       slash: 3.0.0
-      tmp: 0.2.3
+      tmp: 0.2.6
       workerpool: 6.5.1
     transitivePeerDependencies:
       - supports-color
@@ -21102,7 +21091,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.6
 
   extglob@2.0.4:
     dependencies:
@@ -21386,12 +21375,12 @@ snapshots:
   fixturify-project@1.10.0:
     dependencies:
       fixturify: 1.3.0
-      tmp: 0.0.33
+      tmp: 0.2.6
 
   fixturify-project@2.1.1:
     dependencies:
       fixturify: 2.1.1
-      tmp: 0.0.33
+      tmp: 0.2.6
       type-fest: 0.11.0
 
   fixturify@1.3.0:
@@ -26255,7 +26244,7 @@ snapshots:
       spawn-args: 0.2.0
       styled_string: 0.0.1
       tap-parser: 7.0.0
-      tmp: 0.0.33
+      tmp: 0.2.6
     transitivePeerDependencies:
       - arc-templates
       - atpl
@@ -26367,19 +26356,7 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
-  tmp@0.0.28:
-    dependencies:
-      os-tmpdir: 1.0.2
-
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
-
-  tmp@0.1.0:
-    dependencies:
-      rimraf: 2.7.1
-
-  tmp@0.2.3: {}
+  tmp@0.2.6: {}
 
   tmpl@1.0.5: {}
 
@@ -26953,7 +26930,7 @@ snapshots:
     dependencies:
       heimdalljs-logger: 0.1.10
       silent-error: 1.1.1
-      tmp: 0.1.0
+      tmp: 0.2.6
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Override `tmp` to `0.2.6` at the repo root and refresh the lockfile so the vulnerable `tmp` resolutions flagged by SECVULN-45694, SECVULN-45695, SECVULN-45696, and SECVULN-45697 are removed from the dependency graph.

## How to review

1. Review `package.json` for the new root `pnpm.overrides.tmp` pin.
2. Review `pnpm-lock.yaml` to confirm the vulnerable `tmp` entries (`0.0.28`, `0.0.33`, `0.1.0`, `0.2.3`) were collapsed to `0.2.6`.
3. Check the validation notes below for the lockfile-only install and targeted lockfile searches.

## File-by-file review notes

- `package.json` — adds a root pnpm override forcing `tmp` to `0.2.6`.
- `pnpm-lock.yaml` — updates the override block, removes vulnerable `tmp` package entries, and repoints dependent snapshots to `tmp@0.2.6`.

## Behavior to verify

- The workspace lockfile no longer resolves `tmp@0.0.28`, `tmp@0.0.33`, `tmp@0.1.0`, or `tmp@0.2.3`.
- The lockfile now resolves `tmp@0.2.6` for the previously affected dependency paths.

## Validation run

- `npm exec --yes pnpm@10.11.0 -- install --lockfile-only --ignore-scripts`
- `rg -n "tmp@(0\.0\.28|0\.0\.33|0\.1\.0|0\.2\.3)" pnpm-lock.yaml`
- `rg -n "tmp@0\.2\.6" pnpm-lock.yaml`
- Reviewer approval on the scoped diff

## Risks / edge cases

- This fix relies on a root override for a transitive tooling dependency, so future dependency refreshes should retain the override until upstream trees naturally converge on a safe `tmp` version.
- No broader runtime smoke tests were run because the change is limited to dependency metadata and lockfile resolution.

## README / docs updates

- No docs updates were needed because this change only remediates transitive dependency resolution.

## Jira
- [SECVULN-45694](https://hashicorp.atlassian.net/browse/SECVULN-45694)
- [SECVULN-45695](https://hashicorp.atlassian.net/browse/SECVULN-45695)
- [SECVULN-45696](https://hashicorp.atlassian.net/browse/SECVULN-45696)
- [SECVULN-45697](https://hashicorp.atlassian.net/browse/SECVULN-45697)

[SECVULN-45694]: https://hashicorp.atlassian.net/browse/SECVULN-45694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ