### PR TITLE
`Pagination`: add focus management when button becomes disabled

### DIFF
--- a/.changeset/long-shrimps-lick.md
+++ b/.changeset/long-shrimps-lick.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/pagination -->
+`Pagination` - Added keyboard focus management at the beginning and end of pagination. When an arrow button becomes disabled after clicking because a boundary has been reached, focus moves to the opposite arrow button.
+<!-- END -->

--- a/packages/components/src/components/hds/pagination/compact/index.gts
+++ b/packages/components/src/components/hds/pagination/compact/index.gts
@@ -256,6 +256,8 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
   };
 
   onPageSizeChange = (newPageSize: number): void => {
+    this._lastActivatedDirection = undefined;
+
     const { onPageSizeChange } = this.args;
 
     // invoke the callback function

--- a/packages/components/src/components/hds/pagination/compact/index.gts
+++ b/packages/components/src/components/hds/pagination/compact/index.gts
@@ -100,6 +100,7 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
   // has with the component (the state is controlled externally, eg. via query parameters)
   @tracked private _currentPageSize;
   @tracked private _isControlled;
+  @tracked private _lastActivatedDirection?: HdsPaginationDirections;
 
   showLabels = this.args.showLabels ?? true; // if the labels for the "prev/next" controls are visible
   showSizeSelector = this.args.showSizeSelector ?? false; // if the "size selector" block is visible
@@ -224,8 +225,30 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
     return routing;
   }
 
+  get shouldFocusPrevArrow() {
+    return (
+      this._lastActivatedDirection === HdsPaginationDirectionValues.Next &&
+      this.args.isDisabledNext === true &&
+      this.args.isDisabledPrev !== true
+    );
+  }
+
+  get shouldFocusNextArrow() {
+    return (
+      this._lastActivatedDirection === HdsPaginationDirectionValues.Prev &&
+      this.args.isDisabledPrev === true &&
+      this.args.isDisabledNext !== true
+    );
+  }
+
+  onFocusHandled = (): void => {
+    this._lastActivatedDirection = undefined;
+  };
+
   onPageChange = (newPage: HdsPaginationDirections): void => {
     const { onPageChange } = this.args;
+
+    this._lastActivatedDirection = newPage;
 
     if (typeof onPageChange === 'function') {
       onPageChange(newPage);
@@ -254,6 +277,8 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
           @replace={{this.routing.replace}}
           @onClick={{this.onPageChange}}
           @disabled={{@isDisabledPrev}}
+          @isFocused={{this.shouldFocusPrevArrow}}
+          @onFocusHandled={{this.onFocusHandled}}
         />
         <HdsPaginationNavArrow
           @direction="next"
@@ -265,6 +290,8 @@ export default class HdsPaginationCompact extends Component<HdsPaginationCompact
           @replace={{this.routing.replace}}
           @onClick={{this.onPageChange}}
           @disabled={{@isDisabledNext}}
+          @isFocused={{this.shouldFocusNextArrow}}
+          @onFocusHandled={{this.onFocusHandled}}
         />
       </nav>
 

--- a/packages/components/src/components/hds/pagination/nav/arrow.gts
+++ b/packages/components/src/components/hds/pagination/nav/arrow.gts
@@ -6,6 +6,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
+import { modifier } from 'ember-modifier';
 
 import type HdsIntlService from '../../../../services/hds-intl';
 
@@ -33,6 +34,8 @@ interface HdsPaginationControlArrowArgs {
   disabled?: boolean;
   showLabel?: boolean;
   onClick?: (direction: HdsPaginationDirections) => void;
+  isFocused?: boolean;
+  onFocusHandled?: () => void;
 }
 
 export interface HdsPaginationControlArrowSignature {
@@ -47,6 +50,24 @@ export const DIRECTIONS: HdsPaginationDirections[] = [
 
 export default class HdsPaginationControlArrow extends Component<HdsPaginationControlArrowSignature> {
   @service declare readonly hdsIntl: HdsIntlService;
+
+  focusWhen = modifier<{
+    Args: {
+      Positional: [boolean | undefined, (() => void) | undefined];
+    };
+    Element: HTMLElement;
+  }>((element, [isFocused, onFocusHandled]) => {
+    if (isFocused) {
+      element.focus();
+
+      if (typeof onFocusHandled === 'function') {
+        requestAnimationFrame(() => {
+          onFocusHandled();
+        });
+      }
+    }
+  });
+
   get content(): HdsPaginationControlArrowContent {
     const { direction } = this.args;
 
@@ -142,6 +163,7 @@ export default class HdsPaginationControlArrow extends Component<HdsPaginationCo
         @models={{@models}}
         @replace={{@replace}}
         {{on "click" this.onClick}}
+        {{this.focusWhen @isFocused @onFocusHandled}}
         aria-label={{this.content.ariaLabel}}
         ...attributes
       >

--- a/packages/components/src/components/hds/pagination/nav/arrow.gts
+++ b/packages/components/src/components/hds/pagination/nav/arrow.gts
@@ -61,9 +61,13 @@ export default class HdsPaginationControlArrow extends Component<HdsPaginationCo
       element.focus();
 
       if (typeof onFocusHandled === 'function') {
-        requestAnimationFrame(() => {
+        const onFocusHandledFrame = requestAnimationFrame(() => {
           onFocusHandled();
         });
+
+        return () => {
+          cancelAnimationFrame(onFocusHandledFrame);
+        };
       }
     }
   });

--- a/packages/components/src/components/hds/pagination/numbered/index.gts
+++ b/packages/components/src/components/hds/pagination/numbered/index.gts
@@ -22,6 +22,7 @@ import HdsPaginationSizeSelector from '../size-selector/index.gts';
 import type HdsIntlService from '../../../../services/hds-intl.ts';
 
 import type {
+  HdsPaginationDirections,
   HdsPaginationPage,
   HdsPaginationRoutingProps,
   HdsPaginationElliptizedPageArray,

--- a/packages/components/src/components/hds/pagination/numbered/index.gts
+++ b/packages/components/src/components/hds/pagination/numbered/index.gts
@@ -462,6 +462,8 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
   };
 
   onPageSizeChange = (newPageSize: number) => {
+    this._lastActivatedDirection = undefined;
+
     const { onPageSizeChange } = this.args;
 
     if (!this._isControlled) {

--- a/packages/components/src/components/hds/pagination/numbered/index.gts
+++ b/packages/components/src/components/hds/pagination/numbered/index.gts
@@ -187,6 +187,7 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
   @tracked private _currentPage;
   @tracked private _currentPageSize;
   @tracked private _isControlled;
+  @tracked private _lastActivatedDirection?: HdsPaginationDirections;
 
   showInfo = this.args.showInfo ?? true; // if the "info" block is visible
   showLabels = this.args.showLabels ?? false; // if the labels for the "prev/next" controls are visible
@@ -404,7 +405,29 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
     return this.currentPage === this.totalPages;
   }
 
+  get shouldFocusPrevArrow() {
+    return (
+      this._lastActivatedDirection === HdsPaginationDirectionValues.Next &&
+      this.isDisabledNext &&
+      !this.isDisabledPrev
+    );
+  }
+
+  get shouldFocusNextArrow() {
+    return (
+      this._lastActivatedDirection === HdsPaginationDirectionValues.Prev &&
+      this.isDisabledPrev &&
+      !this.isDisabledNext
+    );
+  }
+
+  onFocusHandled = (): void => {
+    this._lastActivatedDirection = undefined;
+  };
+
   onPageChange = (page: HdsPaginationPage) => {
+    this._lastActivatedDirection = undefined;
+
     let gotoPageNumber;
     if (page === HdsPaginationDirectionValues.Prev && this.currentPage > 1) {
       gotoPageNumber = this.currentPage - 1;
@@ -426,6 +449,13 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
 
       if (typeof onPageChange === 'function') {
         onPageChange(this.currentPage, this.currentPageSize);
+      }
+
+      if (
+        page === HdsPaginationDirectionValues.Prev ||
+        page === HdsPaginationDirectionValues.Next
+      ) {
+        this._lastActivatedDirection = page;
       }
     }
   };
@@ -481,6 +511,8 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
           @replace={{this.routing.replace}}
           @onClick={{this.onPageChange}}
           @disabled={{this.isDisabledPrev}}
+          @isFocused={{this.shouldFocusPrevArrow}}
+          @onFocusHandled={{this.onFocusHandled}}
         />
         {{#if this.showPageNumbers}}
           <ul class="hds-pagination-nav__page-list">
@@ -514,6 +546,8 @@ export default class HdsPaginationNumbered extends Component<HdsPaginationNumber
           @replace={{this.routing.replace}}
           @onClick={{this.onPageChange}}
           @disabled={{this.isDisabledNext}}
+          @isFocused={{this.shouldFocusNextArrow}}
+          @onFocusHandled={{this.onFocusHandled}}
         />
       </nav>
 

--- a/showcase/tests/integration/components/hds/pagination/compact-test.gts
+++ b/showcase/tests/integration/components/hds/pagination/compact-test.gts
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import {
   click,
   focus,
+  select,
   render,
   resetOnerror,
   setupOnerror,
@@ -225,6 +226,56 @@ module('Integration | Component | hds/pagination/compact', function (hooks) {
 
     assert.dom('.hds-pagination-nav__arrow--direction-next').isDisabled();
     assert.dom('.hds-pagination-nav__arrow--direction-prev').isFocused();
+  });
+
+  test('changing page size clears arrow focus intent and does not move focus to the opposite arrow', async function (assert) {
+    const context = new TrackedObject({
+      isDisabledPrev: false,
+      isDisabledNext: false,
+      currentPageSize: 10,
+    });
+
+    const onPageChange = (direction: HdsPaginationDirections) => {
+      if (direction === 'prev') {
+        context.isDisabledPrev = true;
+        context.isDisabledNext = false;
+      } else {
+        context.isDisabledPrev = false;
+        context.isDisabledNext = true;
+      }
+    };
+
+    const onPageSizeChange = (pageSize: number) => {
+      context.currentPageSize = pageSize;
+      context.isDisabledPrev = true;
+      context.isDisabledNext = false;
+    };
+
+    await render(
+      <template>
+        <HdsPaginationCompact
+          @showSizeSelector={{true}}
+          @isDisabledPrev={{context.isDisabledPrev}}
+          @isDisabledNext={{context.isDisabledNext}}
+          @currentPageSize={{context.currentPageSize}}
+          @onPageChange={{onPageChange}}
+          @onPageSizeChange={{onPageSizeChange}}
+        />
+      </template>,
+    );
+
+    await click('.hds-pagination-nav__arrow--direction-prev');
+    await focus('.hds-pagination-size-selector select');
+    await select('.hds-pagination-size-selector select', '30');
+
+    // Wait one animation frame so RAF-scheduled focus updates complete before assertions.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+
+    assert.dom('.hds-pagination-nav__arrow--direction-prev').isDisabled();
+    assert.dom('.hds-pagination-nav__arrow--direction-next').isNotFocused();
+    assert.dom('.hds-pagination-size-selector select').isFocused();
   });
 
   // EVENTS

--- a/showcase/tests/integration/components/hds/pagination/compact-test.gts
+++ b/showcase/tests/integration/components/hds/pagination/compact-test.gts
@@ -4,7 +4,14 @@
  */
 
 import { module, test } from 'qunit';
-import { click, render, resetOnerror, setupOnerror } from '@ember/test-helpers';
+import {
+  click,
+  focus,
+  render,
+  resetOnerror,
+  setupOnerror,
+} from '@ember/test-helpers';
+import { TrackedObject } from 'tracked-built-ins';
 
 import { HdsPaginationCompact } from '@hashicorp/design-system-components/components';
 import type { HdsPaginationDirections } from '@hashicorp/design-system-components/components/hds/pagination/types';
@@ -144,6 +151,80 @@ module('Integration | Component | hds/pagination/compact', function (hooks) {
     assert
       .dom('.hds-pagination-nav__arrow--direction-next')
       .hasAttribute('disabled');
+  });
+
+  test('it moves focus to the opposite arrow when an activated arrow becomes disabled', async function (assert) {
+    const context = new TrackedObject({
+      isDisabledPrev: false,
+      isDisabledNext: false,
+    });
+
+    const onPageChange = (direction: HdsPaginationDirections) => {
+      if (direction === 'prev') {
+        context.isDisabledPrev = true;
+        context.isDisabledNext = false;
+      } else {
+        context.isDisabledPrev = false;
+        context.isDisabledNext = true;
+      }
+    };
+
+    await render(
+      <template>
+        <HdsPaginationCompact
+          @isDisabledPrev={{context.isDisabledPrev}}
+          @isDisabledNext={{context.isDisabledNext}}
+          @onPageChange={{onPageChange}}
+        />
+      </template>,
+    );
+
+    await focus('.hds-pagination-nav__arrow--direction-prev');
+    await click('.hds-pagination-nav__arrow--direction-prev');
+
+    // Wait one animation frame so RAF-scheduled focus updates complete before assertions.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+
+    assert.dom('.hds-pagination-nav__arrow--direction-prev').isDisabled();
+    assert.dom('.hds-pagination-nav__arrow--direction-next').isFocused();
+
+    const context2 = new TrackedObject({
+      isDisabledPrev: false,
+      isDisabledNext: false,
+    });
+
+    const onPageChange2 = (direction: HdsPaginationDirections) => {
+      if (direction === 'prev') {
+        context2.isDisabledPrev = true;
+        context2.isDisabledNext = false;
+      } else {
+        context2.isDisabledPrev = false;
+        context2.isDisabledNext = true;
+      }
+    };
+
+    await render(
+      <template>
+        <HdsPaginationCompact
+          @isDisabledPrev={{context2.isDisabledPrev}}
+          @isDisabledNext={{context2.isDisabledNext}}
+          @onPageChange={{onPageChange2}}
+        />
+      </template>,
+    );
+
+    await focus('.hds-pagination-nav__arrow--direction-next');
+    await click('.hds-pagination-nav__arrow--direction-next');
+
+    // Wait one animation frame so RAF-scheduled focus updates complete before assertions.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+
+    assert.dom('.hds-pagination-nav__arrow--direction-next').isDisabled();
+    assert.dom('.hds-pagination-nav__arrow--direction-prev').isFocused();
   });
 
   // EVENTS

--- a/showcase/tests/integration/components/hds/pagination/numbered-test.gts
+++ b/showcase/tests/integration/components/hds/pagination/numbered-test.gts
@@ -13,6 +13,7 @@ import {
   resetOnerror,
   setupOnerror,
 } from '@ember/test-helpers';
+import { TrackedObject } from 'tracked-built-ins';
 
 import { HdsPaginationNumbered } from '@hashicorp/design-system-components/components';
 
@@ -371,6 +372,55 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
 
     assert.dom('.hds-pagination-nav__arrow--direction-next').isDisabled();
     assert.dom('.hds-pagination-nav__arrow--direction-prev').isFocused();
+  });
+
+  test('changing page size clears arrow focus intent and does not move focus to the opposite arrow', async function (assert) {
+    const context = new TrackedObject({
+      currentPage: 5,
+      currentPageSize: 10,
+    });
+
+    const queryFunction = (page: number, pageSize: number) => ({
+      page,
+      pageSize,
+    });
+
+    const onPageChange = (page: number, pageSize: number) => {
+      context.currentPage = page;
+      context.currentPageSize = pageSize;
+    };
+
+    const onPageSizeChange = (pageSize: number) => {
+      context.currentPageSize = pageSize;
+      context.currentPage = 2;
+    };
+
+    await render(
+      <template>
+        <HdsPaginationNumbered
+          @totalItems={{100}}
+          @currentPage={{context.currentPage}}
+          @currentPageSize={{context.currentPageSize}}
+          @route="page-components.pagination"
+          @queryFunction={{queryFunction}}
+          @onPageChange={{onPageChange}}
+          @onPageSizeChange={{onPageSizeChange}}
+        />
+      </template>,
+    );
+
+    await click('.hds-pagination-nav__arrow--direction-next');
+    await focus('.hds-pagination-size-selector select');
+    await select('.hds-pagination-size-selector select', '50');
+
+    // Wait one animation frame so RAF-scheduled focus updates complete before assertions.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+
+    assert.dom('.hds-pagination-nav__arrow--direction-next').isDisabled();
+    assert.dom('.hds-pagination-nav__arrow--direction-prev').isNotFocused();
+    assert.dom('.hds-pagination-size-selector select').isFocused();
   });
 
   // INTERACTION

--- a/showcase/tests/integration/components/hds/pagination/numbered-test.gts
+++ b/showcase/tests/integration/components/hds/pagination/numbered-test.gts
@@ -401,7 +401,7 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
           @totalItems={{100}}
           @currentPage={{context.currentPage}}
           @currentPageSize={{context.currentPageSize}}
-          @route="page-components.pagination"
+          @model="pagination-test"
           @queryFunction={{queryFunction}}
           @onPageChange={{onPageChange}}
           @onPageSizeChange={{onPageSizeChange}}

--- a/showcase/tests/integration/components/hds/pagination/numbered-test.gts
+++ b/showcase/tests/integration/components/hds/pagination/numbered-test.gts
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import { array } from '@ember/helper';
 import {
   click,
+  focus,
   select,
   render,
   resetOnerror,
@@ -332,6 +333,44 @@ module('Integration | Component | hds/pagination/numbered', function (hooks) {
       )
       .hasClass('hds-pagination-nav__number--is-selected');
     assert.dom('.hds-pagination-nav__arrow--direction-next').isDisabled();
+  });
+
+  test('it moves focus to the opposite arrow when an activated arrow becomes disabled', async function (assert) {
+    // reaching the first page disables "prev" and moves focus to "next"
+    await render(
+      <template>
+        <HdsPaginationNumbered @totalItems={{30}} @currentPage={{2}} />
+      </template>,
+    );
+
+    await focus('.hds-pagination-nav__arrow--direction-prev');
+    await click('.hds-pagination-nav__arrow--direction-prev');
+
+    // Wait one animation frame so RAF-scheduled focus updates complete before assertions.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+
+    assert.dom('.hds-pagination-nav__arrow--direction-prev').isDisabled();
+    assert.dom('.hds-pagination-nav__arrow--direction-next').isFocused();
+
+    // reaching the last page disables "next" and moves focus to "prev"
+    await render(
+      <template>
+        <HdsPaginationNumbered @totalItems={{30}} @currentPage={{2}} />
+      </template>,
+    );
+
+    await focus('.hds-pagination-nav__arrow--direction-next');
+    await click('.hds-pagination-nav__arrow--direction-next');
+
+    // Wait one animation frame so RAF-scheduled focus updates complete before assertions.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+
+    assert.dom('.hds-pagination-nav__arrow--direction-next').isDisabled();
+    assert.dom('.hds-pagination-nav__arrow--direction-prev').isFocused();
   });
 
   // INTERACTION


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add focus management when a button becomes disabled (ie. when you press next and theres no more pages after the current one).

### :hammer_and_wrench: Detailed description
Currently, when you press next or previous and reach a point where there is not another page, the button becomes disabled and the users focus can be lost. Now it it doesn't get lost and moves to the most logical element which is the opposite button. For example, if you press next until the last page, focus will move to previous.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6161](https://hashicorp.atlassian.net/browse/HDS-6161)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6161]: https://hashicorp.atlassian.net/browse/HDS-6161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ