### PR TITLE
Clarify supported TextInput types in docs

### DIFF
--- a/website/docs/components/form/text-input/partials/guidelines/guidelines.md
+++ b/website/docs/components/form/text-input/partials/guidelines/guidelines.md
@@ -11,7 +11,7 @@
 
 ## Types of text inputs
 
-Text Input accepts [all native HTML types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types), but we offer built in styling for the following:
+Text Input accepts [a subset of types](https://helios.hashicorp.design/components/form/text-input?tab=code#component-api) and offer built in styling for the following:
 
 ### Text
 


### PR DESCRIPTION
### :pushpin: Summary

Update guidelines to state that TextInput accepts a subset of HTML input types (not all native types) and replace the MDN link with the component API reference. This clarifies which types receive built-in styling.

### :link: External links

<!-- Issues, RFC, etc. -->
[Slack thread](https://ibm-hashicorp.slack.com/archives/C09KTVB7GSX/p1780494705688409)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.
