### PR TITLE
[Project Solar / Phase 1 / Migration]  Set LinkStandalone secondary hover state color

### DIFF
--- a/packages/components/src/styles/components/link/standalone.scss
+++ b/packages/components/src/styles/components/link/standalone.scss
@@ -100,6 +100,8 @@ $hds-link-standalone-sizes: ("small", "medium", "large");
 
   &:hover,
   &.mock-hover {
+    color: var(--token-color-foreground-strong);
+
     .hds-link-standalone__text {
       text-decoration-color: var(--token-color-foreground-strong);
     }


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would set a `color` for the `LinkStandalone` secondary color to prevent it from being overridden by consumer styles.

### :hammer_and_wrench: Detailed description

Currently in the `LinkStandalone` `secondary` color variant, the text color for both the default and hover states is the same (`foreground.strong`). Because of this inside the `:hover` selector styles for the component there is no `color` value set.

This was recently caught to cause certain issues in the Atlas Carbonization test. Atlas has global link styles for `a:hover`. Since the link standalone sets no color on hover, the Atlas global styles were taking precedence.

<img width="505" height="124" alt="Screenshot 2026-06-09 at 2 29 04 PM" src="https://github.com/user-attachments/assets/e228a1bc-0326-47a2-9945-d7060b05fcfa" />

<img width="399" height="112" alt="Screenshot 2026-06-09 at 3 56 50 PM" src="https://github.com/user-attachments/assets/fdb67bf9-354c-4893-b7f6-8096f94d7882" />

 To prevent this from occurring this PR sets a `color` for the `:hover` state of the secondary variant equal to `--token-color-foreground-strong`. 

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6358](https://hashicorp.atlassian.net/browse/HDS-6358)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6358]: https://hashicorp.atlassian.net/browse/HDS-6358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ