### PR TITLE
`Alert` - Web docs for Generic content blocks (HDS-6287)

### DIFF
--- a/website/docs/components/alert/partials/code/code-snippets/alert-generic.classic.hbs
+++ b/website/docs/components/alert/partials/code/code-snippets/alert-generic.classic.hbs
@@ -1,7 +1,12 @@
 <Hds::Alert @type="inline" as |A|>
   <A.Title>Title here</A.Title>
   <A.Description>Description here</A.Description>
-  <A.Generic>
-    [your content here]
-  </A.Generic>
+  <A.GenericContent>
+    [your custom content here]
+  </A.GenericContent>
+  <A.Button @text="Your action" @color="secondary" {{on "click" this.yourOnClickFunction}} />
+  <A.LinkStandalone @color="secondary" @icon="arrow-right" @iconPosition="trailing" @text="Another action" @href="#" />
+  <A.GenericFooter>
+    [your custom footer here]
+  </A.GenericFooter>
 </Hds::Alert>

--- a/website/docs/components/alert/partials/code/code-snippets/alert-generic.classic.js
+++ b/website/docs/components/alert/partials/code/code-snippets/alert-generic.classic.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class LocalComponent extends Component {
+  @action
+  yourOnClickFunction() {
+    console.log('Clicked the button in the "alert"!');
+  }
+}

--- a/website/docs/components/alert/partials/code/code-snippets/alert-generic.gts
+++ b/website/docs/components/alert/partials/code/code-snippets/alert-generic.gts
@@ -1,15 +1,34 @@
-import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
 
 import { HdsAlert } from '@hashicorp/design-system-components/components';
 
-const LocalComponent: TemplateOnlyComponent = <template>
-  <HdsAlert @type="inline" as |A|>
-    <A.Title>Title here</A.Title>
-    <A.Description>Description here</A.Description>
-    <A.Generic>
-      [your content here]
-    </A.Generic>
-  </HdsAlert>
-</template>;
-
-export default LocalComponent;
+export default class LocalComponent extends Component {
+  yourOnClickFunction = () => {
+    console.log('Clicked the button in the "alert"!');
+  };
+  <template>
+    <HdsAlert @type="inline" as |A|>
+      <A.Title>Title here</A.Title>
+      <A.Description>Description here</A.Description>
+      <A.GenericContent>
+        [your custom content here]
+      </A.GenericContent>
+      <A.Button
+        @text="Your action"
+        @color="secondary"
+        {{on "click" this.yourOnClickFunction}}
+      />
+      <A.LinkStandalone
+        @color="secondary"
+        @icon="arrow-right"
+        @iconPosition="trailing"
+        @text="Another action"
+        @href="#"
+      />
+      <A.GenericFooter>
+        [your custom footer here]
+      </A.GenericFooter>
+    </HdsAlert>
+  </template>
+}

--- a/website/docs/components/alert/partials/code/component-api.md
+++ b/website/docs/components/alert/partials/code/component-api.md
@@ -15,6 +15,9 @@
   <C.Property @name="<[A].LinkStandalone>" @type="yielded component">
     `Link::Standalone` yielded as contextual component (see below).
   </C.Property>
+  <C.Property @name="<[A].Generic>" @type="yielded component" @deprecated={{true}}>
+    A generic container yielded as contextual component (see below).
+  </C.Property>
   <C.Property @name="<[A].GenericContent>" @type="yielded component">
     A generic container yielded as contextual component (see below).
   </C.Property>

--- a/website/docs/components/alert/partials/code/component-api.md
+++ b/website/docs/components/alert/partials/code/component-api.md
@@ -15,7 +15,10 @@
   <C.Property @name="<[A].LinkStandalone>" @type="yielded component">
     `Link::Standalone` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[A].Generic>" @type="yielded component">
+  <C.Property @name="<[A].GenericContent>" @type="yielded component">
+    A generic container yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[A].GenericFooter>" @type="yielded component">
     A generic container yielded as contextual component (see below).
   </C.Property>
   <C.Property @name="type" @required={{true}} @type="enum" @values={{array "page" "inline" "compact"}}>
@@ -88,9 +91,20 @@ The `Link::Standalone` component, yielded as contextual component inside the `"a
   </C.Property>
 </Doc::ComponentApi>
 
-#### [A].Generic
+#### [A].GenericContent
 
-A generic container, yielded as contextual component.
+A generic container, yielded as contextual component which renders below the Title and Description and above any Actions.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="yield">
+    Elements passed as children are yielded after all the other elements.
+    <br/>The content is unstyled by default, so consumers will need to take care of layout and style of the content.
+  </C.Property>
+</Doc::ComponentApi>
+
+#### [A].GenericFooter
+
+A generic container, yielded as contextual component which at the bottom of Alert content and below any Actions.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="yield">

--- a/website/docs/components/alert/partials/code/how-to-use.md
+++ b/website/docs/components/alert/partials/code/how-to-use.md
@@ -78,6 +78,6 @@ You can pass more than one `D.Description` contextual component to have multiple
 
 ### Generic content
 
-Use the `Generic` contextual component to insert custom content. Generic content will appear after the title, description, and actions. Application teams will need to implement spacing, layout, and styling for generic content.
+Use the `GenericContent` and `GenericFooter` contextual components to insert custom content. Generic Content will appear after the Title and Description and above the Actions while the Generic Footer will appear at the bottom of the Alert content below the actions. Application teams will need to implement spacing, layout, and styling for generic content.
 
 [[code-snippets/alert-generic]]


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR update the web documentaion for the `Alert` component to document the new `GenericContent` and `GenericFooter` yielded blocks which replace the deprecated `Generic` block.

**Preview**: https://hds-website-git-kristin-hds-6287-alert-docs-update-hashicorp.vercel.app/components/alert?tab=code#generic-content

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :copilot: Copilot instructions
Specific instructions for Copilot when reviewing the PR
-->

### :camera_flash: Screenshots

<img width="851" height="795" alt="image" src="https://github.com/user-attachments/assets/cb95408f-e6f5-424d-bc22-a65363535d2c" />

**_API docs_**:
<img width="857" height="273" alt="image" src="https://github.com/user-attachments/assets/b8e9b20b-158d-4626-a8fa-44997a2bff79" />

<img width="856" height="563" alt="image" src="https://github.com/user-attachments/assets/c34c51d3-53ff-402e-86d2-22803f996fea" />

### :link: External links

* Jira ticket: [HDS-6287](https://hashicorp.atlassian.net/browse/HDS-6287)

***

### :eyes: Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))~~

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6287]: https://hashicorp.atlassian.net/browse/HDS-6287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ