### PR TITLE
test(website): add key-value input acceptance test + update changelog…

### DIFF
--- a/.changeset/changelog-hds.cjs.js
+++ b/.changeset/changelog-hds.cjs.js
@@ -31,6 +31,7 @@ const SKIP_USERS = [
   'shleewhite',
   'LilithJames-HDS',
   'dchyun',
+  'pkj-web',
   // bots
   'apps/dependabot',
   'apps/hashicorp-copywrite',

--- a/website/tests/acceptance/components/form/key-value-inputs-test.js
+++ b/website/tests/acceptance/components/form/key-value-inputs-test.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'website/tests/helpers';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+
+module('Acceptance | components/form/key-value-inputs', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /components/form/key-value-inputs', async function (assert) {
+    await visit('/components/form/key-value-inputs');
+
+    assert.strictEqual(currentURL(), '/components/form/key-value-inputs');
+  });
+
+  test('Components/form/key-value-inputs page passes automated a11y checks', async function (assert) {
+    await visit('/components/form/key-value-inputs');
+    await a11yAudit();
+    assert.ok(true, 'a11y automation audit passed');
+  });
+});


### PR DESCRIPTION
### :pushpin: Summary
Adds an acceptance test for the key-value input component and updates changelog configuration.

This ensures the component route renders correctly and passes basic accessibility checks.

### Jira
[HDS-6186](https://hashicorp.atlassian.net/browse/HDS-6186)

---

### :camera_flash: Screenshots

#### Key-value input page

<!-- Add your image below -->
<img width="1728" height="904" alt="Screenshot 2026-06-03 at 2 06 27 PM" src="https://github.com/user-attachments/assets/04277090-c749-4ee1-8d4e-a31d803f6ae6" />

### :hammer_and_wrench: Changes
- Added Ember acceptance test for `/components/form/key-value-inputs`
- Included basic route navigation test
- Added automated accessibility audit (`a11yAudit`)
- Updated changelog config to exclude contributor entry for `pkj-web`

---

### :test_tube: How to test

#### Automated
```bash
ember test



[HDS-6186]: https://hashicorp.atlassian.net/browse/HDS-6186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ