### PR TITLE
🚧 [SPIKE] Website IA for Carbonization documentation - Possible navigational structure (to kick off the conversation)

### DIFF
--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -16,6 +16,7 @@ import type FastbootService from 'ember-cli-fastboot/services/fastboot';
 import DocCodeGroupActionBar from 'website/components/doc/code-group/action-bar';
 import DocCodeGroupExpandButton from 'website/components/doc/code-group/expand-button';
 import DocCodeGroupLanguagePicker from 'website/components/doc/code-group/language-picker';
+import DocCodeGroupThemePicker from 'website/components/doc/code-group/theme-picker';
 import DocCopyButton from 'website/components/doc/copy-button';
 import DynamicTemplate from 'website/components/dynamic-template';
 
@@ -39,6 +40,8 @@ interface DocCodeGroupSignature {
 
 type LanguageOption = { label: string; value: string };
 
+type Themes = 'hds-default' | 'carbon-light' | 'carbon-dark';
+
 const CODE_GROUP_LANGUAGE_STORAGE_KEY = 'hds-doc-code-group-language';
 const CODE_GROUP_LANGUAGE_CHANGE_EVENT = 'hds-doc-code-group-language-change';
 
@@ -53,6 +56,7 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
 
   @tracked currentView = 'hbs';
   @tracked isExpanded = false;
+  @tracked currentTheme: Themes = 'hds-default';
 
   private readonly handleRouteDidChange = () => {
     if (this.shouldSyncLanguageSelection) {
@@ -199,6 +203,18 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     return this.currentView === 'gts';
   }
 
+  get previewThemeClass() {
+    if (this.currentTheme === 'carbon-light') {
+      return 'hds-theme-light hds-mode-cds-g0';
+    }
+
+    if (this.currentTheme === 'carbon-dark') {
+      return 'hds-theme-dark hds-mode-cds-g100';
+    }
+
+    return '';
+  }
+
   get normalizedCurrentRouteName() {
     const path = this.router.currentURL?.split('?')[0] ?? '';
     return path.replace(/^\/+/, '').replace(/\/+$/, '');
@@ -211,6 +227,10 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
   getCodeLanguageEventName = (value: string) => {
     return `Code Demo Language Tab Selected - ${this.normalizedCurrentRouteName} - ${value}`;
   };
+
+  get themeEventName() {
+    return `Code Demo Theme Selected - ${this.normalizedCurrentRouteName} - ${this.currentTheme}`;
+  }
 
   get shouldSyncLanguageSelection() {
     return !!this.args.hbsSnippet && !!this.args.gtsSnippet;
@@ -236,6 +256,14 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     }
 
     return options;
+  }
+
+  get themeOptions() {
+    return [
+      { label: 'HDS Default', value: 'hds-default' },
+      { label: 'Carbon Light', value: 'carbon-light' },
+      { label: 'Carbon Dark', value: 'carbon-dark' },
+    ];
   }
 
   private getStoredLanguage() {
@@ -293,6 +321,15 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     this.isExpanded = !this.isExpanded;
   };
 
+  handleThemeChange = (event: Event) => {
+    const input = event.target as HTMLSelectElement;
+    const selectedOption = input.selectedOptions[0]?.value;
+
+    if (selectedOption) {
+      this.currentTheme = selectedOption as Themes;
+    }
+  };
+
   // NOTE: we don't have access to the code element inside the CodeBlock component, so we need to set the tabindex using query selectors (need to set tabindex because the code element can be scrollable and it needs to be focusable for keyboard users)
   setCodeElementTabIndex = modifier((element: HTMLDivElement) => {
     element.querySelector('code')?.setAttribute('tabindex', '0');
@@ -300,8 +337,18 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
 
   <template>
     <div class="doc-code-group">
+      <DocCodeGroupActionBar>
+        <:primary>
+          <DocCodeGroupThemePicker
+            @themeOptions={{this.themeOptions}}
+            @currentTheme={{this.currentTheme}}
+            @eventName={{this.themeEventName}}
+            @onThemeChange={{this.handleThemeChange}}
+          />
+        </:primary>
+      </DocCodeGroupActionBar>
       {{#if this.showPreview}}
-        <div class="doc-code-group__preview">
+        <div class="doc-code-group__preview {{this.previewThemeClass}}">
           <DynamicTemplate
             @templateString={{this.preview.templateString}}
             @componentId={{this.preview.componentId}}

--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -44,6 +44,8 @@ type Themes = 'hds-default' | 'carbon-light' | 'carbon-dark';
 
 const CODE_GROUP_LANGUAGE_STORAGE_KEY = 'hds-doc-code-group-language';
 const CODE_GROUP_LANGUAGE_CHANGE_EVENT = 'hds-doc-code-group-language-change';
+const CODE_GROUP_THEME_STORAGE_KEY = 'hds-doc-code-group-theme';
+const CODE_GROUP_THEME_CHANGE_EVENT = 'hds-doc-code-group-theme-change';
 
 // Helper to undo code escaping for display
 const unescapeCode = (code?: string) => {
@@ -75,15 +77,21 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     this.applyLanguageSelection(customEvent.detail);
   };
 
-  private readonly handleStorageEvent = (event: StorageEvent) => {
-    if (
-      !this.shouldSyncLanguageSelection ||
-      event.key !== CODE_GROUP_LANGUAGE_STORAGE_KEY
-    ) {
-      return;
-    }
+  private readonly handleStoredThemeChange = (event: Event) => {
+    const customEvent = event as CustomEvent<string>;
+    this.applyThemeSelection(customEvent.detail);
+  };
 
-    this.applyLanguageSelection(event.newValue);
+  private readonly handleStorageEvent = (event: StorageEvent) => {
+    if (event.key === CODE_GROUP_LANGUAGE_STORAGE_KEY) {
+      if (!this.shouldSyncLanguageSelection) {
+        return;
+      }
+
+      this.applyLanguageSelection(event.newValue);
+    } else if (event.key === CODE_GROUP_THEME_STORAGE_KEY) {
+      this.applyThemeSelection(event.newValue);
+    }
   };
 
   constructor(owner: Owner, args: DocCodeGroupSignature['Args']) {
@@ -94,6 +102,8 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
           this.getStoredLanguage() || this.languageOptions[0]?.value || 'hbs',
         )
       : this.languageOptions[0]?.value || 'hbs';
+
+    this.currentTheme = this.resolveThemeSelection(this.getStoredTheme());
 
     if (args.isExpanded === 'true') {
       this.isExpanded = true;
@@ -111,12 +121,21 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
         CODE_GROUP_LANGUAGE_CHANGE_EVENT,
         this.handleStoredLanguageChange,
       );
+      // this custom event is used to notify other code group instances on the page that the theme selection has changed so that they can update their selected theme too
+      window.addEventListener(
+        CODE_GROUP_THEME_CHANGE_EVENT,
+        this.handleStoredThemeChange,
+      );
       window.addEventListener('storage', this.handleStorageEvent);
 
       registerDestructor(this, () => {
         window.removeEventListener(
           CODE_GROUP_LANGUAGE_CHANGE_EVENT,
           this.handleStoredLanguageChange,
+        );
+        window.removeEventListener(
+          CODE_GROUP_THEME_CHANGE_EVENT,
+          this.handleStoredThemeChange,
         );
         window.removeEventListener('storage', this.handleStorageEvent);
       });
@@ -279,6 +298,19 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     }
   }
 
+  private getStoredTheme() {
+    if (this.fastboot.isFastBoot) {
+      return null;
+    }
+
+    try {
+      return window.localStorage.getItem(CODE_GROUP_THEME_STORAGE_KEY);
+    } catch (err) {
+      console.warn('Failed to access localStorage:', err);
+      return null;
+    }
+  }
+
   private resolveLanguageSelection(value?: string | null) {
     if (!value) {
       return this.languageOptions[0]?.value || 'hbs';
@@ -289,8 +321,18 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
       : this.languageOptions[0]?.value || 'hbs';
   }
 
+  private resolveThemeSelection(value?: string | null): Themes {
+    return this.themeOptions.some((option) => option.value === value)
+      ? (value as Themes)
+      : 'hds-default';
+  }
+
   private applyLanguageSelection(value?: string | null) {
     this.currentView = this.resolveLanguageSelection(value);
+  }
+
+  private applyThemeSelection(value?: string | null) {
+    this.currentTheme = this.resolveThemeSelection(value);
   }
 
   private persistLanguageSelection(value: string) {
@@ -301,6 +343,19 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     window.localStorage.setItem(CODE_GROUP_LANGUAGE_STORAGE_KEY, value);
     window.dispatchEvent(
       new CustomEvent(CODE_GROUP_LANGUAGE_CHANGE_EVENT, {
+        detail: value,
+      }),
+    );
+  }
+
+  private persistThemeSelection(value: string) {
+    if (this.fastboot.isFastBoot) {
+      return;
+    }
+
+    window.localStorage.setItem(CODE_GROUP_THEME_STORAGE_KEY, value);
+    window.dispatchEvent(
+      new CustomEvent(CODE_GROUP_THEME_CHANGE_EVENT, {
         detail: value,
       }),
     );
@@ -326,7 +381,7 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     const selectedOption = input.selectedOptions[0]?.value;
 
     if (selectedOption) {
-      this.currentTheme = selectedOption as Themes;
+      this.persistThemeSelection(selectedOption);
     }
   };
 
@@ -337,17 +392,17 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
 
   <template>
     <div class="doc-code-group">
-      <DocCodeGroupActionBar>
-        <:primary>
-          <DocCodeGroupThemePicker
-            @themeOptions={{this.themeOptions}}
-            @currentTheme={{this.currentTheme}}
-            @eventName={{this.themeEventName}}
-            @onThemeChange={{this.handleThemeChange}}
-          />
-        </:primary>
-      </DocCodeGroupActionBar>
       {{#if this.showPreview}}
+        <DocCodeGroupActionBar>
+          <:primary>
+            <DocCodeGroupThemePicker
+              @themeOptions={{this.themeOptions}}
+              @currentTheme={{this.currentTheme}}
+              @eventName={{this.themeEventName}}
+              @onThemeChange={{this.handleThemeChange}}
+            />
+          </:primary>
+        </DocCodeGroupActionBar>
         <div class="doc-code-group__preview {{this.previewThemeClass}}">
           <DynamicTemplate
             @templateString={{this.preview.templateString}}

--- a/website/app/components/doc/code-group/theme-picker.gts
+++ b/website/app/components/doc/code-group/theme-picker.gts
@@ -1,0 +1,48 @@
+/**
+ * Copyright IBM Corp. 2021, 2026
+ * SPDX-License-Identifier: MPL-2.0
+ */
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+import { eq } from 'ember-truth-helpers';
+import { guidFor } from '@ember/object/internals';
+
+import docTrackEvent from 'website/modifiers/doc-track-event';
+
+interface DocCodeGroupThemePickerSignature {
+  Args: {
+    themeOptions: Array<{ label: string; value: string }>;
+    currentTheme: string;
+    onThemeChange: (event: Event) => void;
+    eventName: string;
+  };
+  Element: HTMLFieldSetElement;
+}
+
+export default class DocCodeGroupThemePicker extends Component<DocCodeGroupThemePickerSignature> {
+  id = guidFor(this);
+
+  <template>
+    <div class="doc-code-group__theme-picker-container">
+      <label
+        for={{this.id}}
+        class="doc-code-group__theme-picker-label"
+      >Theme:</label>
+
+      <select
+        name="theme-picker-{{this.id}}"
+        id={{this.id}}
+        class="doc-code-group__theme-picker"
+        {{docTrackEvent triggerEvent="change" eventName=@eventName}}
+        {{on "change" @onThemeChange}}
+      >
+        {{#each @themeOptions as |optionData|}}
+          <option
+            selected={{eq @currentTheme optionData.value}}
+            value={{optionData.value}}
+          >{{optionData.label}}</option>
+        {{/each}}
+      </select>
+    </div>
+  </template>
+}

--- a/website/app/components/doc/page/sidebar.gjs
+++ b/website/app/components/doc/page/sidebar.gjs
@@ -18,7 +18,7 @@ const DEBOUNCE_MS = 250;
 // we want to limit the content of the sidebar navigation to only the links related to the current "section".
 // notice: super hacky way to do it, but... it works™ !
 const getTocSectionsBundle = (section) => {
-  const ABOUT = ['about', 'whats-new', 'getting-started'];
+  const ABOUT = ['about', 'whats-new', 'getting-started', 'carbonization'];
   const FOUNDATIONS = ['foundations', 'icons'];
   const COMPONENTS = ['components', 'layouts', 'overrides', 'utilities'];
   const CONTENT = ['content'];

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -14,6 +14,12 @@
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/website.css">
 
+    <link
+      integrity=""
+      rel="stylesheet"
+      href="{{rootURL}}assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css"
+    >
+
     <link rel="shortcut icon" href="/assets/logos/favicon.png" />
 
     {{content-for "head-footer"}}

--- a/website/app/styles/doc-components/code-group.scss
+++ b/website/app/styles/doc-components/code-group.scss
@@ -81,6 +81,46 @@ $doc-code-group-footer-height: 48px; // 32px button height + 16px bottom padding
   }
 }
 
+.doc-code-group__theme-picker-container {
+display:flex;
+flex-direction: row;
+padding: 6px;
+border-right: 1px solid var(--doc-color-gray-400);
+}
+
+.doc-code-group__theme-picker-label {
+  @include doc-font-style-body-small();
+  padding: 3.5px 6px;
+}
+
+.doc-code-group__theme-picker {
+  @include doc-font-style-body-small();
+  margin: 0;
+  padding: 4px 8px;
+  padding-right: 32px; // space for the caret icon
+  font-weight: bold;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.55 2.24a.75.75 0 0 0-1.1 0L4.2 5.74a.75.75 0 1 0 1.1 1.02L8 3.852l2.7 2.908a.75.75 0 1 0 1.1-1.02l-3.25-3.5Zm-1.1 11.52a.75.75 0 0 0 1.1 0l3.25-3.5a.75.75 0 1 0-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 0 0-1.1 1.02l3.25 3.5Z' fill='%23656A76'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 16px 16px;
+  border: none;
+  border-radius: 4px;
+  appearance: none;
+
+  &:hover {
+    background-color: var(--doc-color-gray-600);
+  }
+
+  &:active {
+    background-color: var(--doc-color-gray-500);
+  }
+
+  &:focus-within {
+    outline: none;
+    box-shadow:0 0 0 2px #2264D6;
+  }
+}
+
 .doc-code-group__secondary-actions {
   display: flex;
   flex-direction: row;
@@ -108,6 +148,18 @@ $doc-code-group-footer-height: 48px; // 32px button height + 16px bottom padding
   @include breakpoint.large () {
     padding: 32px;
   }
+}
+
+.doc-code-group__preview.hds-theme-dark {
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 70%), rgba(0, 0, 0, 70%)),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 2'%3E%3Cpath d='M1 2V0h1v1H0v1z' fill-opacity='.05'/%3E%3C/svg%3E");
+  background-repeat:
+    no-repeat,
+    repeat;
+  background-size:
+    auto,
+    16px 16px;
 }
 
 // Optional separator for rendered code examples

--- a/website/app/styles/pages/application/tabs.scss
+++ b/website/app/styles/pages/application/tabs.scss
@@ -85,4 +85,28 @@
       color: var(--doc-color-black);
     }
   }
+
+  // special treatment for the "carbonization" tab
+  button#tab-carbonization {
+    padding-left: 24px;
+    color: #4589ff;
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><path d="M13.5 30.815a1 1 0 0 1-.493-.13l-8.5-4.815A1 1 0 0 1 4 25V15a1 1 0 0 1 .507-.87l8.5-4.815a1 1 0 0 1 .986 0l8.5 4.815A1 1 0 0 1 23 15v10a1 1 0 0 1-.507.87l-8.5 4.815a1 1 0 0 1-.493.13M6 24.417l7.5 4.249 7.5-4.249v-8.834l-7.5-4.248L6 15.583Z"/><path d="M28 17h-2V7.583l-7.5-4.248-8.007 4.535-.986-1.74 8.5-4.815a1 1 0 0 1 .986 0l8.5 4.815A1 1 0 0 1 28 7Z"/></svg>');
+    background-repeat: no-repeat;
+    background-position: 4px 50%;
+    background-size: 16px 16px;
+
+    &:hover {
+      color: #0f62fe;
+    }
+  }
+
+  &.doc-page-tabs__tab--is-current:has(button#tab-carbonization) {
+    &::after {
+      background-color: #0f62fe;
+    }
+
+    button#tab-carbonization {
+      color: #0f62fe;
+    }
+  }
 }

--- a/website/docs/carbonization/for-designers.md
+++ b/website/docs/carbonization/for-designers.md
@@ -1,0 +1,38 @@
+---
+title: Carbonization for designers
+navigation:
+  order: 102
+  label: Carbonization for designers
+---
+
+## Lorem ipsum
+
+What would this page contain?
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+

--- a/website/docs/carbonization/for-engineers.md
+++ b/website/docs/carbonization/for-engineers.md
@@ -1,0 +1,38 @@
+---
+title: Carbonization for engineers
+navigation:
+  order: 103
+  label: Carbonization for engineers
+---
+
+## Lorem ipsum
+
+What would this page contain?
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+

--- a/website/docs/carbonization/introduction.md
+++ b/website/docs/carbonization/introduction.md
@@ -1,0 +1,38 @@
+---
+title: From Helios to Carbon
+navigation:
+  order: 101
+  label: From Helios to Carbon
+---
+
+## Lorem ipsum
+
+What would this page contain?
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+

--- a/website/docs/components/accordion/index.md
+++ b/website/docs/components/accordion/index.md
@@ -50,3 +50,7 @@ navigation:
 <section data-tab="Version history">
   @include "partials/version-history/version-history.md"
 </section>
+
+<section data-tab="Carbonization">
+  @include "partials/carbonization/index.md"
+</section>

--- a/website/docs/components/accordion/partials/carbonization/index.md
+++ b/website/docs/components/accordion/partials/carbonization/index.md
@@ -1,0 +1,31 @@
+## Carbonization
+
+What would this page contain?
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+.
+
+

--- a/website/docs/foundations/colors/index.js
+++ b/website/docs/foundations/colors/index.js
@@ -7,6 +7,16 @@ import Component from '@glimmer/component';
 
 import TOKENS_RAW from '@hashicorp/design-system-tokens/dist/docs/products/tokens.json';
 
+const COLOR_TOKEN_CATEGORIES = [
+  'core',
+  'foreground',
+  'surface',
+  'border',
+  'focus',
+  'page',
+  'product'
+];
+
 export default class Colors extends Component {
   get colors() {
     const colors = {
@@ -16,9 +26,9 @@ export default class Colors extends Component {
     };
 
     TOKENS_RAW.forEach((token) => {
-      if (token.attributes.category === 'color' && !token.deprecated) {
+      if (COLOR_TOKEN_CATEGORIES.includes(token.attributes.category) && !token.deprecated) {
         if (token.group) {
-          if (token.group === 'palette') {
+          if (token.group === 'core') {
             // notice: we expect the color name to always follow a specific naming pattern (eg. 'blue-200')
             const tone = token.path[2].match(/^(\w+)-(\d+)$/)[1];
             if (!colors['palette'][tone]) {
@@ -31,19 +41,18 @@ export default class Colors extends Component {
               value: token.$value,
             });
           } else if (token.group === 'semantic') {
-            const context = token.path[1];
+            const context = token.path[0];
             if (!colors['semantic'][context]) {
               colors['semantic'][context] = [];
             }
             const tokenObj = {
-              colorName: token.path.slice(1).join('-'),
+              colorName: token.path.slice().join('-'),
               cssVariable: `--${token.name}`,
               // note: we prefix `value` with `$` because we're using the DTCG format
               value: token.$value,
             };
             if (['foreground', 'page', 'surface', 'border'].includes(context)) {
-              const name = token.path[2];
-              tokenObj.cssHelper = `hds-${context}-${name}`;
+              tokenObj.cssHelper = token.name;
             }
             colors['semantic'][context].push(tokenObj);
           } else if (token.group === 'branding') {
@@ -52,7 +61,7 @@ export default class Colors extends Component {
               colors['branding'][brand] = [];
             }
             colors['branding'][brand].push({
-              colorName: token.path.slice(1).join('-'),
+              colorName: token.path.slice().join('-'),
               cssVariable: `--${token.name}`,
               // note: we prefix `value` with `$` because we're using the DTCG format
               value: token.$value,

--- a/website/ember-cli-build.js
+++ b/website/ember-cli-build.js
@@ -46,5 +46,13 @@ module.exports = function (defaults) {
     },
   });
 
+  app.import(
+    'node_modules/@hashicorp/design-system-tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css',
+    {
+      outputFile:
+        'assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css',
+    },
+  );
+
   return app.toTree();
 };

--- a/website/tests/index.html
+++ b/website/tests/index.html
@@ -16,6 +16,10 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/website.css">
+    <link
+      rel="stylesheet"
+      href="{{rootURL}}assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css"
+    >
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}


### PR DESCRIPTION
> [!WARNING]
> **Note**: DO NOT MERGE

### :pushpin: Summary

This is a spike to kick off the conversation about how we could update the website to include informations about the carbonization of our components, and provide useful guidance to our consumers about it

At the same time, I wanted also to understand how easy it would be to make these changes, which by the first exploration looks quite easy (if the idea of having dedicated sections/pages is something we're all OK with). It's just™ a matter of understanding how we want to structure/organize the content and what the pages should contain.

### 👀 Previews (placeholders)

**About**
- [From Helios to Carbon](https://hds-website-git-project-solar-phase-1mock-website-ia-hashicorp.vercel.app/carbonization/introduction)
- [Carbonization for designers](https://hds-website-git-project-solar-phase-1mock-website-ia-hashicorp.vercel.app/carbonization/for-designers)
- [Carbonization for engineers](https://hds-website-git-project-solar-phase-1mock-website-ia-hashicorp.vercel.app/carbonization/for-engineers)

**Components**
- [Accordion > "Carbonization" tab](https://hds-website-git-project-solar-phase-1mock-website-ia-hashicorp.vercel.app/components/accordion?tab=carbonization)