### PR TITLE
[Project Solar / Phase 1 / Showcase] Convert HdsIcon in Carbon Web Components to `cds-icon`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,7 +556,7 @@ importers:
         specifier: ^11.53.0
         version: 11.53.0
       '@carbon/icons':
-        specifier: 11.76.0
+        specifier: ^11.76.0
         version: 11.76.0
       '@carbon/layout':
         specifier: ^11.51.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,6 +555,9 @@ importers:
       '@carbon/grid':
         specifier: ^11.53.0
         version: 11.53.0
+      '@carbon/icons':
+        specifier: 11.76.0
+        version: 11.76.0
       '@carbon/layout':
         specifier: ^11.51.0
         version: 11.51.0

--- a/showcase/app/components/page-carbonization/components/badge/index.gts
+++ b/showcase/app/components/page-carbonization/components/badge/index.gts
@@ -6,6 +6,7 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { pageTitle } from 'ember-page-title';
 import { array } from '@ember/helper';
+import Activity16 from '@carbon/icons/es/activity/16';
 
 import ShwTextH1 from 'showcase/components/shw/text/h1';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
@@ -13,10 +14,8 @@ import ShwFlex from 'showcase/components/shw/flex';
 import ShwDivider from 'showcase/components/shw/divider';
 import ShwCarbonizationComparisonGrid from 'showcase/components/shw/carbonization/comparison-grid';
 
-import {
-  HdsBadge,
-  HdsIcon,
-} from '@hashicorp/design-system-components/components';
+import { HdsBadge } from '@hashicorp/design-system-components/components';
+import setCdsIcon from 'showcase/modifiers/set-cds-icon';
 import {
   SIZES,
   TYPES,
@@ -44,7 +43,8 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
         <HdsBadge @icon="activity" @text="Lorem ipsum" />
       </:theming>
       <:reference>
-        <cds-tag>Lorem ipsum <HdsIcon @name="activity" slot="icon" /></cds-tag>
+        <cds-tag>Lorem ipsum
+          <cds-icon slot="icon" {{setCdsIcon Activity16}} /></cds-tag>
       </:reference>
     </ShwCarbonizationComparisonGrid>
     <ShwCarbonizationComparisonGrid>
@@ -52,7 +52,7 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
         <HdsBadge @icon="activity" @text="Only icon" @isIconOnly={{true}} />
       </:theming>
       <:reference>
-        <cds-tag><HdsIcon @name="activity" slot="icon" /></cds-tag>
+        <cds-tag><cds-icon slot="icon" {{setCdsIcon Activity16}} /></cds-tag>
       </:reference>
     </ShwCarbonizationComparisonGrid>
     <ShwCarbonizationComparisonGrid>
@@ -63,7 +63,7 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
         />
       </:theming>
       <:reference>
-        <cds-tag><HdsIcon @name="activity" slot="icon" />
+        <cds-tag><cds-icon slot="icon" {{setCdsIcon Activity16}} />
           This is a very long text that should go on multiple lines</cds-tag>
       </:reference>
     </ShwCarbonizationComparisonGrid>
@@ -93,13 +93,13 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
           {{#let (array "sm" "md" "lg") as |SIZES|}}
             {{#each SIZES as |size|}}
               <SF.Item>
-                <cds-tag size={{size}}><HdsIcon
-                    @name="activity"
+                <cds-tag size={{size}}><cds-icon
                     slot="icon"
+                    {{setCdsIcon Activity16}}
                   /></cds-tag>
-                <cds-tag size={{size}}><HdsIcon
-                    @name="activity"
+                <cds-tag size={{size}}><cds-icon
                     slot="icon"
+                    {{setCdsIcon Activity16}}
                   />Lorem ipsum</cds-tag>
               </SF.Item>
             {{/each}}
@@ -133,11 +133,14 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
           {{#let (array "gray" "high-contrast" "outline") as |TYPES|}}
             {{#each TYPES as |type|}}
               <SF.Item>
-                <cds-tag type={{type}}><HdsIcon
-                    @name="activity"
+                <cds-tag type={{type}}><cds-icon
                     slot="icon"
+                    {{setCdsIcon Activity16}}
                   /></cds-tag>
-                <cds-tag type={{type}}><HdsIcon @name="activity" slot="icon" />
+                <cds-tag type={{type}}><cds-icon
+                    slot="icon"
+                    {{setCdsIcon Activity16}}
+                  />
                   Lorem ipsum</cds-tag>
               </SF.Item>
             {{/each}}
@@ -175,19 +178,25 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
       <:reference>
         <ShwFlex @direction="column" @gap="0.5rem" as |SF|>
           <SF.Item>
-            <cds-tag type="gray"><HdsIcon
-                @name="activity"
+            <cds-tag type="gray"><cds-icon
                 slot="icon"
+                {{setCdsIcon Activity16}}
               /></cds-tag>
-            <cds-tag type="gray"><HdsIcon @name="activity" slot="icon" />
+            <cds-tag type="gray"><cds-icon
+                slot="icon"
+                {{setCdsIcon Activity16}}
+              />
               Lorem ipsum</cds-tag>
           </SF.Item>
           <SF.Item>
-            <cds-tag type="outline"><HdsIcon
-                @name="activity"
+            <cds-tag type="outline"><cds-icon
                 slot="icon"
+                {{setCdsIcon Activity16}}
               /></cds-tag>
-            <cds-tag type="outline"><HdsIcon @name="activity" slot="icon" />
+            <cds-tag type="outline"><cds-icon
+                slot="icon"
+                {{setCdsIcon Activity16}}
+              />
               Lorem ipsum</cds-tag>
           </SF.Item>
         </ShwFlex>
@@ -223,11 +232,14 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
       </:theming>
       <:reference>
         <div class="shw-component-badge-sample-color--neutral-dark-mode">
-          <cds-tag type="high-contrast"><HdsIcon
-              @name="activity"
+          <cds-tag type="high-contrast"><cds-icon
               slot="icon"
+              {{setCdsIcon Activity16}}
             /></cds-tag>
-          <cds-tag type="high-contrast"><HdsIcon @name="activity" slot="icon" />
+          <cds-tag type="high-contrast"><cds-icon
+              slot="icon"
+              {{setCdsIcon Activity16}}
+            />
             Lorem ipsum</cds-tag>
         </div>
       </:reference>
@@ -256,11 +268,14 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
         </ShwFlex>
       </:theming>
       <:reference>
-        <cds-tag type="purple"><HdsIcon
-            @name="activity"
+        <cds-tag type="purple"><cds-icon
             slot="icon"
+            {{setCdsIcon Activity16}}
           /></cds-tag>
-        <cds-tag type="purple"><HdsIcon @name="activity" slot="icon" />
+        <cds-tag type="purple"><cds-icon
+            slot="icon"
+            {{setCdsIcon Activity16}}
+          />
           Lorem ipsum</cds-tag>
       </:reference>
     </ShwCarbonizationComparisonGrid>
@@ -288,8 +303,11 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
         </ShwFlex>
       </:theming>
       <:reference>
-        <cds-tag type="green"><HdsIcon @name="activity" slot="icon" /></cds-tag>
-        <cds-tag type="green"><HdsIcon @name="activity" slot="icon" />
+        <cds-tag type="green"><cds-icon
+            slot="icon"
+            {{setCdsIcon Activity16}}
+          /></cds-tag>
+        <cds-tag type="green"><cds-icon slot="icon" {{setCdsIcon Activity16}} />
           Lorem ipsum</cds-tag>
       </:reference>
     </ShwCarbonizationComparisonGrid>
@@ -344,8 +362,11 @@ const BadgeCarbonizationIndex: TemplateOnlyComponent = <template>
         </ShwFlex>
       </:theming>
       <:reference>
-        <cds-tag type="red"><HdsIcon @name="activity" slot="icon" /></cds-tag>
-        <cds-tag type="red"><HdsIcon @name="activity" slot="icon" />
+        <cds-tag type="red"><cds-icon
+            slot="icon"
+            {{setCdsIcon Activity16}}
+          /></cds-tag>
+        <cds-tag type="red"><cds-icon slot="icon" {{setCdsIcon Activity16}} />
           Lorem ipsum</cds-tag>
       </:reference>
     </ShwCarbonizationComparisonGrid>

--- a/showcase/app/components/page-carbonization/components/breadcrumb/index.gts
+++ b/showcase/app/components/page-carbonization/components/breadcrumb/index.gts
@@ -7,6 +7,8 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { pageTitle } from 'ember-page-title';
 import { capitalize } from '@ember/string';
 import { eq } from 'ember-truth-helpers';
+import Enterprise16 from '@carbon/icons/es/enterprise/16.js';
+import Folder16 from '@carbon/icons/es/folder/16.js';
 
 import ShwTextH1 from 'showcase/components/shw/text/h1';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
@@ -17,8 +19,8 @@ import {
   HdsBreadcrumb,
   HdsBreadcrumbItem,
   HdsBreadcrumbTruncation,
-  HdsIcon,
 } from '@hashicorp/design-system-components/components';
+import setCdsIcon from 'showcase/modifiers/set-cds-icon';
 
 const STATES = ['default', 'hover', 'active', 'focus'];
 
@@ -74,13 +76,13 @@ const BreadcrumbCarbonizationIndex: TemplateOnlyComponent = <template>
         <cds-breadcrumb>
           <cds-breadcrumb-item>
             <cds-breadcrumb-link href="#">
-              <HdsIcon @name="org" slot="icon" />
+              <cds-icon slot="icon" {{setCdsIcon Enterprise16}} />
               Level one
             </cds-breadcrumb-link>
           </cds-breadcrumb-item>
           <cds-breadcrumb-item>
             <cds-breadcrumb-link href="#">
-              <HdsIcon @name="folder" slot="icon" />
+              <cds-icon slot="icon" {{setCdsIcon Folder16}} />
               Level two
             </cds-breadcrumb-link>
           </cds-breadcrumb-item>
@@ -116,13 +118,13 @@ const BreadcrumbCarbonizationIndex: TemplateOnlyComponent = <template>
         <cds-breadcrumb>
           <cds-breadcrumb-item>
             <cds-breadcrumb-link href="#">
-              <HdsIcon @name="org" slot="icon" />
+              <cds-icon slot="icon" {{setCdsIcon Enterprise16}} />
               Level one
             </cds-breadcrumb-link>
           </cds-breadcrumb-item>
           <cds-breadcrumb-item>
             <cds-breadcrumb-link href="#">
-              <HdsIcon @name="folder" slot="icon" />
+              <cds-icon slot="icon" {{setCdsIcon Folder16}} />
               Level two
             </cds-breadcrumb-link>
           </cds-breadcrumb-item>

--- a/showcase/app/components/page-carbonization/components/button/index.gts
+++ b/showcase/app/components/page-carbonization/components/button/index.gts
@@ -5,6 +5,9 @@ import { capitalize } from '@ember/string';
 import { array } from '@ember/helper';
 import style from 'ember-style-modifier';
 import { eq } from 'ember-truth-helpers';
+import ArrowRight16 from '@carbon/icons/es/arrow--right/16.js';
+import Add16 from '@carbon/icons/es/add/16.js';
+import InProgress16 from '@carbon/icons/es/in-progress/16.js';
 
 import ShwTextH1 from 'showcase/components/shw/text/h1';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
@@ -14,10 +17,8 @@ import ShwFlex from 'showcase/components/shw/flex';
 import ShwDivider from 'showcase/components/shw/divider';
 import ShwCarbonizationComparisonGrid from 'showcase/components/shw/carbonization/comparison-grid';
 
-import {
-  HdsButton,
-  HdsIcon,
-} from '@hashicorp/design-system-components/components';
+import { HdsButton } from '@hashicorp/design-system-components/components';
+import setCdsIcon from 'showcase/modifiers/set-cds-icon';
 import {
   COLORS,
   SIZES,
@@ -74,9 +75,9 @@ const ButtonCarbonizationIndex: TemplateOnlyComponent = <template>
         />
       </:theming>
       <:reference>
-        <cds-button size="md" kind="primary"><HdsIcon
-            @name="arrow-right"
+        <cds-button size="md" kind="primary"><cds-icon
             slot="icon"
+            {{setCdsIcon ArrowRight16}}
           />Lorem ipsum</cds-button>
       </:reference>
     </ShwCarbonizationComparisonGrid>
@@ -92,7 +93,7 @@ const ButtonCarbonizationIndex: TemplateOnlyComponent = <template>
           tooltip-text="cds-button description (via attribute)"
           tooltip-position="top"
         >
-          <HdsIcon @name="plus" slot="icon" />
+          <cds-icon slot="icon" {{setCdsIcon Add16}} />
         </cds-button>
       </:reference>
     </ShwCarbonizationComparisonGrid>
@@ -107,9 +108,9 @@ const ButtonCarbonizationIndex: TemplateOnlyComponent = <template>
       </:theming>
       <:reference>
         <div {{style width="200px" overflow="scroll"}}>
-          <cds-button size="md" kind="primary"><HdsIcon
-              @name="plus"
+          <cds-button size="md" kind="primary"><cds-icon
               slot="icon"
+              {{setCdsIcon Add16}}
             />This is a very long text that should go on multiple lines</cds-button>
         </div>
       </:reference>
@@ -122,9 +123,9 @@ const ButtonCarbonizationIndex: TemplateOnlyComponent = <template>
       </:theming>
       <:reference>
         <div {{style width="150px"}}>
-          <cds-button size="md" kind="primary"><HdsIcon
-              @name="loading"
+          <cds-button size="md" kind="primary"><cds-icon
               slot="icon"
+              {{setCdsIcon InProgress16}}
             />Loading</cds-button>
         </div>
       </:reference>
@@ -155,9 +156,9 @@ const ButtonCarbonizationIndex: TemplateOnlyComponent = <template>
           {{#let (array "sm" "md" "lg") as |SIZES|}}
             {{#each SIZES as |size|}}
               <SF.Item>
-                <cds-button size={{size}}><HdsIcon
-                    @name="plus"
+                <cds-button size={{size}}><cds-icon
                     slot="icon"
+                    {{setCdsIcon Add16}}
                   />Lorem ipsum</cds-button>
               </SF.Item>
             {{/each}}
@@ -181,9 +182,9 @@ const ButtonCarbonizationIndex: TemplateOnlyComponent = <template>
           />
         </:theming>
         <:reference>
-          <cds-button size="md" kind={{mapHdsColorToCdsKind color}}><HdsIcon
-              @name="plus"
+          <cds-button size="md" kind={{mapHdsColorToCdsKind color}}><cds-icon
               slot="icon"
+              {{setCdsIcon Add16}}
             />Lorem ipsum</cds-button>
         </:reference>
       </ShwCarbonizationComparisonGrid>
@@ -234,7 +235,7 @@ const ButtonCarbonizationIndex: TemplateOnlyComponent = <template>
                       <cds-button
                         size={{size}}
                         kind={{mapHdsColorToCdsKind color}}
-                      ><HdsIcon @name="plus" slot="icon" />Lorem ipsum</cds-button>
+                      ><cds-icon slot="icon" {{setCdsIcon Add16}} />Lorem ipsum</cds-button>
                     </SF.Item>
                   {{/each}}
                 {{/let}}
@@ -248,7 +249,7 @@ const ButtonCarbonizationIndex: TemplateOnlyComponent = <template>
                         size={{size}}
                         kind={{mapHdsColorToCdsKind color}}
                         disabled
-                      ><HdsIcon @name="plus" slot="icon" />Lorem ipsum</cds-button>
+                      ><cds-icon slot="icon" {{setCdsIcon Add16}} />Lorem ipsum</cds-button>
                     </SF.Item>
                   {{/each}}
                 {{/let}}

--- a/showcase/app/components/page-carbonization/components/form/radio-card/index.gts
+++ b/showcase/app/components/page-carbonization/components/form/radio-card/index.gts
@@ -9,6 +9,7 @@ import { pageTitle } from 'ember-page-title';
 import { capitalize } from '@ember/string';
 import { eq } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
+import HexagonSolid24 from '@carbon/icons/es/hexagon--solid/24.js';
 
 import ShwTextH1 from 'showcase/components/shw/text/h1';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
@@ -21,10 +22,10 @@ import {
   HdsBadge,
   HdsFormRadioCard,
   HdsFormRadioCardGroup,
-  HdsIcon,
   HdsTextBody,
   HdsTextDisplay,
 } from '@hashicorp/design-system-components/components';
+import setCdsIcon from 'showcase/modifiers/set-cds-icon';
 
 import {
   CONTROL_POSITIONS,
@@ -56,7 +57,7 @@ const CdsRadioTileContent: TemplateOnlyComponent<CdsRadioTileContentSignature> =
         }}"
     >
       {{#if @showIcon}}
-        <HdsIcon @name="hexagon" @size="24" />
+        <cds-icon {{setCdsIcon HexagonSolid24}} />
       {{/if}}
       <HdsTextDisplay @tag="span" @size="300" @weight="bold">{{if
           @label

--- a/showcase/app/components/page-carbonization/components/link/inline/index.gts
+++ b/showcase/app/components/page-carbonization/components/link/inline/index.gts
@@ -7,6 +7,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { pageTitle } from 'ember-page-title';
 import { capitalize } from '@ember/string';
 import { eq } from 'ember-truth-helpers';
+import ArrowRight16 from '@carbon/icons/es/arrow--right/16.js';
 
 import ShwTextH1 from 'showcase/components/shw/text/h1';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
@@ -16,10 +17,10 @@ import ShwDivider from 'showcase/components/shw/divider';
 import ShwCarbonizationComparisonGrid from 'showcase/components/shw/carbonization/comparison-grid';
 
 import {
-  HdsIcon,
   HdsLayoutFlex,
   HdsLinkInline,
 } from '@hashicorp/design-system-components/components';
+import setCdsIcon from 'showcase/modifiers/set-cds-icon';
 import { COLORS } from '@hashicorp/design-system-components/components/hds/link/inline';
 
 const STATES = ['default', 'hover', 'active', 'focus'];
@@ -58,11 +59,7 @@ const BadgeLinkInlineIndex: TemplateOnlyComponent = <template>
         <HdsLayoutFlex @direction="column">
           <cds-link href="#" inline size="lg">Lorem ipsum dolor</cds-link>
           <cds-link href="#" inline size="lg">Lorem ipsum dolor
-            <HdsIcon
-              @name="arrow-right-circle"
-              @isInline={{true}}
-              slot="icon"
-            /></cds-link>
+            <cds-icon slot="icon" {{setCdsIcon ArrowRight16}} /></cds-link>
         </HdsLayoutFlex>
       </:reference>
     </ShwCarbonizationComparisonGrid>

--- a/showcase/app/components/page-carbonization/components/link/standalone/index.gts
+++ b/showcase/app/components/page-carbonization/components/link/standalone/index.gts
@@ -8,6 +8,7 @@ import { pageTitle } from 'ember-page-title';
 import { capitalize } from '@ember/string';
 import { helper } from '@ember/component/helper';
 import { eq } from 'ember-truth-helpers';
+import ArrowRight16 from '@carbon/icons/es/arrow--right/16.js';
 
 import ShwTextH1 from 'showcase/components/shw/text/h1';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
@@ -17,10 +18,10 @@ import ShwDivider from 'showcase/components/shw/divider';
 import ShwCarbonizationComparisonGrid from 'showcase/components/shw/carbonization/comparison-grid';
 
 import {
-  HdsIcon,
   HdsLayoutFlex,
   HdsLinkStandalone,
 } from '@hashicorp/design-system-components/components';
+import setCdsIcon from 'showcase/modifiers/set-cds-icon';
 import {
   COLORS,
   SIZES,
@@ -67,10 +68,10 @@ const BadgeLinkStandaloneIndex: TemplateOnlyComponent = <template>
       <:reference>
         <HdsLayoutFlex @direction="column">
           <cds-link href="#" size="md">Lorem ipsum
-            <HdsIcon @name="arrow-right" slot="icon" /></cds-link>
+            <cds-icon slot="icon" {{setCdsIcon ArrowRight16}} /></cds-link>
           <cds-link href="#" size="md">Very long text that should wrap for
             multiple lines
-            <HdsIcon @name="arrow-right" slot="icon" /></cds-link>
+            <cds-icon slot="icon" {{setCdsIcon ArrowRight16}} /></cds-link>
         </HdsLayoutFlex>
       </:reference>
     </ShwCarbonizationComparisonGrid>
@@ -95,7 +96,7 @@ const BadgeLinkStandaloneIndex: TemplateOnlyComponent = <template>
         <HdsLayoutFlex @direction="column">
           {{#each SIZES as |size|}}
             <cds-link href="#" size={{mapHdsSizeToCdsSize size}}>Lorem ipsum
-              <HdsIcon @name="arrow-right" slot="icon" /></cds-link>
+              <cds-icon slot="icon" {{setCdsIcon ArrowRight16}} /></cds-link>
           {{/each}}
         </HdsLayoutFlex>
       </:reference>
@@ -127,7 +128,7 @@ const BadgeLinkStandaloneIndex: TemplateOnlyComponent = <template>
               <R.NoEquivalent @isCompact={{true}} />
             {{else if (eq state "default")}}
               <cds-link href="#" size="md">Lorem ipsum
-                <HdsIcon @name="arrow-right" slot="icon" /></cds-link>
+                <cds-icon slot="icon" {{setCdsIcon ArrowRight16}} /></cds-link>
             {{else}}
               <pre>TODO: static image here</pre>
             {{/if}}

--- a/showcase/app/components/page-carbonization/components/tooltip/index.gts
+++ b/showcase/app/components/page-carbonization/components/tooltip/index.gts
@@ -7,6 +7,8 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { pageTitle } from 'ember-page-title';
 import { hash } from '@ember/helper';
 import { eq, or } from 'ember-truth-helpers';
+import Information16 from '@carbon/icons/es/information/16.js';
+import Activity16 from '@carbon/icons/es/activity/16.js';
 
 import ShwTextH1 from 'showcase/components/shw/text/h1';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
@@ -23,6 +25,7 @@ import {
   HdsTooltipButton,
 } from '@hashicorp/design-system-components/components';
 import { PLACEMENTS } from '@hashicorp/design-system-components/components/hds/tooltip-button/index';
+import setCdsIcon from 'showcase/modifiers/set-cds-icon';
 
 const STATES = ['default', 'hover', 'focus'];
 
@@ -81,7 +84,10 @@ const TooltipCarbonizationIndex: TemplateOnlyComponent = <template>
         <ShwFlex @direction="column" as |SF|>
           <SF.Item>
             <cds-tooltip open>
-              <HdsIcon @name="info" class="sb-tooltip-trigger" />
+              <cds-icon
+                class="sb-tooltip-trigger"
+                {{setCdsIcon Information16}}
+              />
               <cds-tooltip-content id="content-1">Here is more information</cds-tooltip-content>
             </cds-tooltip>
           </SF.Item>
@@ -101,7 +107,7 @@ const TooltipCarbonizationIndex: TemplateOnlyComponent = <template>
           <SF.Item>
             <cds-tooltip>
               <cds-tag class="sb-tooltip-trigger">Lorem ipsum
-                <HdsIcon @name="activity" slot="icon" /></cds-tag>
+                <cds-icon slot="icon" {{setCdsIcon Activity16}} /></cds-tag>
               <cds-tooltip-content id="content-3">Lorem ipsum dolor sit amet,
                 consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
                 labore et dolore magna aliqua. Ut enim ad minim veniam, quis
@@ -116,7 +122,7 @@ const TooltipCarbonizationIndex: TemplateOnlyComponent = <template>
           <SF.Item>
             <cds-tooltip>
               <cds-tag class="sb-tooltip-trigger">Lorem ipsum
-                <HdsIcon @name="activity" slot="icon" /></cds-tag>
+                <cds-icon slot="icon" {{setCdsIcon Activity16}} /></cds-tag>
               <cds-tooltip-content
                 id="content-4"
               >Loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtempor!</cds-tooltip-content>
@@ -152,7 +158,7 @@ const TooltipCarbonizationIndex: TemplateOnlyComponent = <template>
         <p>
           <span class="hds-typography-display-300">Lorem ipsum dolor</span>
           <cds-tooltip>
-            <HdsIcon @name="info" class="sb-tooltip-trigger" />
+            <cds-icon class="sb-tooltip-trigger" {{setCdsIcon Information16}} />
             <cds-tooltip-content id="content-inline-1">Here is more infor</cds-tooltip-content>
           </cds-tooltip>
         </p>
@@ -160,7 +166,7 @@ const TooltipCarbonizationIndex: TemplateOnlyComponent = <template>
         <p class="hds-typography-body-300">
           Lorem ipsum dolor sit amet
           <cds-tooltip>
-            <HdsIcon @name="info" class="sb-tooltip-trigger" />
+            <cds-icon class="sb-tooltip-trigger" {{setCdsIcon Information16}} />
             <cds-tooltip-content id="content-inline-2">Here is more info</cds-tooltip-content>
           </cds-tooltip>
           consectetur adipisicing elit.
@@ -217,7 +223,10 @@ const TooltipCarbonizationIndex: TemplateOnlyComponent = <template>
             <ShwFlex @gap="4rem" @direction="column" as |SF|>
               <SF.Item>
                 <cds-tooltip>
-                  <HdsIcon @name="info" class="sb-tooltip-trigger" />
+                  <cds-icon
+                    class="sb-tooltip-trigger"
+                    {{setCdsIcon Information16}}
+                  />
                   <cds-tooltip-content id="content-{{state}}-1">More info</cds-tooltip-content>
                 </cds-tooltip>
               </SF.Item>

--- a/showcase/app/index.html
+++ b/showcase/app/index.html
@@ -48,56 +48,56 @@
 
     <!-- IBM Carbon Web Components - Import via CDN -->
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/badge-indicator.min.js"></script>
-    <script type="module"
       src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/breadcrumb.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/button.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/badge-indicator.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/code-snippet.min.js"></script>
-      <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/copy-button.min.js"></script>
-    <!-- <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/icon.min.js"></script> -->
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/button.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/icon-button.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/code-snippet.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/menu-button.min.js"></script>
-    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/tag.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/copy-button.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/inline-loading.min.js"></script>
-    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/tabs.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/icon.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/text-input.min.js"></script>
-    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.47.0/link.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/icon-button.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/modal.min.js"></script>
-    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/tag.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/menu-button.min.js"></script>
+    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/tag.min.js"></script>
+    <script type="module"
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/inline-loading.min.js"></script>
+    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/tabs.min.js"></script>
+    <script type="module"
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/text-input.min.js"></script>
+    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/link.min.js"></script>
+    <script type="module"
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/modal.min.js"></script>
     <script type="module"
       src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/overflow-menu.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/pagination.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/pagination.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/pagination-nav.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/pagination-nav.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/tile.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/tile.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/tooltip.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/tooltip.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/toggle-tip.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/toggle-tip.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/notification.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/notification.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/stack.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/stack.min.js"></script>
     <script type="module"
-      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/ui-shell.min.js"></script>
+      src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/ui-shell.min.js"></script>
     <script type="module">
       import carbonibmProductsWebComponents from 'https://cdn.jsdelivr.net/npm/@carbon/ibm-products-web-components@0.34.0/+esm'
     </script>
 
     <!-- form related components -->
-    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version//v2.48.0/form.min.js"></script>
-    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/form-group.min.js"></script>
-    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.48.0/file-uploader.min.js"></script>
+    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/form.min.js"></script>
+    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/form-group.min.js"></script>
+    <script type="module" src="https://1.www.s81c.com/common/carbon/web-components/version/v2.50.0/file-uploader.min.js"></script>
 
     <!-- This contains global styles and CSS resets too! -->
     <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/web-components/tag/latest/themes.css" />
@@ -110,7 +110,7 @@
       cds-button:not(:defined),
       cds-code-snippet:not(:defined),
       cds-copy-button:not(:defined),
-      /* cds-icon:not(:defined), */
+      cds-icon:not(:defined),
       /* cds-icon-button:not(:defined), */
       cds-link:not(:defined),
       cds-menu-button:not(:defined),

--- a/showcase/app/modifiers/set-cds-icon.ts
+++ b/showcase/app/modifiers/set-cds-icon.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { modifier } from 'ember-modifier';
+
+interface SetCdsIconSignature {
+  Element: Element & { icon?: unknown };
+  Args: {
+    Positional: [unknown];
+  };
+}
+
+export default modifier<SetCdsIconSignature>((element, [icon]) => {
+  element.icon = icon;
+});

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -40,7 +40,7 @@
     "@babel/eslint-parser": "^7.27.1",
     "@babel/plugin-proposal-decorators": "^7.27.1",
     "@carbon/grid": "^11.53.0",
-    "@carbon/icons": "11.76.0",
+    "@carbon/icons": "^11.76.0",
     "@carbon/layout": "^11.51.0",
     "@carbon/styles": "^1.104.0",
     "@carbon/themes": "^11.71.0",

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -40,6 +40,7 @@
     "@babel/eslint-parser": "^7.27.1",
     "@babel/plugin-proposal-decorators": "^7.27.1",
     "@carbon/grid": "^11.53.0",
+    "@carbon/icons": "11.76.0",
     "@carbon/layout": "^11.51.0",
     "@carbon/styles": "^1.104.0",
     "@carbon/themes": "^11.71.0",

--- a/showcase/types/global.d.ts
+++ b/showcase/types/global.d.ts
@@ -2,3 +2,8 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
+
+declare module '@carbon/icons/es/*' {
+  const icon: unknown;
+  export default icon;
+}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would convert instances of HdsIcon within the demo carbon web components in the carbonization pages to cds-icon. 

This PR also cleans up the versions of Carbon Web Components so its always `v2.5.0`.

**[Current](https://hds-showcase-git-project-solar-phase-1-main-fe-1ffc6c-hashicorp.vercel.app/carbonization/components/badge)**
**[Proposed](https://hds-showcase-git-project-solar-phase-1showcase-0d0c2d-hashicorp.vercel.app/carbonization/components/badge)**

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6020](https://hashicorp.atlassian.net/browse/HDS-6020)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6020]: https://hashicorp.atlassian.net/browse/HDS-6020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ