### PR TITLE
`Modal` -  Update Overlay close behavior (HDS-6032)

### DIFF
--- a/.changeset/loose-pianos-warn.md
+++ b/.changeset/loose-pianos-warn.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`Modal` - Fixed issue causing `Modal` to close unexpectely by checking that a click on the `Modal` overlay both starts and ends within the overlay before closing
+<!-- START {components/modal} -->
+`Modal` - Fixed issue causing `Modal` to close unexpectedly by checking that a click on the `Overlay` both starts and ends within the `Overlay` before closing
+<!-- END -->

--- a/.changeset/loose-pianos-warn.md
+++ b/.changeset/loose-pianos-warn.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Modal` - Fixed issue causing `Modal` to close unexpectely by checking that a click on the `Modal` overlay both starts and ends within the overlay before closing

--- a/packages/components/src/components/hds/modal/index.gts
+++ b/packages/components/src/components/hds/modal/index.gts
@@ -65,6 +65,8 @@ export default class HdsModal extends Component<HdsModalSignature> {
   private _body!: HTMLElement;
   private _bodyInitialOverflowValue = '';
   private _clickOutsideToDismissHandler!: (event: MouseEvent) => void;
+  private _mousedownOutsideModalHandler!: (event: MouseEvent) => void;
+  private _mousedownWasOutsideModal = false;
 
   get isDismissDisabled(): boolean {
     return this.args.isDismissDisabled ?? false;
@@ -183,9 +185,22 @@ export default class HdsModal extends Component<HdsModalSignature> {
     }
 
     // Note: because the Modal has the `@isDismissedDisabled` argument, we need to add our own click outside to dismiss logic. This is because `ember-focus-trap` treats the `focusTrapOptions` as static, so we can't update it dynamically if `@isDismissDisabled` changes.
+
+    // Track whether the mousedown that initiated the click started outside the modal.
+    // This prevents a drag that begins inside the modal but ends outside from closing it.
+    this._mousedownOutsideModalHandler = (event: MouseEvent) => {
+      this._mousedownWasOutsideModal = !this._element.contains(
+        event.target as Node
+      );
+    };
+
     this._clickOutsideToDismissHandler = (event: MouseEvent) => {
-      // check if the click is outside the modal and the modal is open
-      if (!this._element.contains(event.target as Node) && this._isOpen) {
+      // Only dismiss if both the mousedown and the click (mouseup) occurred outside the modal
+      if (
+        !this._element.contains(event.target as Node) &&
+        this._mousedownWasOutsideModal &&
+        this._isOpen
+      ) {
         if (!this.isDismissDisabled) {
           //  here we use `void` because `onDismiss` is an async function, but in reality we don't need to handle the result or wait for its completion
           void this.onDismiss();
@@ -193,6 +208,10 @@ export default class HdsModal extends Component<HdsModalSignature> {
       }
     };
 
+    document.addEventListener('mousedown', this._mousedownOutsideModalHandler, {
+      capture: true,
+      passive: true,
+    });
     document.addEventListener('click', this._clickOutsideToDismissHandler, {
       capture: true,
       passive: false,
@@ -211,6 +230,11 @@ export default class HdsModal extends Component<HdsModalSignature> {
         true
       );
 
+      document.removeEventListener(
+        'mousedown',
+        this._mousedownOutsideModalHandler,
+        true
+      );
       document.removeEventListener(
         'click',
         this._clickOutsideToDismissHandler,

--- a/showcase/tests/integration/components/hds/modal/index-test.gts
+++ b/showcase/tests/integration/components/hds/modal/index-test.gts
@@ -11,6 +11,7 @@ import {
   resetOnerror,
   settled,
   setupOnerror,
+  triggerEvent,
   triggerKeyEvent,
 } from '@ember/test-helpers';
 import { on } from '@ember/modifier';
@@ -209,6 +210,19 @@ module('Integration | Component | hds/modal/index', function (hooks) {
     assert.dom('#test-modal').isVisible();
     await click('.hds-modal__overlay');
     assert.dom('#test-modal').isNotVisible();
+  });
+
+  test('it should not close the modal when a click starts inside the modal but ends outside on the overlay', async function (assert) {
+    await render(
+      <template>
+        <HdsModal id="test-modal" as |M|><M.Header>Title</M.Header></HdsModal>
+      </template>,
+    );
+    assert.dom('#test-modal').isVisible();
+    // Simulate a drag: mousedown originates inside the modal, click ends on the overlay
+    await triggerEvent('#test-modal', 'mousedown');
+    await triggerEvent('.hds-modal__overlay', 'click');
+    assert.dom('#test-modal').isVisible();
   });
 
   test('it should not close the modal when `@isDismissDisabled` is `true`', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the close behavior of the `Modal` to check that a click event both starts and ends within the `Overlay` before closing the `Modal`.

### :hammer_and_wrench: Detailed description

The updated behavior prevents users from closing the `Modal` when clicking to perform an action inside it in the case they accidentally drag outside it and into the `Overlay` area before releasing the mouse button.

#### To Test:

* BEFORE FIX: https://hds-showcase.vercel.app/components/modal#demo
* AFTER FIX: https://hds-showcase-git-kristin-hds-6032-modal-close-2133e0-hashicorp.vercel.app/components/modal#demo

Within an open `Modal`,

##### Test 1:

1. Click and hold down your mouse button while inside the `Modal`. 
2. Drag outside the `Modal` into the `Overlay` area, then release the mouse button.

**Expected**: The `Modal` should not close.

##### Test 2:

1. Within the `Overlay` area, click and release your mouse button.

**Expected**: The `Modal` should close.

<!-- 
### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-6032](https://hashicorp.atlassian.net/browse/HDS-6032)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6032]: https://hashicorp.atlassian.net/browse/HDS-6032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ