### PR TITLE
Showcase: fix flaky time test to allow 2 or 3 days

### DIFF
--- a/showcase/tests/integration/components/hds/time/index-test.gts
+++ b/showcase/tests/integration/components/hds/time/index-test.gts
@@ -335,7 +335,18 @@ module('Integration | Component | hds/time/index', function (hooks) {
         <HdsTime @date={{twoDaysFromNow}} @display="relative" />
       </template>,
     );
-    assert.dom('.hds-time').hasText('in 2 days');
+
+    const renderedText = document
+      .querySelector('.hds-time')
+      ?.textContent?.trim();
+
+    // This can render as 2 or 3 days because hds-time updates "now"
+    // during insertion and the relative value is truncated. This happens more
+    // in Ember 5.12 because of test timing compared to other versions.
+    assert.true(
+      renderedText === 'in 2 days' || renderedText === 'in 3 days',
+      `Element .hds-time has text "${renderedText}"`,
+    );
   });
 
   test('it should render the correct string for a date that is one week from now', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would make the a time test flexible to allow 2 or 3 days to avoid it flaking.

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>