### PR TITLE
[Docs] `StepperList` - Hide description and content when conditionally empty

### DIFF
--- a/website/docs/components/stepper/list/partials/code/code-snippets/stepper-list-blocks-conditional.classic.hbs
+++ b/website/docs/components/stepper/list/partials/code/code-snippets/stepper-list-blocks-conditional.classic.hbs
@@ -1,0 +1,36 @@
+<Hds::Stepper::List @ariaLabel="Additional information" as |S|>
+  <S.Step @status="complete">
+    <:title>Completed step</:title>
+    <:description>
+      {{~#if this.showBlocks~}}
+        Step description
+      {{/if~}}
+    </:description>
+  </S.Step>
+  <S.Step @status="progress">
+    <:title>Current step</:title>
+    <:description>
+      {{~#if this.showBlocks~}}
+        Step description
+      {{/if~}}
+    </:description>
+    <:content>
+      {{~#if this.showBlocks~}}
+        <Hds::Button @text="Do step action" />
+      {{/if~}}
+    </:content>
+  </S.Step>
+  <S.Step>
+    <:title>Upcoming step</:title>
+    <:description>
+      {{~#if this.showBlocks~}}
+        Step description
+      {{/if~}}
+    </:description>
+  </S.Step>
+</Hds::Stepper::List>
+<Hds::Button
+  @text={{if this.showBlocks "Hide blocks" "Show blocks"}}
+  {{on "click" this.toggleBlocks}}
+  {{style marginTop="24px"}}
+/>

--- a/website/docs/components/stepper/list/partials/code/code-snippets/stepper-list-blocks-conditional.classic.js
+++ b/website/docs/components/stepper/list/partials/code/code-snippets/stepper-list-blocks-conditional.classic.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class LocalComponent extends Component {
+  @tracked showBlocks = true;
+
+  @action
+  toggleBlocks() {
+    this.showBlocks = !this.showBlocks;
+  }
+}

--- a/website/docs/components/stepper/list/partials/code/code-snippets/stepper-list-blocks-conditional.gts
+++ b/website/docs/components/stepper/list/partials/code/code-snippets/stepper-list-blocks-conditional.gts
@@ -1,0 +1,56 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import style from 'ember-style-modifier';
+
+import {
+  HdsStepperList,
+  HdsButton,
+} from '@hashicorp/design-system-components/components';
+
+export default class LocalComponent extends Component {
+  @tracked showBlocks = true;
+
+  toggleBlocks = () => {
+    this.showBlocks = !this.showBlocks;
+  };
+
+  <template>
+    <HdsStepperList @ariaLabel="Additional information" as |S|>
+      <S.Step @status="complete">
+        <:title>Completed step</:title>
+        <:description>
+          {{~#if this.showBlocks~}}
+            Step description
+          {{/if~}}
+        </:description>
+      </S.Step>
+      <S.Step @status="progress">
+        <:title>Current step</:title>
+        <:description>
+          {{~#if this.showBlocks~}}
+            Step description
+          {{/if~}}
+        </:description>
+        <:content>
+          {{~#if this.showBlocks~}}
+            <HdsButton @text="Do step action" />
+          {{/if~}}
+        </:content>
+      </S.Step>
+      <S.Step>
+        <:title>Upcoming step</:title>
+        <:description>
+          {{~#if this.showBlocks~}}
+            Step description
+          {{/if~}}
+        </:description>
+      </S.Step>
+    </HdsStepperList>
+    <HdsButton
+      @text={{if this.showBlocks "Hide blocks" "Show blocks"}}
+      {{on "click" this.toggleBlocks}}
+      {{style marginTop="24px"}}
+    />
+  </template>
+}

--- a/website/docs/components/stepper/list/partials/code/how-to-use.md
+++ b/website/docs/components/stepper/list/partials/code/how-to-use.md
@@ -17,3 +17,9 @@ A `processing` status is used to indicate an ongoing process in the background, 
 Using the named `<:title>` block is required. Additional information for a step is added through the named blocks `<:description>` and `<:content>`.
 
 [[code-snippets/stepper-list-blocks]]
+
+#### Conditional content
+
+If you need to conditionally show the `<:description>` or `<:content>`, you must add `~` in your conditional blocks. The `<:description>` and `<:content>` elements are shown based on the CSS `:empty` selector which requires no whitespace be present. Otherwise, the HTML elements will be visible and add unintended spacing inside the component.
+
+[[code-snippets/stepper-list-blocks-conditional]]


### PR DESCRIPTION
### :pushpin: Summary

If merged, this would add a docs example to the `StepperList` for when the `<:description>` and `<:content>` blocks need to be rendered conditionally. This example was added based on the change in #3899 to inform users of adding `~` inside their conditional blocks since the hiding and showing of the blocks relies on the CSS `:empty` selector.

[Preview link](https://hds-website-6hwk5uylb-hashicorp.vercel.app/components/stepper/list?tab=code#conditional-content)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6309](https://hashicorp.atlassian.net/browse/HDS-6309)

***

### :eyes: Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6309]: https://hashicorp.atlassian.net/browse/HDS-6309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ