### PR TITLE
`Toggle`: add aria-checked attribute to input

### DIFF
--- a/.changeset/eleven-clocks-shine.md
+++ b/.changeset/eleven-clocks-shine.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/form/toggle -->
-`Toggle` - Added `aria-checked` attribute to the input for accessibility, it is synced with the `checked` attribute.
+`Toggle` - Added the `aria-checked` attribute to the input for accessibility. It is synced with the `checked` attribute.
 <!-- END -->

--- a/.changeset/eleven-clocks-shine.md
+++ b/.changeset/eleven-clocks-shine.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/form/toggle -->
+`Toggle` - Added `aria-checked` attribute to the input for accessibility, it is synced with the `checked` attribute.
+<!-- END -->

--- a/packages/components/src/components/hds/form/toggle/base.gts
+++ b/packages/components/src/components/hds/form/toggle/base.gts
@@ -16,7 +16,16 @@ export interface HdsFormToggleBaseSignature {
 export default class HdsFormToggleBase extends Component<HdsFormToggleBaseSignature> {
   private _syncAriaChecked = modifier((element: HTMLInputElement) => {
     const syncAriaChecked = () => {
-      element.setAttribute('aria-checked', element.checked ? 'true' : 'false');
+      const checkedValue = element.getAttribute('checked');
+      let ariaCheckedValue: 'true' | 'false';
+
+      if (checkedValue === 'mixed') {
+        ariaCheckedValue = 'false';
+      } else {
+        ariaCheckedValue = element.checked ? 'true' : 'false';
+      }
+
+      element.setAttribute('aria-checked', ariaCheckedValue);
     };
 
     syncAriaChecked();

--- a/packages/components/src/components/hds/form/toggle/base.gts
+++ b/packages/components/src/components/hds/form/toggle/base.gts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import Component from '@glimmer/component';
+import { modifier } from 'ember-modifier';
 
 export interface HdsFormToggleBaseSignature {
   Args: {
@@ -12,7 +13,28 @@ export interface HdsFormToggleBaseSignature {
   Element: HTMLInputElement;
 }
 
-const HdsFormToggleBase: TemplateOnlyComponent<HdsFormToggleBaseSignature> =
+export default class HdsFormToggleBase extends Component<HdsFormToggleBaseSignature> {
+  private _syncAriaChecked = modifier((element: HTMLInputElement) => {
+    const syncAriaChecked = () => {
+      element.setAttribute('aria-checked', element.checked ? 'true' : 'false');
+    };
+
+    syncAriaChecked();
+
+    const observer = new MutationObserver(syncAriaChecked);
+    observer.observe(element, {
+      attributes: true,
+      attributeFilter: ['checked'],
+    });
+
+    element.addEventListener('change', syncAriaChecked);
+
+    return () => {
+      observer.disconnect();
+      element.removeEventListener('change', syncAriaChecked);
+    };
+  });
+
   <template>
     <div class="hds-form-toggle">
       <input
@@ -21,9 +43,9 @@ const HdsFormToggleBase: TemplateOnlyComponent<HdsFormToggleBaseSignature> =
         ...attributes
         value={{@value}}
         role="switch"
+        {{this._syncAriaChecked}}
       />
       <div class="hds-form-toggle__facade"></div>
     </div>
-  </template>;
-
-export default HdsFormToggleBase;
+  </template>
+}

--- a/showcase/tests/integration/components/hds/form/toggle/base-test.gts
+++ b/showcase/tests/integration/components/hds/form/toggle/base-test.gts
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 
 import { HdsFormToggleBase } from '@hashicorp/design-system-components/components';
 
@@ -30,6 +30,41 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
       <template><HdsFormToggleBase id="test-form-toggle" /></template>,
     );
     assert.dom('#test-form-toggle').hasAttribute('role', 'switch');
+  });
+
+  test('it should render aria-checked="false" by default', async function (assert) {
+    await render(
+      <template><HdsFormToggleBase id="test-form-toggle" /></template>,
+    );
+    assert.dom('#test-form-toggle').hasAttribute('aria-checked', 'false');
+  });
+
+  test('it should render aria-checked="true" when checked', async function (assert) {
+    await render(
+      <template>
+        <HdsFormToggleBase id="test-form-toggle" checked="checked" />
+      </template>,
+    );
+    assert.dom('#test-form-toggle').hasAttribute('aria-checked', 'true');
+  });
+
+  test('it should keep aria-checked in sync with checked when toggled', async function (assert) {
+    await render(
+      <template><HdsFormToggleBase id="test-form-toggle" /></template>,
+    );
+
+    assert.dom('#test-form-toggle').isNotChecked();
+    assert.dom('#test-form-toggle').hasAttribute('aria-checked', 'false');
+
+    await click('#test-form-toggle');
+
+    assert.dom('#test-form-toggle').isChecked();
+    assert.dom('#test-form-toggle').hasAttribute('aria-checked', 'true');
+
+    await click('#test-form-toggle');
+
+    assert.dom('#test-form-toggle').isNotChecked();
+    assert.dom('#test-form-toggle').hasAttribute('aria-checked', 'false');
   });
   // role="switch"
 });

--- a/showcase/tests/integration/components/hds/form/toggle/base-test.gts
+++ b/showcase/tests/integration/components/hds/form/toggle/base-test.gts
@@ -48,6 +48,17 @@ module('Integration | Component | hds/form/toggle/base', function (hooks) {
     assert.dom('#test-form-toggle').hasAttribute('aria-checked', 'true');
   });
 
+  test('it should render aria-checked="false" when checked="mixed"', async function (assert) {
+    await render(
+      <template>
+        <HdsFormToggleBase id="test-form-toggle" checked="mixed" />
+      </template>,
+    );
+
+    assert.dom('#test-form-toggle').hasAttribute('checked', 'mixed');
+    assert.dom('#test-form-toggle').hasAttribute('aria-checked', 'false');
+  });
+
   test('it should keep aria-checked in sync with checked when toggled', async function (assert) {
     await render(
       <template><HdsFormToggleBase id="test-form-toggle" /></template>,


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add a new modifier to the Toggle Base that keeps the aria-checked attribute in sync with the checked attribute. this is because ARIA 1.2 requires elements with role switch have aria-checked ([source](https://www.w3.org/TR/wai-aria-1.2/#switch)).

I did it this way to avoid creating a breaking change for consumers and so that all instances of toggle will be fixed after this is released. 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6134](https://hashicorp.atlassian.net/browse/HDS-6134)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6134]: https://hashicorp.atlassian.net/browse/HDS-6134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ