### PR TITLE
fix: flaky time test failure

### DIFF
--- a/showcase/tests/integration/components/hds/time/index-test.gts
+++ b/showcase/tests/integration/components/hds/time/index-test.gts
@@ -347,7 +347,18 @@ module('Integration | Component | hds/time/index', function (hooks) {
         <HdsTime @date={{oneWeekFromNow}} @display="relative" />
       </template>,
     );
-    assert.dom('.hds-time').hasText('in 7 days');
+
+    const renderedText = document
+      .querySelector('.hds-time')
+      ?.textContent?.trim();
+
+    // This can render as 7 or 8 days because hds-time updates "now"
+    // during insertion and the relative value is truncated. This happens more
+    // in Ember 5.12 because of test timing compared to other versions.
+    assert.true(
+      renderedText === 'in 7 days' || renderedText === 'in 8 days',
+      `Element .hds-time has text "${renderedText}"`,
+    );
   });
 
   // near times in the past


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix a flaky test. The easiest way to fix it is to allow for 7 or 8 days so the test doesn't rely on perfect timing anymore.

It seems that the failure is happening in 5.12 more than other versions because of how the component lifecycle + test is rendered, this causes slight differences in how "now" is timed and then that can make it be rounded differently.

### :camera_flash: Screenshots

The flaky test: 
<img width="1055" height="348" alt="Screenshot 2026-06-10 at 9 51 01 AM" src="https://github.com/user-attachments/assets/cabb38a1-86bc-48dd-ab03-a3c1558c217e" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6351](https://hashicorp.atlassian.net/browse/HDS-6351)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6351]: https://hashicorp.atlassian.net/browse/HDS-6351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ