### PR TITLE
docs: add note about adding sr-only text to external links

### DIFF
--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-basic.classic.hbs
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-basic.classic.hbs
@@ -1,3 +1,3 @@
 Lorem
-<Hds::Link::Inline @href="https://helios.hashicorp.design/">ipsum dolor</Hds::Link::Inline>
+<Hds::Link::Inline @href="https://helios.hashicorp.design/">ipsum dolor<span class="sr-only">(opens in a new window)</span></Hds::Link::Inline>
 sit amet consectetur adipiscing elit.

--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-basic.gts
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-basic.gts
@@ -4,7 +4,9 @@ import { HdsLinkInline } from '@hashicorp/design-system-components/components';
 
 const LocalComponent: TemplateOnlyComponent = <template>
   Lorem
-  <HdsLinkInline @href="https://helios.hashicorp.design/">ipsum dolor</HdsLinkInline>
+  <HdsLinkInline @href="https://helios.hashicorp.design/">ipsum dolor<span
+      class="sr-only"
+    >(opens in a new window)</span></HdsLinkInline>
   sit amet consectetur adipiscing elit.
 </template>;
 

--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-color.classic.hbs
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-color.classic.hbs
@@ -1,3 +1,4 @@
 Lorem
-<Hds::Link::Inline @color="secondary" @href="https://helios.hashicorp.design/">ipsum dolor</Hds::Link::Inline>
+<Hds::Link::Inline @color="secondary" @href="https://helios.hashicorp.design/">ipsum dolor<span class="sr-only">(opens
+    in a new window)</span></Hds::Link::Inline>
 sit amet consectetur adipiscing elit.

--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-color.gts
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-color.gts
@@ -7,7 +7,7 @@ const LocalComponent: TemplateOnlyComponent = <template>
   <HdsLinkInline
     @color="secondary"
     @href="https://helios.hashicorp.design/"
-  >ipsum dolor</HdsLinkInline>
+  >ipsum dolor<span class="sr-only">(opens in a new window)</span></HdsLinkInline>
   sit amet consectetur adipiscing elit.
 </template>;
 

--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-href.classic.hbs
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-href.classic.hbs
@@ -1,3 +1,4 @@
 Lorem
-<Hds::Link::Inline @icon="external-link" @href="https://www.hashicorp.com">ipsum dolor</Hds::Link::Inline>
+<Hds::Link::Inline @icon="external-link" @href="https://www.hashicorp.com">ipsum dolor<span class="sr-only">(opens in a
+    new window)</span></Hds::Link::Inline>
 sit amet consectetur adipiscing elit.

--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-href.gts
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-href.gts
@@ -5,7 +5,7 @@ import { HdsLinkInline } from '@hashicorp/design-system-components/components';
 const LocalComponent: TemplateOnlyComponent = <template>
   Lorem
   <HdsLinkInline @icon="external-link" @href="https://www.hashicorp.com">ipsum
-    dolor</HdsLinkInline>
+    dolor<span class="sr-only">(opens in a new window)</span></HdsLinkInline>
   sit amet consectetur adipiscing elit.
 </template>;
 

--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-icon-position.classic.hbs
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-icon-position.classic.hbs
@@ -1,3 +1,5 @@
 Lorem
-<Hds::Link::Inline @icon="external-link" @iconPosition="leading" @href="https://helios.hashicorp.design/">ipsum dolor</Hds::Link::Inline>
+<Hds::Link::Inline @icon="external-link" @iconPosition="leading" @href="https://helios.hashicorp.design/">ipsum dolor<span
+    class="sr-only"
+  >(opens in a new window)</span></Hds::Link::Inline>
 sit amet consectetur adipiscing elit.

--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-icon-position.gts
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-icon-position.gts
@@ -8,7 +8,7 @@ const LocalComponent: TemplateOnlyComponent = <template>
     @icon="external-link"
     @iconPosition="leading"
     @href="https://helios.hashicorp.design/"
-  >ipsum dolor</HdsLinkInline>
+  >ipsum dolor<span class="sr-only">(opens in a new window)</span></HdsLinkInline>
   sit amet consectetur adipiscing elit.
 </template>;
 

--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-icon.classic.hbs
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-icon.classic.hbs
@@ -1,3 +1,5 @@
 Lorem
-<Hds::Link::Inline @icon="external-link" @href="https://helios.hashicorp.design/">ipsum dolor</Hds::Link::Inline>
+<Hds::Link::Inline @icon="external-link" @href="https://helios.hashicorp.design/">ipsum dolor<span
+    class="sr-only"
+  >(opens in a new window)</span></Hds::Link::Inline>
 sit amet consectetur adipiscing elit.

--- a/website/docs/components/link/inline/partials/code/code-snippets/link-inline-icon.gts
+++ b/website/docs/components/link/inline/partials/code/code-snippets/link-inline-icon.gts
@@ -7,7 +7,7 @@ const LocalComponent: TemplateOnlyComponent = <template>
   <HdsLinkInline
     @icon="external-link"
     @href="https://helios.hashicorp.design/"
-  >ipsum dolor</HdsLinkInline>
+  >ipsum dolor<span class="sr-only">(opens in a new window)</span></HdsLinkInline>
   sit amet consectetur adipiscing elit.
 </template>;
 

--- a/website/docs/components/link/inline/partials/code/how-to-use.md
+++ b/website/docs/components/link/inline/partials/code/how-to-use.md
@@ -39,6 +39,13 @@ Inline Links use the generic `Hds::Interactive` component. Learn more about [how
 
 #### With `@href`
 
+!!! Warning 
+
+**Accessibility alert**
+
+For external links, we strongly recommend adding visually hidden text to indicate that the link opens in a new page or website. Use Helios's sr-only class to provide this context to screen reader users without changing the visible link text.
+!!!
+
 To generate an `<a>` link, pass an `@href` argument with a URL as the value.
 
 By default, the link is considered "external", which means that the `target=“_blank”` and `rel=“noopener noreferrer”` attributes are applied to the `<a>` element. This is the most common case, as internal links are generally handled using a `@route` argument.


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add an accessibility note about adding visually hidden text to external links. For completeness, I also  added the recommended sr-only text to all external link demos on the page.

### :camera_flash: Screenshots

<img width="827" height="342" alt="Screenshot 2026-06-17 at 1 53 12 PM" src="https://github.com/user-attachments/assets/7b8ef1e1-2edd-4f2e-8444-cca2b001c1a2" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5906](https://hashicorp.atlassian.net/browse/HDS-5906)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5906]: https://hashicorp.atlassian.net/browse/HDS-5906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ