### PR TITLE
SECVULN-45697: Override tmp to remediate related findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
       "socks": "2.8.9",
       "socket.io-parser": "4.2.6",
       "systeminformation": "5.31.6",
+      "tmp": "0.2.6",
       "undici": "6.24.0",
       "underscore": "1.13.8",
       "yaml@1": "1.10.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   socks: 2.8.9
   socket.io-parser: 4.2.6
   systeminformation: 5.31.6
+  tmp: 0.2.6
   undici: 6.24.0
   underscore: 1.13.8
   yaml@1: 1.10.3
@@ -11355,20 +11356,8 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tmp@0.0.28:
-    resolution: {integrity: sha512-c2mmfiBmND6SOVxzogm1oda0OJ1HZVIk/5n26N59dDTh80MUeavpiCls4PGAdkX1PFkKokLpcf7prSjCeXLsJg==}
-    engines: {node: '>=0.4.0'}
-
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
-
-  tmp@0.1.0:
-    resolution: {integrity: sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==}
-    engines: {node: '>=6'}
-
-  tmp@0.2.3:
-    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -17799,7 +17788,7 @@ snapshots:
       resolve-path: 1.4.0
       rimraf: 3.0.2
       sane: 4.1.0
-      tmp: 0.0.33
+      tmp: 0.2.6
       tree-sync: 2.1.0
       underscore.string: 3.3.6
       watch-detector: 1.0.2
@@ -17920,7 +17909,7 @@ snapshots:
 
   can-symlink@1.0.0:
     dependencies:
-      tmp: 0.0.28
+      tmp: 0.2.6
 
   caniuse-api@3.0.0:
     dependencies:
@@ -20409,7 +20398,7 @@ snapshots:
       globby: 11.1.0
       ora: 5.4.1
       slash: 3.0.0
-      tmp: 0.2.3
+      tmp: 0.2.6
       workerpool: 6.5.1
     transitivePeerDependencies:
       - supports-color
@@ -21070,7 +21059,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.6
 
   extglob@2.0.4:
     dependencies:
@@ -21354,12 +21343,12 @@ snapshots:
   fixturify-project@1.10.0:
     dependencies:
       fixturify: 1.3.0
-      tmp: 0.0.33
+      tmp: 0.2.6
 
   fixturify-project@2.1.1:
     dependencies:
       fixturify: 2.1.1
-      tmp: 0.0.33
+      tmp: 0.2.6
       type-fest: 0.11.0
 
   fixturify@1.3.0:
@@ -26221,7 +26210,7 @@ snapshots:
       spawn-args: 0.2.0
       styled_string: 0.0.1
       tap-parser: 7.0.0
-      tmp: 0.0.33
+      tmp: 0.2.6
     transitivePeerDependencies:
       - arc-templates
       - atpl
@@ -26333,19 +26322,7 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
-  tmp@0.0.28:
-    dependencies:
-      os-tmpdir: 1.0.2
-
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
-
-  tmp@0.1.0:
-    dependencies:
-      rimraf: 2.7.1
-
-  tmp@0.2.3: {}
+  tmp@0.2.6: {}
 
   tmpl@1.0.5: {}
 
@@ -26919,7 +26896,7 @@ snapshots:
     dependencies:
       heimdalljs-logger: 0.1.10
       silent-error: 1.1.1
-      tmp: 0.1.0
+      tmp: 0.2.6
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Add a root `pnpm` override for `tmp` and update the lockfile so the repo no longer resolves the vulnerable `tmp` versions flagged by SECVULN-45697, SECVULN-45696, SECVULN-45695, and SECVULN-45694.

## How to review

1. Review `package.json` to confirm the new root-level `tmp: 0.2.6` override.
2. Review `pnpm-lock.yaml` to confirm the vulnerable `tmp` entries (`0.0.28`, `0.0.33`, `0.1.0`, `0.2.3`) were consolidated to `0.2.6`.
3. Verify the lockfile snapshot references that previously pointed at old `tmp` versions now point at `0.2.6`.

## File-by-file review notes

- `package.json` — adds a root `pnpm.overrides` entry pinning `tmp` to `0.2.6`.
- `pnpm-lock.yaml` — replaces vulnerable `tmp` package entries with `tmp@0.2.6` and repoints dependent snapshots to that version.

## Behavior to verify

- The dependency graph resolves `tmp` to `0.2.6` instead of the vulnerable versions flagged by code scanning.
- No unrelated dependency upgrades were introduced as part of this remediation.

## Validation run

- Verified the tracked diff is limited to `package.json` and `pnpm-lock.yaml`.
- Searched `package.json` and `pnpm-lock.yaml` to confirm `tmp: 0.2.6` / `tmp@0.2.6` is present and the previously flagged versions are absent.
- Full install/CI validation was not run in this workflow.

## Risks / edge cases

- This change relies on a root override, so older transitive consumers now resolve `tmp` to `0.2.6`; that is intentionally narrow, but not execution-validated here.
- If any consumer is unexpectedly incompatible with `tmp@0.2.6`, follow-up validation may expose it.

## README / docs updates

- No README or docs updates were needed because this is a lockfile/package-manager security remediation.

## Jira
- [SECVULN-45697](https://hashicorp.atlassian.net/browse/SECVULN-45697)
- [SECVULN-45696](https://hashicorp.atlassian.net/browse/SECVULN-45696)
- [SECVULN-45695](https://hashicorp.atlassian.net/browse/SECVULN-45695)
- [SECVULN-45694](https://hashicorp.atlassian.net/browse/SECVULN-45694)

[SECVULN-45697]: https://hashicorp.atlassian.net/browse/SECVULN-45697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ