### PR TITLE
[Project Solar / Phase 1 / Follow-up] Include declarations for CSS `color-scheme` properties in generated token files

### DIFF
--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -2,6 +2,55 @@
  * Do not edit directly, this file was auto-generated.
  */
 
+/*
+
+COLOR SCHEMES
+
+These `color-scheme` declarations make native UI (scrollbars, form controls, etc.) adapt to the active theme/mode.
+
+Known platform limitations: some OS-drawn widgets (eg. the native `<select>` popup on macOS) always follow the OS appearance, regardless of `color-scheme`.
+With `.hds-theme-system` this matches (it defers to the OS anyway), but `.hds-theme-light`/`.hds-theme-dark` color schemes are ignored for these widgets.
+This is by "CSS Color Adjustment Module Level 1" specs (the scheme is "negotiated" with the OS) and cannot be controlled via CSS; everything else adapts correctly.
+
+*/
+
+:root {
+  color-scheme: light;
+}
+.hds-theme-system {
+  color-scheme: light dark;
+}
+.hds-theme-light {
+  color-scheme: light;
+}
+.hds-theme-dark {
+  color-scheme: dark;
+}
+.hds-theme-default {
+  color-scheme: light;
+}
+.hds-mode-cds-g0 {
+  color-scheme: light;
+}
+.hds-mode-cds-g10 {
+  color-scheme: light;
+}
+.hds-mode-cds-g90 {
+  color-scheme: dark;
+}
+.hds-mode-cds-g100 {
+  color-scheme: dark;
+}
+
+/*
+
+DESIGN TOKENS (CSS VARIABLES) FOR THE DIFFERENT THEMES/MODES
+
+The declarations below define the value of each design token (CSS variable) for every theme/mode,
+scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
+
+*/
+
 :root,
 .hds-theme-default {
   --token-accordion-card-gap-large: 12px;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
@@ -2,6 +2,43 @@
  * Do not edit directly, this file was auto-generated.
  */
 
+/*
+
+COLOR SCHEMES
+
+These `color-scheme` declarations make native UI (scrollbars, form controls, etc.) adapt to the active theme/mode.
+
+Known platform limitations: some OS-drawn widgets (eg. the native `<select>` popup on macOS) always follow the OS appearance, regardless of `color-scheme`.
+With `.hds-theme-system` this matches (it defers to the OS anyway), but `.hds-theme-light`/`.hds-theme-dark` color schemes are ignored for these widgets.
+This is by "CSS Color Adjustment Module Level 1" specs (the scheme is "negotiated" with the OS) and cannot be controlled via CSS; everything else adapts correctly.
+
+*/
+
+:root {
+  color-scheme: light;
+}
+.hds-theme-system {
+  color-scheme: light dark;
+}
+.hds-theme-light {
+  color-scheme: light;
+}
+.hds-theme-dark {
+  color-scheme: dark;
+}
+.hds-theme-default {
+  color-scheme: light;
+}
+
+/*
+
+DESIGN TOKENS (CSS VARIABLES) FOR THE DIFFERENT THEMES/MODES
+
+The declarations below define the value of each design token (CSS variable) for every theme/mode,
+scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
+
+*/
+
 :root,
 .hds-theme-default {
   --token-accordion-card-gap-large: 12px;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
@@ -2,6 +2,40 @@
  * Do not edit directly, this file was auto-generated.
  */
 
+/*
+
+COLOR SCHEMES
+
+These `color-scheme` declarations make native UI (scrollbars, form controls, etc.) adapt to the active theme/mode.
+
+Known platform limitations: some OS-drawn widgets (eg. the native `<select>` popup on macOS) always follow the OS appearance, regardless of `color-scheme`.
+With `.hds-theme-system` this matches (it defers to the OS anyway), but `.hds-theme-light`/`.hds-theme-dark` color schemes are ignored for these widgets.
+This is by "CSS Color Adjustment Module Level 1" specs (the scheme is "negotiated" with the OS) and cannot be controlled via CSS; everything else adapts correctly.
+
+*/
+
+:root {
+  color-scheme: light;
+}
+.hds-theme-system {
+  color-scheme: light dark;
+}
+.hds-theme-light {
+  color-scheme: light;
+}
+.hds-theme-dark {
+  color-scheme: dark;
+}
+
+/*
+
+DESIGN TOKENS (CSS VARIABLES) FOR THE DIFFERENT THEMES/MODES
+
+The declarations below define the value of each design token (CSS variable) for every theme/mode,
+scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
+
+*/
+
 :root {
   --token-accordion-card-gap-large: 0px;
   --token-accordion-card-gap-medium: 0px;

--- a/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
@@ -1049,6 +1049,8 @@
 
 @mixin hds-theme-light() {
   :root {
+    color-scheme: light;
+
     --token-accordion-card-gap-large: 0px;
     --token-accordion-card-gap-medium: 0px;
     --token-accordion-card-gap-small: 0px;
@@ -1673,6 +1675,8 @@
 
 @mixin hds-theme-dark() {
   :root {
+    color-scheme: dark;
+
     --token-accordion-card-gap-large: 0px;
     --token-accordion-card-gap-medium: 0px;
     --token-accordion-card-gap-small: 0px;
@@ -2297,6 +2301,8 @@
 
 @mixin hds-mode-cds0() {
   :root {
+    color-scheme: light;
+
     --token-accordion-card-gap-large: 0px;
     --token-accordion-card-gap-medium: 0px;
     --token-accordion-card-gap-small: 0px;
@@ -2921,6 +2927,8 @@
 
 @mixin hds-mode-cds10() {
   :root {
+    color-scheme: light;
+
     --token-accordion-card-gap-large: 0px;
     --token-accordion-card-gap-medium: 0px;
     --token-accordion-card-gap-small: 0px;
@@ -3545,6 +3553,8 @@
 
 @mixin hds-mode-cds90() {
   :root {
+    color-scheme: dark;
+
     --token-accordion-card-gap-large: 0px;
     --token-accordion-card-gap-medium: 0px;
     --token-accordion-card-gap-small: 0px;
@@ -4169,6 +4179,8 @@
 
 @mixin hds-mode-cds100() {
   :root {
+    color-scheme: dark;
+
     --token-accordion-card-gap-large: 0px;
     --token-accordion-card-gap-medium: 0px;
     --token-accordion-card-gap-small: 0px;

--- a/packages/tokens/scripts/build-parts/generateThemingCssFiles.ts
+++ b/packages/tokens/scripts/build-parts/generateThemingCssFiles.ts
@@ -33,8 +33,12 @@ export async function generateThemingCssFiles(_dictionary: Dictionary, config: P
     if (method.startsWith('css-selectors')) {
 
       // emit the `color-scheme` declarations up-front, so native UI (scrollbars, form controls, etc.) matches the active theme/mode
+      // note: the `--migration`/`--advanced` formats also output the `.hds-theme-default` tokens, so we declare its scheme too
       // note: the `--advanced` format also exposes the explicit `.hds-mode-cds-*` selectors, so we declare their scheme too
       const colorSchemeSelectors = [':root', '.hds-theme-system', '.hds-theme-light', '.hds-theme-dark'];
+      if (method === 'css-selectors--migration' || method === 'css-selectors--advanced') {
+        colorSchemeSelectors.push('.hds-theme-default');
+      }
       if (method === 'css-selectors--advanced') {
         colorSchemeSelectors.push('.hds-mode-cds-g0', '.hds-mode-cds-g10', '.hds-mode-cds-g90', '.hds-mode-cds-g100');
       }
@@ -113,8 +117,10 @@ function withColorScheme(source: string, value: string): string {
 
 // the `color-scheme` value to use for each theme/mode selector
 const COLOR_SCHEME_BY_SELECTOR: Record<string, string> = {
-  // support both schemes, so the document-level scrollbar and any unthemed surface follow the OS preference by default
-  ':root': 'light dark',
+  // the `:root` fallback tokens are always light (`cds-g0`/HDS default), so force `light` to keep native controls in sync
+  ':root': 'light',
+  // the `default` theme uses the (light) standard HDS tokens, so force `light` to match
+  '.hds-theme-default': 'light',
   // declare support for both schemes, so native controls resolve via the OS `prefers-color-scheme` setting automatically
   '.hds-theme-system': 'light dark',
   // force light/dark-rendered native controls, so they match the explicitly chosen theme

--- a/packages/tokens/scripts/build-parts/generateThemingCssFiles.ts
+++ b/packages/tokens/scripts/build-parts/generateThemingCssFiles.ts
@@ -32,6 +32,17 @@ export async function generateThemingCssFiles(_dictionary: Dictionary, config: P
     // CSS file for combined `system/light/dark` themes in the same file (using `.class` selectors)
     if (method.startsWith('css-selectors')) {
 
+      // emit the `color-scheme` declarations up-front, so native UI (scrollbars, form controls, etc.) matches the active theme/mode
+      // note: the `--advanced` format also exposes the explicit `.hds-mode-cds-*` selectors, so we declare their scheme too
+      const colorSchemeSelectors = [':root', '.hds-theme-system', '.hds-theme-light', '.hds-theme-dark'];
+      if (method === 'css-selectors--advanced') {
+        colorSchemeSelectors.push('.hds-mode-cds-g0', '.hds-mode-cds-g10', '.hds-mode-cds-g90', '.hds-mode-cds-g100');
+      }
+      outputContent += getColorSchemeDeclarations(colorSchemeSelectors);
+
+      // add an intro comment for the tokens that acts as a separator
+      outputContent += getDesignTokensIntroComment();
+
       // this is the `:root`-only fallback if no theme is applied at all (we use the light/`cds-g0` mode)
       if (method === 'css-selectors') {
         outputContent += `${cds0ThemedSource}\n\n`;
@@ -74,13 +85,14 @@ export async function generateThemingCssFiles(_dictionary: Dictionary, config: P
     // SCSS file for mixins
     if (method === 'scss-mixins') {
       // these are the mixins that can be used to include the "themed" tokens
+      // note: each themed mixin also injects a matching `color-scheme` (so native UI follows the theme/mode), while the `default` mixin is left as-is
       outputContent += `@mixin hds-theme-default() { ${defaultThemedSource} }\n\n`;
-      outputContent += `@mixin hds-theme-light() { ${cds0ThemedSource} }\n\n`;
-      outputContent += `@mixin hds-theme-dark() { ${cds100ThemedSource} }\n\n`;
-      outputContent += `@mixin hds-mode-cds0() { ${cds0ThemedSource} }\n\n`;
-      outputContent += `@mixin hds-mode-cds10() { ${cds10ThemedSource} }\n\n`;
-      outputContent += `@mixin hds-mode-cds90() { ${cds90ThemedSource} }\n\n`;
-      outputContent += `@mixin hds-mode-cds100() { ${cds100ThemedSource} }\n\n`;
+      outputContent += `@mixin hds-theme-light() { ${withColorScheme(cds0ThemedSource, 'light')} }\n\n`;
+      outputContent += `@mixin hds-theme-dark() { ${withColorScheme(cds100ThemedSource, 'dark')} }\n\n`;
+      outputContent += `@mixin hds-mode-cds0() { ${withColorScheme(cds0ThemedSource, 'light')} }\n\n`;
+      outputContent += `@mixin hds-mode-cds10() { ${withColorScheme(cds10ThemedSource, 'light')} }\n\n`;
+      outputContent += `@mixin hds-mode-cds90() { ${withColorScheme(cds90ThemedSource, 'dark')} }\n\n`;
+      outputContent += `@mixin hds-mode-cds100() { ${withColorScheme(cds100ThemedSource, 'dark')} }\n\n`;
 
       // this is the mixin that needs to be used to include the common tokens, shared across themes
       outputContent += `@mixin hds-theme-common() { ${commonSource} }\n\n`;
@@ -92,6 +104,60 @@ export async function generateThemingCssFiles(_dictionary: Dictionary, config: P
     await fs.ensureDir(outputFolder);
     await fs.writeFile(`${outputFolder}tokens.css`, outputTokensCss);
   }
+}
+
+// injects a `color-scheme` declaration as the first property inside the leading `:root` block of a source (used by the SCSS "mixins" format)
+function withColorScheme(source: string, value: string): string {
+  return source.replace(/^:root\s*{/, `:root {\n  color-scheme: ${value};\n`);
+}
+
+// the `color-scheme` value to use for each theme/mode selector
+const COLOR_SCHEME_BY_SELECTOR: Record<string, string> = {
+  // support both schemes, so the document-level scrollbar and any unthemed surface follow the OS preference by default
+  ':root': 'light dark',
+  // declare support for both schemes, so native controls resolve via the OS `prefers-color-scheme` setting automatically
+  '.hds-theme-system': 'light dark',
+  // force light/dark-rendered native controls, so they match the explicitly chosen theme
+  '.hds-theme-light': 'light',
+  '.hds-theme-dark': 'dark',
+  // align each Carbon mode with its lightness
+  '.hds-mode-cds-g0': 'light',
+  '.hds-mode-cds-g10': 'light',
+  '.hds-mode-cds-g90': 'dark',
+  '.hds-mode-cds-g100': 'dark',
+};
+
+// builds a block of standalone `color-scheme` rules for the given selectors
+function getColorSchemeDeclarations(selectors: string[]): string {
+  let comment = '';
+  comment += '\n/*\n\n';
+  comment += 'COLOR SCHEMES\n';
+  comment += '\n';
+  comment += 'These `color-scheme` declarations make native UI (scrollbars, form controls, etc.) adapt to the active theme/mode.\n';
+  comment += '\n';
+  comment += 'Known platform limitations: some OS-drawn widgets (eg. the native `<select>` popup on macOS) always follow the OS appearance, regardless of `color-scheme`.\n';
+  comment += 'With `.hds-theme-system` this matches (it defers to the OS anyway), but `.hds-theme-light`/`.hds-theme-dark` color schemes are ignored for these widgets.\n';
+  comment += 'This is by "CSS Color Adjustment Module Level 1" specs (the scheme is "negotiated" with the OS) and cannot be controlled via CSS; everything else adapts correctly.\n';
+  comment += '\n*/\n';
+
+  let code = '';
+  for (const selector of selectors) {
+    code += `${selector} { color-scheme: ${COLOR_SCHEME_BY_SELECTOR[selector]}; }\n`;
+  }
+
+  return `${comment}\n${code}\n`;
+}
+
+function getDesignTokensIntroComment(): string {
+  let comment = '';
+  comment += '\n/*\n\n';
+  comment += 'DESIGN TOKENS (CSS VARIABLES) FOR THE DIFFERENT THEMES/MODES\n';
+  comment += '\n';
+  comment += 'The declarations below define the value of each design token (CSS variable) for every theme/mode,\n';
+  comment += 'scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.\n';
+  comment += '\n*/\n';
+
+  return `${comment}\n`;
 }
 
 function getCssVariablesStalenessComment(): string {

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -2,6 +2,55 @@
  * Do not edit directly, this file was auto-generated.
  */
 
+/*
+
+COLOR SCHEMES
+
+These `color-scheme` declarations make native UI (scrollbars, form controls, etc.) adapt to the active theme/mode.
+
+Known platform limitations: some OS-drawn widgets (eg. the native `<select>` popup on macOS) always follow the OS appearance, regardless of `color-scheme`.
+With `.hds-theme-system` this matches (it defers to the OS anyway), but `.hds-theme-light`/`.hds-theme-dark` color schemes are ignored for these widgets.
+This is by "CSS Color Adjustment Module Level 1" specs (the scheme is "negotiated" with the OS) and cannot be controlled via CSS; everything else adapts correctly.
+
+*/
+
+:root {
+  color-scheme: light;
+}
+.hds-theme-system {
+  color-scheme: light dark;
+}
+.hds-theme-light {
+  color-scheme: light;
+}
+.hds-theme-dark {
+  color-scheme: dark;
+}
+.hds-theme-default {
+  color-scheme: light;
+}
+.hds-mode-cds-g0 {
+  color-scheme: light;
+}
+.hds-mode-cds-g10 {
+  color-scheme: light;
+}
+.hds-mode-cds-g90 {
+  color-scheme: dark;
+}
+.hds-mode-cds-g100 {
+  color-scheme: dark;
+}
+
+/*
+
+DESIGN TOKENS (CSS VARIABLES) FOR THE DIFFERENT THEMES/MODES
+
+The declarations below define the value of each design token (CSS variable) for every theme/mode,
+scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
+
+*/
+
 :root,
 .hds-theme-default {
   --token-accordion-card-gap-large: 12px;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
@@ -2,6 +2,43 @@
  * Do not edit directly, this file was auto-generated.
  */
 
+/*
+
+COLOR SCHEMES
+
+These `color-scheme` declarations make native UI (scrollbars, form controls, etc.) adapt to the active theme/mode.
+
+Known platform limitations: some OS-drawn widgets (eg. the native `<select>` popup on macOS) always follow the OS appearance, regardless of `color-scheme`.
+With `.hds-theme-system` this matches (it defers to the OS anyway), but `.hds-theme-light`/`.hds-theme-dark` color schemes are ignored for these widgets.
+This is by "CSS Color Adjustment Module Level 1" specs (the scheme is "negotiated" with the OS) and cannot be controlled via CSS; everything else adapts correctly.
+
+*/
+
+:root {
+  color-scheme: light;
+}
+.hds-theme-system {
+  color-scheme: light dark;
+}
+.hds-theme-light {
+  color-scheme: light;
+}
+.hds-theme-dark {
+  color-scheme: dark;
+}
+.hds-theme-default {
+  color-scheme: light;
+}
+
+/*
+
+DESIGN TOKENS (CSS VARIABLES) FOR THE DIFFERENT THEMES/MODES
+
+The declarations below define the value of each design token (CSS variable) for every theme/mode,
+scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
+
+*/
+
 :root,
 .hds-theme-default {
   --token-accordion-card-gap-large: 12px;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
@@ -2,6 +2,40 @@
  * Do not edit directly, this file was auto-generated.
  */
 
+/*
+
+COLOR SCHEMES
+
+These `color-scheme` declarations make native UI (scrollbars, form controls, etc.) adapt to the active theme/mode.
+
+Known platform limitations: some OS-drawn widgets (eg. the native `<select>` popup on macOS) always follow the OS appearance, regardless of `color-scheme`.
+With `.hds-theme-system` this matches (it defers to the OS anyway), but `.hds-theme-light`/`.hds-theme-dark` color schemes are ignored for these widgets.
+This is by "CSS Color Adjustment Module Level 1" specs (the scheme is "negotiated" with the OS) and cannot be controlled via CSS; everything else adapts correctly.
+
+*/
+
+:root {
+  color-scheme: light;
+}
+.hds-theme-system {
+  color-scheme: light dark;
+}
+.hds-theme-light {
+  color-scheme: light;
+}
+.hds-theme-dark {
+  color-scheme: dark;
+}
+
+/*
+
+DESIGN TOKENS (CSS VARIABLES) FOR THE DIFFERENT THEMES/MODES
+
+The declarations below define the value of each design token (CSS variable) for every theme/mode,
+scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
+
+*/
+
 :root {
   --token-accordion-card-gap-large: 0px;
   --token-accordion-card-gap-medium: 0px;


### PR DESCRIPTION
### :pushpin: Summary

Small PR that stems from looking at [this code implementation](https://github.com/universal-ember/ember-primitives/blob/main/ember-primitives/src/color-scheme.ts), and [this documentation](https://ember-primitives.pages.dev/6-utils/color-scheme).

I have asked Copilot how I could add the `color-scheme` definitions to the generated CSS files that contain the tokens and the theme/mode CSS selectors that are used to switch between different themes/modes, and if this would be beneficial.

<img width="604" height="440" alt="screenshot_6633" src="https://github.com/user-attachments/assets/abdfa7cb-b261-4575-abcf-32a16b71c337" />

This PR is the result of a few iterations over this idea. This will help also the work that @KristinLBradley is doing in https://github.com/hashicorp/design-system/pull/3911

### :hammer_and_wrench: Detailed description

In this PR I have:
- updated the `generateThemingCssFiles` functions to include declarations for CSS `color-scheme` properties
- re-generated the files in output

**Preview** (try to change theme via selector as well as via OS preferences):
https://hds-showcase-git-project-solar-phase-1hds-5701-962ff3-hashicorp.vercel.app/components/form/text-input

_Note: the `<select>` popup responds only to the theming set via `system`, not via class name; it's a known "thing" and there's not much we can do about it (from what I've read online and what Copilot has inferred)_

### :camera_flash: Screenshots

Before (this applies to all the input element like date, datetime, week, etc (see for yourself in the showcase page):
<img width="1149" height="520" alt="screenshot_6634" src="https://github.com/user-attachments/assets/db9cac7d-1295-4e13-8c33-af6a33b3bb4f" />

After:
<img width="1154" height="521" alt="screenshot_6635" src="https://github.com/user-attachments/assets/8f47cb64-8d98-4e94-964e-b763225dc408" />

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-5701
MDN docs: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/color-scheme

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>