### PR TITLE
`Alert` - Add new generic content yielded blocks to match Figma (HDS-6287)

### DIFF
--- a/.changeset/good-apples-chew.md
+++ b/.changeset/good-apples-chew.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/alert -->
-`Alert` - Deprecated the `Generic` yielded block which renders below actions and added `GenericAbove` and `GenericBelow` yielded blocks for including custom content either above or below `Alert` actions.
+`Alert` - Deprecated the `Generic` yielded block which renders below actions and added `GenericContent` and `GenericFooter` yielded blocks for including custom content either above or below `Alert` actions.
 <!-- END -->

--- a/.changeset/good-apples-chew.md
+++ b/.changeset/good-apples-chew.md
@@ -1,7 +1,7 @@
 ---
-"@hashicorp/design-system-components": patch
+"@hashicorp/design-system-components": minor
 ---
 
 <!-- START components/alert -->
-`Alert` - Changed position of generic yielded content within `Alert` to display above the actions instead of after
+`Alert` - Added `genericLayoutBottom` option with a default value of `true`. When set to `false`, it changes the position of generic yielded content within the `Alert` to display above the actions instead of after them at the bottom of the `Alert`
 <!-- END -->

--- a/.changeset/good-apples-chew.md
+++ b/.changeset/good-apples-chew.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`Alert` - Changed position of generic yielded content within `Alert` to display above the actions instead of after

--- a/.changeset/good-apples-chew.md
+++ b/.changeset/good-apples-chew.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/alert -->
-`Alert` - Added `genericLayoutBottom` option with a default value of `true`. When set to `false`, it changes the position of generic yielded content within the `Alert` to display above the actions instead of after them at the bottom of the `Alert`
+`Alert` - Deprecated the `Generic` yielded block which renders below actions and added `GenericAbove` and `GenericBelow` yielded blocks for including custom content either above or below `Alert` actions.
 <!-- END -->

--- a/.changeset/good-apples-chew.md
+++ b/.changeset/good-apples-chew.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
+<!-- START components/alert -->
 `Alert` - Changed position of generic yielded content within `Alert` to display above the actions instead of after
+<!-- END -->

--- a/packages/components/src/components/hds/alert/index.gts
+++ b/packages/components/src/components/hds/alert/index.gts
@@ -237,7 +237,6 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
           {{yield (hash Description=HdsAlertDescription)}}
         </div>
 
-        {{yield (hash Generic=HdsAlertGenericDeprecated)}}
         {{yield (hash GenericAbove=HdsYield)}}
 
         <div class="hds-alert__actions">
@@ -249,6 +248,7 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
           }}
         </div>
 
+        {{yield (hash Generic=HdsAlertGenericDeprecated)}}
         {{yield (hash GenericBelow=HdsYield)}}
       </div>
 

--- a/packages/components/src/components/hds/alert/index.gts
+++ b/packages/components/src/components/hds/alert/index.gts
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import { eq } from 'ember-truth-helpers';
@@ -28,6 +28,26 @@ import HdsYield from '../yield/index.gts';
 import type { HdsAlertColors, HdsAlertTypes } from './types.ts';
 import type { HdsIconSignature } from '../icon/index.gts';
 
+class HdsAlertGenericDeprecated extends Component<{ Blocks: { default: [] } }> {
+  constructor(owner: Owner, args: Record<string, never>) {
+    super(owner, args);
+    deprecate(
+      'The "Generic" contextual component yielded by "Hds::Alert" is deprecated. Use "GenericAbove" or "GenericBelow" instead.',
+      false,
+      {
+        id: 'hds.alert.use-generic-above-or-generic-below',
+        until: '7.0.0',
+        for: '@hashicorp/design-system-components',
+        since: { available: '6.2.1' },
+      }
+    );
+  }
+  <template>
+    {{! template-lint-disable no-yield-only }}
+    {{yield}}
+  </template>
+}
+
 export const TYPES: HdsAlertTypes[] = Object.values(HdsAlertTypeValues);
 export const DEFAULT_COLOR: HdsAlertColors = HdsAlertColorValues.Neutral;
 export const COLORS: HdsAlertColors[] = Object.values(HdsAlertColorValues);
@@ -49,7 +69,6 @@ export interface HdsAlertSignature {
     type: HdsAlertTypes;
     color?: HdsAlertColors;
     icon?: HdsIconSignature['Args']['name'] | false;
-    genericLayoutBottom?: boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onDismiss?: (event: MouseEvent, ...args: any[]) => void;
   };
@@ -58,7 +77,12 @@ export interface HdsAlertSignature {
       {
         Title?: typeof HdsAlertTitle;
         Description?: typeof HdsAlertDescription;
-        Generic?: typeof HdsYield;
+        /**
+         * @deprecated Use "GenericAbove" or "GenericBelow" instead.
+         */
+        Generic?: typeof HdsAlertGenericDeprecated;
+        GenericAbove?: typeof HdsYield;
+        GenericBelow?: typeof HdsYield;
         LinkStandalone?: WithBoundArgs<typeof HdsLinkStandalone, 'size'>;
         Button?: WithBoundArgs<typeof HdsButton, 'size'>;
       },
@@ -140,10 +164,6 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
     }
   }
 
-  get genericLayoutBottom(): boolean {
-    return this.args.genericLayoutBottom ?? true;
-  }
-
   get classNames(): string {
     const classes = ['hds-alert'];
 
@@ -217,9 +237,8 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
           {{yield (hash Description=HdsAlertDescription)}}
         </div>
 
-        {{#unless this.genericLayoutBottom}}
-          {{yield (hash Generic=HdsYield)}}
-        {{/unless}}
+        {{yield (hash Generic=HdsAlertGenericDeprecated)}}
+        {{yield (hash GenericAbove=HdsYield)}}
 
         <div class="hds-alert__actions">
           {{yield
@@ -230,9 +249,7 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
           }}
         </div>
 
-        {{#if this.genericLayoutBottom}}
-          {{yield (hash Generic=HdsYield)}}
-        {{/if}}
+        {{yield (hash GenericBelow=HdsYield)}}
       </div>
 
       {{#if this.onDismiss}}

--- a/packages/components/src/components/hds/alert/index.gts
+++ b/packages/components/src/components/hds/alert/index.gts
@@ -212,6 +212,8 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
           {{yield (hash Description=HdsAlertDescription)}}
         </div>
 
+        {{yield (hash Generic=HdsYield)}}
+
         <div class="hds-alert__actions">
           {{yield
             (hash
@@ -220,7 +222,6 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
             )
           }}
         </div>
-        {{yield (hash Generic=HdsYield)}}
       </div>
 
       {{#if this.onDismiss}}

--- a/packages/components/src/components/hds/alert/index.gts
+++ b/packages/components/src/components/hds/alert/index.gts
@@ -32,7 +32,7 @@ class HdsAlertGenericDeprecated extends Component<{ Blocks: { default: [] } }> {
   constructor(owner: Owner, args: Record<string, never>) {
     super(owner, args);
     deprecate(
-      'The "Generic" contextual component yielded by "Hds::Alert" is deprecated. Use "GenericAbove" or "GenericBelow" instead.',
+      'The "Generic" contextual component yielded by "Hds::Alert" is deprecated. Use "GenericContent" or "GenericFooter" instead.',
       false,
       {
         id: 'hds.alert.use-generic-above-or-generic-below',
@@ -78,11 +78,11 @@ export interface HdsAlertSignature {
         Title?: typeof HdsAlertTitle;
         Description?: typeof HdsAlertDescription;
         /**
-         * @deprecated Use "GenericAbove" or "GenericBelow" instead.
+         * @deprecated Use "GenericContent" or "GenericFooter" instead.
          */
         Generic?: typeof HdsAlertGenericDeprecated;
-        GenericAbove?: typeof HdsYield;
-        GenericBelow?: typeof HdsYield;
+        GenericContent?: typeof HdsYield;
+        GenericFooter?: typeof HdsYield;
         LinkStandalone?: WithBoundArgs<typeof HdsLinkStandalone, 'size'>;
         Button?: WithBoundArgs<typeof HdsButton, 'size'>;
       },
@@ -237,7 +237,7 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
           {{yield (hash Description=HdsAlertDescription)}}
         </div>
 
-        {{yield (hash GenericAbove=HdsYield)}}
+        {{yield (hash GenericContent=HdsYield)}}
 
         <div class="hds-alert__actions">
           {{yield
@@ -249,7 +249,7 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
         </div>
 
         {{yield (hash Generic=HdsAlertGenericDeprecated)}}
-        {{yield (hash GenericBelow=HdsYield)}}
+        {{yield (hash GenericFooter=HdsYield)}}
       </div>
 
       {{#if this.onDismiss}}

--- a/packages/components/src/components/hds/alert/index.gts
+++ b/packages/components/src/components/hds/alert/index.gts
@@ -49,6 +49,7 @@ export interface HdsAlertSignature {
     type: HdsAlertTypes;
     color?: HdsAlertColors;
     icon?: HdsIconSignature['Args']['name'] | false;
+    genericLayoutBottom?: boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onDismiss?: (event: MouseEvent, ...args: any[]) => void;
   };
@@ -139,6 +140,10 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
     }
   }
 
+  get genericLayoutBottom(): boolean {
+    return this.args.genericLayoutBottom ?? true;
+  }
+
   get classNames(): string {
     const classes = ['hds-alert'];
 
@@ -212,7 +217,9 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
           {{yield (hash Description=HdsAlertDescription)}}
         </div>
 
-        {{yield (hash Generic=HdsYield)}}
+        {{#unless this.genericLayoutBottom}}
+          {{yield (hash Generic=HdsYield)}}
+        {{/unless}}
 
         <div class="hds-alert__actions">
           {{yield
@@ -222,6 +229,10 @@ export default class HdsAlert extends Component<HdsAlertSignature> {
             )
           }}
         </div>
+
+        {{#if this.genericLayoutBottom}}
+          {{yield (hash Generic=HdsYield)}}
+        {{/if}}
       </div>
 
       {{#if this.onDismiss}}

--- a/showcase/app/components/page-components/alert/sub-sections/actions.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/actions.gts
@@ -50,12 +50,14 @@ const SubSectionActions: TemplateOnlyComponent = <template>
 
         <SG.Item>
           <HdsAlert @type={{type}} @color="warning" as |A|>
-            <A.Title>With actions and custom content
-              <em>below</em>
-              the actions</A.Title>
+            <A.Title>With actions and custom content</A.Title>
             <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
               elit, sed do eiusmod tempor incididunt ut labore et dolore magna
               aliqua.</A.Description>
+            <A.GenericAbove>
+              <div class="shw-component-alert-sample-custom-content">This, for
+                example, could be extra text above the actions.</div>
+            </A.GenericAbove>
             <A.Button @text="Action" @color="secondary" />
             <A.LinkStandalone
               @icon="plus"
@@ -63,43 +65,10 @@ const SubSectionActions: TemplateOnlyComponent = <template>
               @href="#"
               @color="secondary"
             />
-            <A.Generic>
-              <div
-                class="shw-component-alert-sample-custom-content-after-actions"
-              >This, for example, could be extra text
-                <strong>below the actions</strong>
-                for a special use case.</div>
-            </A.Generic>
-          </HdsAlert>
-        </SG.Item>
-
-        <SG.Item>
-          <HdsAlert
-            @type={{type}}
-            @genericLayoutBottom={{false}}
-            @color="warning"
-            as |A|
-          >
-            <A.Title>With actions and custom content
-              <em>above</em>
-              the actions</A.Title>
-            <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
-              elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-              aliqua.</A.Description>
-            <A.Button @text="Action" @color="secondary" />
-            <A.LinkStandalone
-              @icon="plus"
-              @text="Action"
-              @href="#"
-              @color="secondary"
-            />
-            <A.Generic>
-              <div
-                class="shw-component-alert-sample-custom-content-after-actions"
-              >This, for example, could be extra text
-                <strong>above the actions</strong>
-                for a special use case.</div>
-            </A.Generic>
+            <A.GenericBelow>
+              <div class="shw-component-alert-sample-custom-content">This, for
+                example, could be extra text below the actions.</div>
+            </A.GenericBelow>
           </HdsAlert>
         </SG.Item>
       </ShwGrid>

--- a/showcase/app/components/page-components/alert/sub-sections/actions.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/actions.gts
@@ -54,10 +54,10 @@ const SubSectionActions: TemplateOnlyComponent = <template>
             <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
               elit, sed do eiusmod tempor incididunt ut labore et dolore magna
               aliqua.</A.Description>
-            <A.GenericAbove>
+            <A.GenericContent>
               <div class="shw-component-alert-sample-custom-content">This, for
                 example, could be extra text above the actions.</div>
-            </A.GenericAbove>
+            </A.GenericContent>
             <A.Button @text="Action" @color="secondary" />
             <A.LinkStandalone
               @icon="plus"
@@ -65,10 +65,10 @@ const SubSectionActions: TemplateOnlyComponent = <template>
               @href="#"
               @color="secondary"
             />
-            <A.GenericBelow>
+            <A.GenericFooter>
               <div class="shw-component-alert-sample-custom-content">This, for
                 example, could be extra text below the actions.</div>
-            </A.GenericBelow>
+            </A.GenericFooter>
           </HdsAlert>
         </SG.Item>
       </ShwGrid>

--- a/showcase/app/components/page-components/alert/sub-sections/actions.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/actions.gts
@@ -50,7 +50,9 @@ const SubSectionActions: TemplateOnlyComponent = <template>
 
         <SG.Item>
           <HdsAlert @type={{type}} @color="warning" as |A|>
-            <A.Title>With actions and custom content</A.Title>
+            <A.Title>With actions and custom content
+              <em>below</em>
+              the actions</A.Title>
             <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
               elit, sed do eiusmod tempor incididunt ut labore et dolore magna
               aliqua.</A.Description>
@@ -64,8 +66,39 @@ const SubSectionActions: TemplateOnlyComponent = <template>
             <A.Generic>
               <div
                 class="shw-component-alert-sample-custom-content-after-actions"
-              >This for example could be extra text, specific for a special use
-                case.</div>
+              >This, for example, could be extra text
+                <strong>below the actions</strong>
+                for a special use case.</div>
+            </A.Generic>
+          </HdsAlert>
+        </SG.Item>
+
+        <SG.Item>
+          <HdsAlert
+            @type={{type}}
+            @genericLayoutBottom={{false}}
+            @color="warning"
+            as |A|
+          >
+            <A.Title>With actions and custom content
+              <em>above</em>
+              the actions</A.Title>
+            <A.Description>Lorem ipsum dolor sit amet, consectetur adipiscing
+              elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+              aliqua.</A.Description>
+            <A.Button @text="Action" @color="secondary" />
+            <A.LinkStandalone
+              @icon="plus"
+              @text="Action"
+              @href="#"
+              @color="secondary"
+            />
+            <A.Generic>
+              <div
+                class="shw-component-alert-sample-custom-content-after-actions"
+              >This, for example, could be extra text
+                <strong>above the actions</strong>
+                for a special use case.</div>
             </A.Generic>
           </HdsAlert>
         </SG.Item>

--- a/showcase/app/components/page-components/alert/sub-sections/content.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/content.gts
@@ -92,23 +92,23 @@ const SubSectionContent: TemplateOnlyComponent = <template>
             <A.Title>An alert with extra/custom content</A.Title>
             <A.Description>In special cases, you can pass extra content to the
               alert using the
-              <code>A.GenericAbove</code>
+              <code>A.GenericContent</code>
               &
-              <code>A.GenericBelow</code>
+              <code>A.GenericFooter</code>
               contextual components.</A.Description>
-            <A.GenericAbove>
+            <A.GenericContent>
               <ShwPlaceholder
                 @text="generic content above actions"
                 @height="50"
               />
-            </A.GenericAbove>
+            </A.GenericContent>
             <A.Button @text="Action" @color="secondary" />
-            <A.GenericBelow>
+            <A.GenericFooter>
               <ShwPlaceholder
                 @text="generic content below actions"
                 @height="50"
               />
-            </A.GenericBelow>
+            </A.GenericFooter>
           </HdsAlert>
         </SF.Item>
       </ShwFlex>

--- a/showcase/app/components/page-components/alert/sub-sections/content.gts
+++ b/showcase/app/components/page-components/alert/sub-sections/content.gts
@@ -92,11 +92,23 @@ const SubSectionContent: TemplateOnlyComponent = <template>
             <A.Title>An alert with extra/custom content</A.Title>
             <A.Description>In special cases, you can pass extra content to the
               alert using the
-              <code>A.Generic</code>
-              contextual component.</A.Description>
-            <A.Generic>
-              <ShwPlaceholder @text="some generic content" @height="50" />
-            </A.Generic>
+              <code>A.GenericAbove</code>
+              &
+              <code>A.GenericBelow</code>
+              contextual components.</A.Description>
+            <A.GenericAbove>
+              <ShwPlaceholder
+                @text="generic content above actions"
+                @height="50"
+              />
+            </A.GenericAbove>
+            <A.Button @text="Action" @color="secondary" />
+            <A.GenericBelow>
+              <ShwPlaceholder
+                @text="generic content below actions"
+                @height="50"
+              />
+            </A.GenericBelow>
           </HdsAlert>
         </SF.Item>
       </ShwFlex>

--- a/showcase/app/styles/showcase-pages/alert.scss
+++ b/showcase/app/styles/showcase-pages/alert.scss
@@ -13,7 +13,7 @@ body.page-components-alert {
     outline: 1px dotted var(--shw-color-gray-400);
   }
 
-  .shw-component-alert-sample-custom-content-after-actions {
+  .shw-component-alert-sample-custom-content {
     @include shw-font-family("system sans");
     display: block;
     margin-top: 1rem;

--- a/showcase/tests/integration/components/hds/alert/index-test.gts
+++ b/showcase/tests/integration/components/hds/alert/index-test.gts
@@ -5,6 +5,7 @@
 
 import { module, test } from 'qunit';
 import { render, resetOnerror, setupOnerror, find } from '@ember/test-helpers';
+import { registerDeprecationHandler } from '@ember/debug';
 
 import { HdsAlert } from '@hashicorp/design-system-components/components';
 
@@ -190,6 +191,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
 
   // GENERIC
 
+  // Note: The "Generic" yielded block is deprecated and will be removed in favor of "GenericAbove" and "GenericBelow"
   test('it should render any content passed to the "generic" contextual component', async function (assert) {
     await render(
       <template>
@@ -200,41 +202,24 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     assert.dom('#test-alert .hds-alert__content pre').exists().hasText('test');
   });
 
-  test('it should render the "generic" content after the actions by default (@genericLayoutBottom defaults to true)', async function (assert) {
+  test('it should render any content passed to the "genericAbove" contextual component', async function (assert) {
     await render(
       <template>
-        <HdsAlert @type="inline" id="test-alert" as |A|>
-          <A.Button @text="Action" @color="secondary" />
-          <A.Generic><div
-              id="test-generic-layout-bottom-true"
-            >generic</div></A.Generic>
-        </HdsAlert>
+        <HdsAlert @type="inline" id="test-alert" as |A|><A.GenericAbove><pre
+            >test</pre></A.GenericAbove></HdsAlert>
       </template>,
     );
-    assert
-      .dom('.hds-alert__actions + #test-generic-layout-bottom-true')
-      .exists();
+    assert.dom('#test-alert .hds-alert__content pre').exists().hasText('test');
   });
 
-  test('it should render the "generic" content before the actions when @genericLayoutBottom is false', async function (assert) {
+  test('it should render any content passed to the "genericBelow" contextual component', async function (assert) {
     await render(
       <template>
-        <HdsAlert
-          @type="inline"
-          @genericLayoutBottom={{false}}
-          id="test-alert"
-          as |A|
-        >
-          <A.Button @text="Action" @color="secondary" />
-          <A.Generic><div
-              id="test-generic-layout-bottom-false"
-            >generic</div></A.Generic>
-        </HdsAlert>
+        <HdsAlert @type="inline" id="test-alert" as |A|><A.GenericBelow><pre
+            >test</pre></A.GenericBelow></HdsAlert>
       </template>,
     );
-    assert
-      .dom('#test-generic-layout-bottom-false + .hds-alert__actions')
-      .exists();
+    assert.dom('#test-alert .hds-alert__content pre').exists().hasText('test');
   });
 
   // DISMISS
@@ -421,6 +406,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
       throw new Error(errorMessage);
     });
   });
+
   test('it should throw an assertion if a "compact" alerts is rendered with @icon equal to false', async function (assert) {
     const errorMessage =
       '@icon for "Hds::Alert" with @type "compact" is required';
@@ -435,6 +421,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
       throw new Error(errorMessage);
     });
   });
+
   test('it should throw an assertion if an incorrect value for @color is provided', async function (assert) {
     const errorMessage =
       '@color for "Hds::Alert" must be one of the following: neutral, highlight, success, warning, critical; received: foo';
@@ -451,5 +438,25 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     assert.throws(function () {
       throw new Error(errorMessage);
     });
+  });
+
+  // DEPRECATION
+
+  test('it should trigger a deprecation warning when the "generic" contextual component is used', async function (assert) {
+    const deprecations: string[] = [];
+    registerDeprecationHandler((message, options, next) => {
+      deprecations.push(options?.id ?? '');
+      next(message, options);
+    });
+    await render(
+      <template>
+        <HdsAlert @type="inline" as |A|><A.Generic><pre
+            >test</pre></A.Generic></HdsAlert>
+      </template>,
+    );
+    assert.ok(
+      deprecations.includes('hds.alert.use-generic-above-or-generic-below'),
+      'deprecation warning is triggered when the "generic" block is used',
+    );
   });
 });

--- a/showcase/tests/integration/components/hds/alert/index-test.gts
+++ b/showcase/tests/integration/components/hds/alert/index-test.gts
@@ -191,7 +191,7 @@ module('Integration | Component | hds/alert/index', function (hooks) {
 
   // GENERIC
 
-  // Note: The "Generic" yielded block is deprecated and will be removed in favor of "GenericAbove" and "GenericBelow"
+  // Note: The "Generic" yielded block is deprecated and will be removed in favor of "GenericContent" and "GenericFooter"
   test('it should render any content passed to the "generic" contextual component', async function (assert) {
     await render(
       <template>
@@ -205,8 +205,8 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   test('it should render any content passed to the "genericAbove" contextual component', async function (assert) {
     await render(
       <template>
-        <HdsAlert @type="inline" id="test-alert" as |A|><A.GenericAbove><pre
-            >test</pre></A.GenericAbove></HdsAlert>
+        <HdsAlert @type="inline" id="test-alert" as |A|><A.GenericContent><pre
+            >test</pre></A.GenericContent></HdsAlert>
       </template>,
     );
     assert.dom('#test-alert .hds-alert__content pre').exists().hasText('test');
@@ -215,8 +215,8 @@ module('Integration | Component | hds/alert/index', function (hooks) {
   test('it should render any content passed to the "genericBelow" contextual component', async function (assert) {
     await render(
       <template>
-        <HdsAlert @type="inline" id="test-alert" as |A|><A.GenericBelow><pre
-            >test</pre></A.GenericBelow></HdsAlert>
+        <HdsAlert @type="inline" id="test-alert" as |A|><A.GenericFooter><pre
+            >test</pre></A.GenericFooter></HdsAlert>
       </template>,
     );
     assert.dom('#test-alert .hds-alert__content pre').exists().hasText('test');

--- a/showcase/tests/integration/components/hds/alert/index-test.gts
+++ b/showcase/tests/integration/components/hds/alert/index-test.gts
@@ -200,6 +200,43 @@ module('Integration | Component | hds/alert/index', function (hooks) {
     assert.dom('#test-alert .hds-alert__content pre').exists().hasText('test');
   });
 
+  test('it should render the "generic" content after the actions by default (@genericLayoutBottom defaults to true)', async function (assert) {
+    await render(
+      <template>
+        <HdsAlert @type="inline" id="test-alert" as |A|>
+          <A.Button @text="Action" @color="secondary" />
+          <A.Generic><div
+              id="test-generic-layout-bottom-true"
+            >generic</div></A.Generic>
+        </HdsAlert>
+      </template>,
+    );
+    assert
+      .dom('.hds-alert__actions + #test-generic-layout-bottom-true')
+      .exists();
+  });
+
+  test('it should render the "generic" content before the actions when @genericLayoutBottom is false', async function (assert) {
+    await render(
+      <template>
+        <HdsAlert
+          @type="inline"
+          @genericLayoutBottom={{false}}
+          id="test-alert"
+          as |A|
+        >
+          <A.Button @text="Action" @color="secondary" />
+          <A.Generic><div
+              id="test-generic-layout-bottom-false"
+            >generic</div></A.Generic>
+        </HdsAlert>
+      </template>,
+    );
+    assert
+      .dom('#test-generic-layout-bottom-false + .hds-alert__actions')
+      .exists();
+  });
+
   // DISMISS
 
   test('it should not render the "dismiss" button by default', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR:

* Adds new `GenericAbove` & `GenericBelow` yielded blocks
* Deprecated the existing `Generic` block

👉 **Preview**: https://hds-showcase-git-kristin-hds-6287-alert-generi-df250e-hashicorp.vercel.app/components/alert#actions

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :copilot: Copilot instructions
Specific instructions for Copilot when reviewing the PR -->

### :camera_flash: Screenshots

<img width="551" height="260" alt="image" src="https://github.com/user-attachments/assets/6ed2d5eb-d7ac-4107-a607-7b33909fd07a" />

<img width="798" height="218" alt="image" src="https://github.com/user-attachments/assets/a3152dd7-58f0-4ee1-9e07-33cc9ecdea4a" />

### :link: External links

* Jira ticket: [HDS-6287](https://hashicorp.atlassian.net/browse/HDS-6287)
* Figma file: https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?node-id=67382-70921&t=hjlIvesqawRNDpoe-0

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6287]: https://hashicorp.atlassian.net/browse/HDS-6287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ