### PR TITLE
Resolve chrome for percy in CI as a temporary workaround

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -54,6 +54,21 @@ jobs:
       - name: Lint Components
         run: pnpm lint
         working-directory: packages/components
+      - name: Resolve Chrome for Percy (as Percy fails to do so)
+        run: |
+          set -euo pipefail
+
+          if command -v google-chrome >/dev/null 2>&1; then
+            echo "PERCY_BROWSER_EXECUTABLE=$(command -v google-chrome)" >> "$GITHUB_ENV"
+          elif command -v google-chrome-stable >/dev/null 2>&1; then
+            echo "PERCY_BROWSER_EXECUTABLE=$(command -v google-chrome-stable)" >> "$GITHUB_ENV"
+          elif command -v chromium-browser >/dev/null 2>&1; then
+            echo "PERCY_BROWSER_EXECUTABLE=$(command -v chromium-browser)" >> "$GITHUB_ENV"
+          elif command -v chromium >/dev/null 2>&1; then
+            echo "PERCY_BROWSER_EXECUTABLE=$(command -v chromium)" >> "$GITHUB_ENV"
+          else
+            echo "No system Chrome/Chromium executable found; Percy will try to download Chromium."
+          fi
       - name: Run Tests
         run: pnpm test:ember:percy
         working-directory: showcase

--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -74,6 +74,7 @@ jobs:
         working-directory: showcase
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_COMPONENTS }}
+          BROWSERSLIST_IGNORE_OLD_DATA: 1
 
   try-scenarios:
     name: ${{ matrix.try-scenario }}


### PR DESCRIPTION
### :pushpin: Summary

Adds a step to explicitly detect a system Chrome/Chromium binary and set `PERCY_BROWSER_EXECUTABLE` as a workaround so Percy doesn't fail to resolve the browser.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6346](https://hashicorp.atlassian.net/browse/HDS-6346)

***

### :eyes: Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.


[HDS-6346]: https://hashicorp.atlassian.net/browse/HDS-6346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ