### PR TITLE
`StepperList` - Hide description and content when conditionally empty

### DIFF
--- a/.changeset/common-parrots-count.md
+++ b/.changeset/common-parrots-count.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/stepper/list -->
+`StepperList` - Fixed description and content contextual blocks to be hidden if conditionally empty
+<!-- END -->

--- a/packages/components/src/components/hds/stepper/list/step.gts
+++ b/packages/components/src/components/hds/stepper/list/step.gts
@@ -138,6 +138,7 @@ export default class HdsStepperListStep extends Component<HdsStepperListStepSign
           {{yield to="title"}}
           <span class="sr-only">{{this.statusSrOnlyText}}</span>
         </HdsTextBody>
+        {{! we use :empty in CSS so we have to add squishes here to avoid whitespaces }}
         {{#if (has-block "description")}}
           <HdsTextBody
             class="hds-stepper-list__step-description"
@@ -146,12 +147,12 @@ export default class HdsStepperListStep extends Component<HdsStepperListStepSign
             @weight="regular"
             @color="primary"
           >
-            {{yield to="description"}}
+            {{~yield to="description"~}}
           </HdsTextBody>
         {{/if}}
         {{#if (has-block "content")}}
           <div class="hds-stepper-list__step-content">
-            {{yield to="content"}}
+            {{~yield to="content"~}}
           </div>
         {{/if}}
       </div>

--- a/packages/components/src/styles/components/stepper/list.scss
+++ b/packages/components/src/styles/components/stepper/list.scss
@@ -68,10 +68,18 @@ $hds-stepper-list-gap-spacing: 16px;
 
 .hds-stepper-list__step-description {
   margin-top: 4px;
+
+  &:empty {
+    display: none;
+  }
 }
 
 .hds-stepper-list__step-content {
   margin-top: 8px;
+
+  &:empty {
+    display: none;
+  }
 }
 
 // STATUSES

--- a/showcase/app/components/page-components/stepper/list/code-fragments/with-default-implementation.gts
+++ b/showcase/app/components/page-components/stepper/list/code-fragments/with-default-implementation.gts
@@ -5,6 +5,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
+import { eq } from 'ember-truth-helpers';
 import style from 'ember-style-modifier';
 import type Owner from '@ember/owner';
 
@@ -22,7 +23,7 @@ import type { HdsStepperListSignature } from '@hashicorp/design-system-component
 type ListData = {
   title: string;
   status: HdsStepperStatuses;
-  description: string;
+  description?: string;
 };
 
 const STEP_DATA: ListData[] = [
@@ -34,7 +35,6 @@ const STEP_DATA: ListData[] = [
   {
     title: 'Step 2',
     status: 'progress',
-    description: 'Description for Step 2',
   },
   {
     title: 'Step 3',
@@ -127,7 +127,9 @@ export default class CodeFragmentWithDefaultImplementationComponents extends Com
           <:title>{{step.title}}</:title>
           <:description>{{step.description}}</:description>
           <:content>
-            <ShwPlaceholder @text="Generic content" @height="20" />
+            {{~#unless (eq step.title "Step 2")}}
+              <ShwPlaceholder @text="Generic content" @height="20" />
+            {{/unless~}}
           </:content>
         </S.Step>
       {{/each}}

--- a/showcase/tests/integration/components/hds/stepper/list-step-test.gts
+++ b/showcase/tests/integration/components/hds/stepper/list-step-test.gts
@@ -153,6 +153,17 @@ module('Integration | Component | hds/stepper/list/step', function (hooks) {
     assert.dom('.hds-stepper-list__step-description').doesNotExist();
   });
 
+  test('it hides the description when the description contextual component block is empty', async function (assert) {
+    await render(
+      <template>
+        <HdsStepperListStep>
+          <:description></:description>
+        </HdsStepperListStep>
+      </template>,
+    );
+    assert.dom('.hds-stepper-list__step-description').isNotVisible();
+  });
+
   test('it renders the description when the description contextual component block is used', async function (assert) {
     await render(
       <template>
@@ -170,6 +181,17 @@ module('Integration | Component | hds/stepper/list/step', function (hooks) {
   test('it does not render the content when the content contextual component block is not used', async function (assert) {
     await render(<template><HdsStepperListStep /></template>);
     assert.dom('.hds-stepper-list__step-content').doesNotExist();
+  });
+
+  test('it hides the content when the content contextual component block is empty', async function (assert) {
+    await render(
+      <template>
+        <HdsStepperListStep>
+          <:content></:content>
+        </HdsStepperListStep>
+      </template>,
+    );
+    assert.dom('.hds-stepper-list__step-content').isNotVisible();
   });
 
   test('it renders the content when the content contextual component block is used', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the `StepperList` to hide the `description` and `content` contextual blocks when conditionally empty in a consumer's implementation.

### :hammer_and_wrench: Detailed description

There is an existing issue in the `StepperList` component when the `description` and `content` blocks are used contextually. 

```
<Hds::Stepper::List
  @titleTag="h3"
  @ariaLabel="Example"
  as |S|
>
  <S.Step>
    <:title>Step 1</:title>
    <:description>
      {{#if this.showDescription}}
        <span>Description</span>
      {{/if}}
    </:description>
    <:content>
      {{#if this.showContent}}
        <span>Content</span>
      {{/if}}
    </:content>
  </S.Step>
</Hds::Stepper::List>
```

When used in this fashion the elements for those blocks are still present in the template and bringing their `margin` values because they are only rendered based on `has-block`.

<img width="300" alt="Screenshot 2026-06-01 at 10 32 36 AM" src="https://github.com/user-attachments/assets/bb344f65-9c56-4a63-9cd7-6f89a62ca4d0" />

To fix the issue styling has been added for the CSS selector `:empty`. When `:empty`, `display: none` is set. This is a pattern following in other components in the repo such as the `CodeBlock` header. 

The only caveat to this approach is `:empty` does not get triggered if any whitespace is present. This is why `~` have been added in the template. It also means consumers will have to add these as well.

```
<Hds::Stepper::List
  @titleTag="h3"
  @ariaLabel="Example"
  as |S|
>
  <S.Step>
    <:title>Step 1</:title>
    <:description>
      {{~#if this.showDescription}}
        <span>Description</span>
      {{/if~}}
    </:description>
    <:content>
      {{~#if this.showContent}}
        <span>Content</span>
      {{/if~}}
    </:content>
  </S.Step>
</Hds::Stepper::List>
```

### :camera_flash: Screenshots

**Before**
<img width="300" alt="Screenshot 2026-06-01 at 10 32 36 AM" src="https://github.com/user-attachments/assets/41141d0c-8421-4b71-b2c2-f89fa541c347" />

**After**
<img width="300"  alt="Screenshot 2026-06-01 at 10 32 21 AM" src="https://github.com/user-attachments/assets/466d192b-6c9f-4a50-bef4-f28585159b3d" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6309](https://hashicorp.atlassian.net/browse/HDS-6309)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6309]: https://hashicorp.atlassian.net/browse/HDS-6309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ