### PR TITLE
`Website`: typo in advanced table docs

### DIFF
--- a/website/docs/components/table/advanced-table/partials/code/component-api.md
+++ b/website/docs/components/table/advanced-table/partials/code/component-api.md
@@ -25,7 +25,7 @@ The Advanced Table component itself is where most of the options will be applied
       <C.Property @name="[B].sortOrder" @type="string">
         The value of the internal `sortOrder` tracked variable.
       </C.Property>
-      <C.Property @name="[B].isExpanded" @type="boolean">
+      <C.Property @name="[B].isOpen" @type="boolean">
         Returns the value of the internal `isExpanded` tracked variable from the row if it has nested rows; otherwise returns `undefined`.
       </C.Property>
     </Doc::ComponentApi>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an issue on the website where we say the expanded state is returned as `isExpanded` instead of `isOpen`.

**[Before](https://hds-website-6-2-0.vercel.app/components/table/advanced-table?tab=code#advancedtable)**
**[After](https://hds-website-git-hds-6318-docs-advanced-table-bug-hashicorp.vercel.app/components/table/advanced-table?tab=code#advancedtable)**

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6318](https://hashicorp.atlassian.net/browse/HDS-6318)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6318]: https://hashicorp.atlassian.net/browse/HDS-6318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ