### PR TITLE
Website: actually render GTS code snippets in code previews

### DIFF
--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -120,15 +120,50 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     }
   }
 
-  // NOTE: the dynamic template requires a component to render a preview. If there is not a component (ex. only a sass/yaml/bash snippet), we hide the preview by default.
+  // NOTE: the dynamic template requires an Ember component to render a preview. If there is not a component (ex. only a sass/yaml/bash snippet), we hide the preview by default.
   get hidePreview() {
-    const hasRenderablePreview =
-      (this.args.hbsSnippet && this.args.hbsSnippet !== '') ||
-      (this.args.gtsSnippet &&
-        this.args.gtsSnippet !== '' &&
-        this.args.filename);
+    if (this.args.hidePreview === 'true') {
+      return true;
+    }
 
-    return !hasRenderablePreview || this.args.hidePreview === 'true';
+    const hasHbsPreview = this.hasSnippet(this.args.hbsSnippet);
+    const hasGtsPreview =
+      this.hasSnippet(this.args.gtsSnippet) && !!this.gtsPreviewComponentId;
+
+    return !(hasHbsPreview || hasGtsPreview);
+  }
+
+  private hasSnippet(snippet?: string) {
+    return !!snippet && snippet !== '';
+  }
+
+  get classicPreviewComponentId() {
+    return this.hasSnippet(this.args.filename) ? this.args.filename : undefined;
+  }
+
+  get gtsPreviewComponentId() {
+    return this.hasSnippet(this.args.gtsFilename)
+      ? this.args.gtsFilename
+      : undefined;
+  }
+
+  get previewMode() {
+    if (
+      this.currentView === 'gts' &&
+      this.hasSnippet(this.args.gtsSnippet) &&
+      this.gtsPreviewComponentId
+    ) {
+      return 'component-module';
+    }
+
+    if (
+      (this.currentView === 'hbs' || this.currentView === 'js') &&
+      this.hasSnippet(this.args.hbsSnippet)
+    ) {
+      return 'runtime-template';
+    }
+
+    return null;
   }
 
   get hbsSnippet() {
@@ -157,35 +192,21 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
   }
 
   get previewTemplateString() {
-    // For .gts view, the preview comes from a real component module (via
-    // `@componentId`), so we intentionally skip passing a runtime template.
-    if (this.currentView === 'gts' && this.args.gtsSnippet !== '') {
-      return undefined;
-    }
-
-    return this.hbsSnippet === '' ? undefined : this.hbsSnippet;
+    return this.previewMode === 'runtime-template'
+      ? this.hbsSnippet
+      : undefined;
   }
 
   get previewComponentId() {
-    const { filename, gtsFilename } = this.args;
-
-    if (!filename) {
-      return undefined;
+    if (this.previewMode === 'component-module') {
+      return this.gtsPreviewComponentId;
     }
 
-    if (this.currentView === 'gts' && this.args.gtsSnippet !== '') {
-      if (gtsFilename && gtsFilename !== '') {
-        // .gts demos can live under a different component file than the .hbs
-        // classic demo, so prefer an explicit gts filename when provided.
-        return gtsFilename;
-      }
-
-      // Fallback: map `foo.classic` docs entries to the colocated modern
-      // component id (`foo`) used by the .gts demo implementation.
-      return filename.replace(/\.classic$/, '');
+    if (this.previewMode === 'runtime-template') {
+      return this.classicPreviewComponentId;
     }
 
-    return filename;
+    return undefined;
   }
 
   get currentSnippet() {
@@ -230,25 +251,28 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
   };
 
   get shouldSyncLanguageSelection() {
-    return this.args.hbsSnippet !== '' && this.args.gtsSnippet !== '';
+    return (
+      this.hasSnippet(this.args.hbsSnippet) &&
+      this.hasSnippet(this.args.gtsSnippet)
+    );
   }
 
   get languageOptions() {
     const options: Array<LanguageOption> = [];
 
-    if (this.args.hbsSnippet !== '') {
+    if (this.hasSnippet(this.args.hbsSnippet)) {
       options.push({ label: '.hbs', value: 'hbs' });
     }
 
-    if (this.args.jsSnippet !== '') {
+    if (this.hasSnippet(this.args.jsSnippet)) {
       options.push({ label: '.js', value: 'js' });
     }
 
-    if (this.args.gtsSnippet !== '') {
+    if (this.hasSnippet(this.args.gtsSnippet)) {
       options.push({ label: '.gts', value: 'gts' });
     }
 
-    if (this.args.customLang && this.args.customSnippet !== '') {
+    if (this.args.customLang && this.hasSnippet(this.args.customSnippet)) {
       options.push({ label: `.${this.args.customLang}`, value: 'custom' });
     }
 

--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -23,6 +23,7 @@ import DynamicTemplate from 'website/components/dynamic-template';
 interface DocCodeGroupSignature {
   Args: {
     filename?: string;
+    gtsFilename?: string;
     hbsSnippet?: string;
     jsSnippet?: string;
     gtsSnippet?: string;
@@ -121,8 +122,13 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
 
   // NOTE: the dynamic template requires a component to render a preview. If there is not a component (ex. only a sass/yaml/bash snippet), we hide the preview by default.
   get hidePreview() {
-    // TODO: refactor dynamic template to support gts components: https://hashicorp.atlassian.net/browse/HDS-5833
-    return this.args.hbsSnippet === '' || this.args.hidePreview === 'true';
+    const hasRenderablePreview =
+      (this.args.hbsSnippet && this.args.hbsSnippet !== '') ||
+      (this.args.gtsSnippet &&
+        this.args.gtsSnippet !== '' &&
+        this.args.filename);
+
+    return !hasRenderablePreview || this.args.hidePreview === 'true';
   }
 
   get hbsSnippet() {
@@ -148,6 +154,38 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
   get customSnippet() {
     const { customSnippet } = this.args;
     return customSnippet ? unescapeCode(customSnippet) : '';
+  }
+
+  get previewTemplateString() {
+    // For .gts view, the preview comes from a real component module (via
+    // `@componentId`), so we intentionally skip passing a runtime template.
+    if (this.currentView === 'gts' && this.args.gtsSnippet !== '') {
+      return undefined;
+    }
+
+    return this.hbsSnippet === '' ? undefined : this.hbsSnippet;
+  }
+
+  get previewComponentId() {
+    const { filename, gtsFilename } = this.args;
+
+    if (!filename) {
+      return undefined;
+    }
+
+    if (this.currentView === 'gts' && this.args.gtsSnippet !== '') {
+      if (gtsFilename && gtsFilename !== '') {
+        // .gts demos can live under a different component file than the .hbs
+        // classic demo, so prefer an explicit gts filename when provided.
+        return gtsFilename;
+      }
+
+      // Fallback: map `foo.classic` docs entries to the colocated modern
+      // component id (`foo`) used by the .gts demo implementation.
+      return filename.replace(/\.classic$/, '');
+    }
+
+    return filename;
   }
 
   get currentSnippet() {
@@ -282,8 +320,8 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
       {{#if (notEq this.hidePreview true)}}
         <div class="doc-code-group__preview">
           <DynamicTemplate
-            @templateString={{this.hbsSnippet}}
-            @componentId={{@filename}}
+            @templateString={{this.previewTemplateString}}
+            @componentId={{this.previewComponentId}}
           />
         </div>
       {{/if}}

--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -6,7 +6,6 @@ import Component from '@glimmer/component';
 import { registerDestructor } from '@ember/destroyable';
 import { CodeBlock } from 'ember-shiki';
 import { tracked } from '@glimmer/tracking';
-import { notEq } from 'ember-truth-helpers';
 import { modifier } from 'ember-modifier';
 import { service } from '@ember/service';
 
@@ -22,8 +21,8 @@ import DynamicTemplate from 'website/components/dynamic-template';
 
 interface DocCodeGroupSignature {
   Args: {
-    gtsFilename?: string;
-    classicFilename?: string;
+    gtsComponentId?: string;
+    classicComponentId?: string;
     hbsSnippet?: string;
     jsSnippet?: string;
     gtsSnippet?: string;
@@ -121,35 +120,37 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
   }
 
   // NOTE: the dynamic template requires an Ember component to render a preview. If there is not a component (ex. only a sass/yaml/bash snippet), we hide the preview by default.
-  get hidePreview() {
+  get showPreview() {
     if (this.args.hidePreview === 'true') {
-      return true;
+      return false;
     }
 
-    const hasHbsPreview = !!this.args.hbsSnippet;
-    const hasGtsPreview = !!this.args.gtsSnippet && !!this.args.gtsFilename;
+    const hasHbsPreview =
+      !!this.args.hbsSnippet && !!this.args.classicComponentId;
+    const hasGtsPreview = !!this.args.gtsSnippet && !!this.args.gtsComponentId;
 
-    return !(hasHbsPreview || hasGtsPreview);
+    return hasHbsPreview || hasGtsPreview;
   }
 
   get preview() {
     if (
       this.currentView === 'gts' &&
       this.args.gtsSnippet &&
-      this.args.gtsFilename
+      this.args.gtsComponentId
     ) {
       return {
-        componentId: this.args.gtsFilename,
+        componentId: this.args.gtsComponentId,
         templateString: undefined,
       };
     }
 
     if (
       (this.currentView === 'hbs' || this.currentView === 'js') &&
-      this.args.hbsSnippet
+      this.args.hbsSnippet &&
+      this.args.classicComponentId
     ) {
       return {
-        componentId: this.args.classicFilename,
+        componentId: this.args.classicComponentId,
         templateString: unescapeCode(this.args.hbsSnippet),
       };
     }
@@ -157,12 +158,12 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
 
   get currentSnippet() {
     const {
+      hbsSnippet,
       jsSnippet,
       gtsSnippet,
-      hbsSnippet,
+      compactGtsSnippet,
       customSnippet,
       customLang,
-      compactGtsSnippet,
     } = this.args;
 
     if (this.currentView === 'js') {
@@ -299,7 +300,7 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
 
   <template>
     <div class="doc-code-group">
-      {{#if (notEq this.hidePreview true)}}
+      {{#if this.showPreview}}
         <div class="doc-code-group__preview">
           <DynamicTemplate
             @templateString={{this.preview.templateString}}

--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -44,8 +44,8 @@ const CODE_GROUP_LANGUAGE_STORAGE_KEY = 'hds-doc-code-group-language';
 const CODE_GROUP_LANGUAGE_CHANGE_EVENT = 'hds-doc-code-group-language-change';
 
 // Helper to undo code escaping for display
-const unescapeCode = (code: string) => {
-  return code.replace(/\\n/g, '\n');
+const unescapeCode = (code?: string) => {
+  return code ? code.replace(/\\n/g, '\n') : '';
 };
 
 export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
@@ -126,41 +126,35 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
       return true;
     }
 
-    const hasHbsPreview = this.hasSnippet(this.args.hbsSnippet);
+    const hasHbsPreview = !!this.args.hbsSnippet;
     const hasGtsPreview =
-      this.hasSnippet(this.args.gtsSnippet) && !!this.gtsPreviewComponentId;
+      !!this.args.gtsSnippet && !!this.gtsPreviewComponentId;
 
     return !(hasHbsPreview || hasGtsPreview);
   }
 
-  private hasSnippet(snippet?: string) {
-    return !!snippet && snippet !== '';
-  }
-
   get classicPreviewComponentId() {
-    return this.hasSnippet(this.args.classicFilename)
+    return this.args.classicFilename !== ''
       ? this.args.classicFilename
       : undefined;
   }
 
   get gtsPreviewComponentId() {
-    return this.hasSnippet(this.args.gtsFilename)
-      ? this.args.gtsFilename
-      : undefined;
+    return this.args.gtsFilename ? this.args.gtsFilename : undefined;
   }
 
   get previewMode() {
     if (
       this.currentView === 'gts' &&
-      this.hasSnippet(this.args.gtsSnippet) &&
-      this.gtsPreviewComponentId
+      !!this.args.gtsSnippet &&
+      !!this.gtsPreviewComponentId
     ) {
       return 'component-module';
     }
 
     if (
       (this.currentView === 'hbs' || this.currentView === 'js') &&
-      this.hasSnippet(this.args.hbsSnippet)
+      !!this.args.hbsSnippet
     ) {
       return 'runtime-template';
     }
@@ -168,34 +162,9 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     return null;
   }
 
-  get hbsSnippet() {
-    const { hbsSnippet } = this.args;
-    return hbsSnippet ? unescapeCode(hbsSnippet) : '';
-  }
-
-  get gtsSnippet() {
-    const { gtsSnippet } = this.args;
-    return gtsSnippet ? unescapeCode(gtsSnippet) : '';
-  }
-
-  get jsSnippet() {
-    const { jsSnippet } = this.args;
-    return jsSnippet ? unescapeCode(jsSnippet) : '';
-  }
-
-  get compactGtsSnippet() {
-    const { compactGtsSnippet } = this.args;
-    return compactGtsSnippet ? unescapeCode(compactGtsSnippet) : '';
-  }
-
-  get customSnippet() {
-    const { customSnippet } = this.args;
-    return customSnippet ? unescapeCode(customSnippet) : '';
-  }
-
   get previewTemplateString() {
     return this.previewMode === 'runtime-template'
-      ? this.hbsSnippet
+      ? unescapeCode(this.args.hbsSnippet)
       : undefined;
   }
 
@@ -212,27 +181,42 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
   }
 
   get currentSnippet() {
+    const {
+      jsSnippet,
+      gtsSnippet,
+      hbsSnippet,
+      customSnippet,
+      customLang,
+      compactGtsSnippet,
+    } = this.args;
+
     if (this.currentView === 'js') {
-      return { snippet: this.jsSnippet, language: 'js' };
+      return { snippet: unescapeCode(jsSnippet), language: 'js' };
     }
 
     if (this.currentView === 'gts') {
       if (this.isExpanded) {
-        return { snippet: this.gtsSnippet, language: 'gts' };
+        return {
+          snippet: unescapeCode(gtsSnippet),
+          language: 'gts',
+        };
       }
 
-      // to display the compact gts snippet correctly, need to use hbs syntax highlighting instead of gts
-      return { snippet: this.compactGtsSnippet, language: 'hbs' };
+      return {
+        snippet: unescapeCode(compactGtsSnippet),
+        // to display the compact gts snippet correctly, need to use hbs syntax highlighting instead of gts
+        language: 'hbs',
+      };
     }
 
     if (this.currentView === 'custom') {
       return {
-        snippet: this.customSnippet,
-        language: this.args.customLang || 'text',
+        snippet: unescapeCode(customSnippet),
+        language: customLang || 'text',
       };
     }
 
-    return { snippet: this.hbsSnippet, language: 'hbs' };
+    return { snippet: unescapeCode(hbsSnippet), language: 'hbs' };
   }
 
   get hasFooter() {
@@ -253,28 +237,25 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
   };
 
   get shouldSyncLanguageSelection() {
-    return (
-      this.hasSnippet(this.args.hbsSnippet) &&
-      this.hasSnippet(this.args.gtsSnippet)
-    );
+    return !!this.args.hbsSnippet && !!this.args.gtsSnippet;
   }
 
   get languageOptions() {
     const options: Array<LanguageOption> = [];
 
-    if (this.hasSnippet(this.args.hbsSnippet)) {
+    if (this.args.hbsSnippet) {
       options.push({ label: '.hbs', value: 'hbs' });
     }
 
-    if (this.hasSnippet(this.args.jsSnippet)) {
+    if (this.args.jsSnippet) {
       options.push({ label: '.js', value: 'js' });
     }
 
-    if (this.hasSnippet(this.args.gtsSnippet)) {
+    if (this.args.gtsSnippet) {
       options.push({ label: '.gts', value: 'gts' });
     }
 
-    if (this.args.customLang && this.hasSnippet(this.args.customSnippet)) {
+    if (this.args.customLang && !!this.args.customSnippet) {
       options.push({ label: `.${this.args.customLang}`, value: 'custom' });
     }
 

--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -127,57 +127,32 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     }
 
     const hasHbsPreview = !!this.args.hbsSnippet;
-    const hasGtsPreview =
-      !!this.args.gtsSnippet && !!this.gtsPreviewComponentId;
+    const hasGtsPreview = !!this.args.gtsSnippet && !!this.args.gtsFilename;
 
     return !(hasHbsPreview || hasGtsPreview);
   }
 
-  get classicPreviewComponentId() {
-    return this.args.classicFilename !== ''
-      ? this.args.classicFilename
-      : undefined;
-  }
-
-  get gtsPreviewComponentId() {
-    return this.args.gtsFilename ? this.args.gtsFilename : undefined;
-  }
-
-  get previewMode() {
+  get preview() {
     if (
       this.currentView === 'gts' &&
-      !!this.args.gtsSnippet &&
-      !!this.gtsPreviewComponentId
+      this.args.gtsSnippet &&
+      this.args.gtsFilename
     ) {
-      return 'component-module';
+      return {
+        componentId: this.args.gtsFilename,
+        templateString: undefined,
+      };
     }
 
     if (
       (this.currentView === 'hbs' || this.currentView === 'js') &&
-      !!this.args.hbsSnippet
+      this.args.hbsSnippet
     ) {
-      return 'runtime-template';
+      return {
+        componentId: this.args.classicFilename,
+        templateString: this.args.hbsSnippet,
+      };
     }
-
-    return null;
-  }
-
-  get previewTemplateString() {
-    return this.previewMode === 'runtime-template'
-      ? unescapeCode(this.args.hbsSnippet)
-      : undefined;
-  }
-
-  get previewComponentId() {
-    if (this.previewMode === 'component-module') {
-      return this.gtsPreviewComponentId;
-    }
-
-    if (this.previewMode === 'runtime-template') {
-      return this.classicPreviewComponentId;
-    }
-
-    return undefined;
   }
 
   get currentSnippet() {
@@ -327,8 +302,8 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
       {{#if (notEq this.hidePreview true)}}
         <div class="doc-code-group__preview">
           <DynamicTemplate
-            @templateString={{this.previewTemplateString}}
-            @componentId={{this.previewComponentId}}
+            @templateString={{this.preview.templateString}}
+            @componentId={{this.preview.componentId}}
           />
         </div>
       {{/if}}

--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -150,7 +150,7 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
     ) {
       return {
         componentId: this.args.classicFilename,
-        templateString: this.args.hbsSnippet,
+        templateString: unescapeCode(this.args.hbsSnippet),
       };
     }
   }

--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -22,8 +22,8 @@ import DynamicTemplate from 'website/components/dynamic-template';
 
 interface DocCodeGroupSignature {
   Args: {
-    filename?: string;
     gtsFilename?: string;
+    classicFilename?: string;
     hbsSnippet?: string;
     jsSnippet?: string;
     gtsSnippet?: string;
@@ -138,7 +138,9 @@ export default class DocCodeGroup extends Component<DocCodeGroupSignature> {
   }
 
   get classicPreviewComponentId() {
-    return this.hasSnippet(this.args.filename) ? this.args.filename : undefined;
+    return this.hasSnippet(this.args.classicFilename)
+      ? this.args.classicFilename
+      : undefined;
   }
 
   get gtsPreviewComponentId() {

--- a/website/app/components/doc/code-group/index.gts
+++ b/website/app/components/doc/code-group/index.gts
@@ -21,8 +21,8 @@ import DynamicTemplate from 'website/components/dynamic-template';
 
 interface DocCodeGroupSignature {
   Args: {
-    gtsComponentId?: string;
     classicComponentId?: string;
+    gtsComponentId?: string;
     hbsSnippet?: string;
     jsSnippet?: string;
     gtsSnippet?: string;

--- a/website/app/components/dynamic-template.gjs
+++ b/website/app/components/dynamic-template.gjs
@@ -61,7 +61,9 @@ export default class DynamicTemplate extends Component {
         setComponentTemplate(compiledTemplate, component);
       } else {
         // Component module mode (single file component): render a precompiled component by id.
-        component = componentId || null;
+        component = componentId
+          ? getOwner(this).factoryFor(`component:${componentId}`)?.class || null
+          : null;
       }
 
       // eslint-disable-next-line ember/no-side-effects

--- a/website/app/components/dynamic-template.gjs
+++ b/website/app/components/dynamic-template.gjs
@@ -19,58 +19,78 @@ export default class DynamicTemplate extends Component {
     let owner = getOwner(this);
     let templateMap = templateOwnerMap.get(owner);
     if (templateMap === undefined) {
-      templateMap = templateOwnerMap.set(owner, new Map());
+      templateMap = new Map();
+      templateOwnerMap.set(owner, templateMap);
     }
     this.templateMap = templateMap;
   }
 
-  get component() {
+  get resolvedComponent() {
     let owner = getOwner(this);
 
-    let { templateString } = this.args;
-    if (!templateString) {
-      return null;
+    let factory = owner.factoryFor(`component:${this.args.componentId}`);
+    if (factory?.class && typeof factory.class === 'function') {
+      return class extends factory.class {};
     }
 
-    let component = this.templateMap.get(templateString);
-    if (component === undefined) {
-      let compiledTemplate;
+    // if component couldn't be found the old way try importing it directly
+    let module;
+    try {
+      module = importSync(`./${this.args.componentId}.gts`);
+    } catch {
       try {
-        compiledTemplate = compileTemplate(templateString);
-      } catch (err) {
-        console.error(err);
-        console.error(templateString);
-        compiledTemplate = compileTemplate(`<DynamicTemplateError />`);
+        module = importSync(`./${this.args.componentId}.js`);
+      } catch {
+        // backing class doesn't exist so just ignore the error
       }
+    }
 
-      component = owner.factoryFor(`component:${this.args.componentId}`);
+    let defaultExport = module?.default;
+    if (typeof defaultExport === 'function') {
+      return defaultExport;
+    }
 
-      if (component) {
-        component = class extends component.class {};
-      } else {
-        // if component couldn't be found the old way try importing it directly
-        let module;
+    return null;
+  }
+
+  get component() {
+    let { componentId } = this.args;
+    let { templateString } = this.args;
+    let cacheKey = `${componentId || ''}::${templateString || ''}`;
+
+    let component = this.templateMap.get(cacheKey);
+    if (component === undefined) {
+      if (templateString) {
+        // .hbs examples are provided as raw template strings, so we compile
+        // them at runtime and attach them to a backing class (if one exists).
+        component = this.resolvedComponent;
+
+        let compiledTemplate;
         try {
-          module = importSync(`./docs/${this.args.componentId}.js`);
-        } catch {
-          // backing class doesn't exist so just ignore the error
+          compiledTemplate = compileTemplate(templateString);
+        } catch (err) {
+          console.error(err);
+          console.error(templateString);
+          compiledTemplate = compileTemplate(`<DynamicTemplateError />`);
         }
 
-        component = module?.default;
-      }
+        if (!component) {
+          component = class extends Component {};
+        }
 
-      if (!component) {
-        component = class extends Component {};
+        setComponentTemplate(compiledTemplate, component);
+      } else {
+        // .gts examples are precompiled modules with their own template + class,
+        // so we render the component by id instead of compiling a template string.
+        component = componentId || null;
       }
-
-      setComponentTemplate(compiledTemplate, component);
 
       // eslint-disable-next-line ember/no-side-effects
-      this.templateMap.set(templateString, component);
+      this.templateMap.set(cacheKey, component);
     }
 
     return component;
   }
 
-  <template>{{component (ensureSafeComponent this.component)}}</template>
+  <template>{{component (ensureSafeComponent this.component this)}}</template>
 }

--- a/website/app/components/dynamic-template.gjs
+++ b/website/app/components/dynamic-template.gjs
@@ -8,7 +8,6 @@ import { ensureSafeComponent } from '@embroider/util';
 import { setComponentTemplate } from '@ember/component';
 import { getOwner } from '@ember/owner';
 import { compileTemplate } from '@ember/template-compilation';
-import { importSync } from '@embroider/macros';
 
 let templateOwnerMap = new Map();
 
@@ -25,45 +24,26 @@ export default class DynamicTemplate extends Component {
     this.templateMap = templateMap;
   }
 
-  get resolvedComponent() {
+  get backingComponentClass() {
     let owner = getOwner(this);
-
     let factory = owner.factoryFor(`component:${this.args.componentId}`);
+
     if (factory?.class && typeof factory.class === 'function') {
       return class extends factory.class {};
-    }
-
-    // if component couldn't be found the old way try importing it directly
-    let module;
-    try {
-      module = importSync(`./${this.args.componentId}.gts`);
-    } catch {
-      try {
-        module = importSync(`./${this.args.componentId}.js`);
-      } catch {
-        // backing class doesn't exist so just ignore the error
-      }
-    }
-
-    let defaultExport = module?.default;
-    if (typeof defaultExport === 'function') {
-      return defaultExport;
     }
 
     return null;
   }
 
   get component() {
-    let { componentId } = this.args;
-    let { templateString } = this.args;
-    let cacheKey = `${componentId || ''}::${templateString || ''}`;
+    const { componentId, templateString } = this.args;
+    const cacheKey = `${componentId || ''}::${templateString || ''}`;
 
     let component = this.templateMap.get(cacheKey);
     if (component === undefined) {
       if (templateString) {
-        // .hbs examples are provided as raw template strings, so we compile
-        // them at runtime and attach them to a backing class (if one exists).
-        component = this.resolvedComponent;
+        // Runtime template mode (classic Ember component): compile provided template text and attach it to a backing class when one exists for the provided component id.
+        component = this.backingComponentClass;
 
         let compiledTemplate;
         try {
@@ -80,8 +60,7 @@ export default class DynamicTemplate extends Component {
 
         setComponentTemplate(compiledTemplate, component);
       } else {
-        // .gts examples are precompiled modules with their own template + class,
-        // so we render the component by id instead of compiling a template string.
+        // Component module mode (single file component): render a precompiled component by id.
         component = componentId || null;
       }
 

--- a/website/app/shared/showdown-extensions/content-blocks.js
+++ b/website/app/shared/showdown-extensions/content-blocks.js
@@ -53,7 +53,7 @@ export const contentBlocks = function () {
 
       // NOTE: this regex must match the output created in markdown-process-demos.js
       const demoRegex = new RegExp(
-        /<\?php start="demo-block" filename="(.*?)" hbs="(.*?)" js="(.*?)" gts="(.*?)" compactGts="(.*?)" custom="(.*?)" customLang="(.*?)" hidePreview="(.*?)" expanded="(.*?)" \?>\n?/,
+        /<\?php start="demo-block" filename="(.*?)"(?: gtsFilename="(.*?)")? hbs="(.*?)" js="(.*?)" gts="(.*?)" compactGts="(.*?)" custom="(.*?)" customLang="(.*?)" hidePreview="(.*?)" expanded="(.*?)" \?>\n?/,
         'g',
       );
 
@@ -62,6 +62,7 @@ export const contentBlocks = function () {
         function (
           _match,
           filename,
+          gtsFilename,
           hbs,
           js,
           gts,
@@ -71,7 +72,7 @@ export const contentBlocks = function () {
           hidePreview,
           expanded,
         ) {
-          return `<Doc::CodeGroup @filename="${filename}" @hbsSnippet="${hbs}" @jsSnippet="${js}" @gtsSnippet="${gts}" @compactGtsSnippet="${compactGts}" @customSnippet="${custom}" @customLang="${customLang}" @hidePreview="${hidePreview}" @isExpanded="${expanded}">\n`;
+          return `<Doc::CodeGroup @filename="${filename}" @gtsFilename="${gtsFilename || ''}" @hbsSnippet="${hbs}" @jsSnippet="${js}" @gtsSnippet="${gts}" @compactGtsSnippet="${compactGts}" @customSnippet="${custom}" @customLang="${customLang}" @hidePreview="${hidePreview}" @isExpanded="${expanded}">\n`;
         },
       );
 

--- a/website/app/shared/showdown-extensions/content-blocks.js
+++ b/website/app/shared/showdown-extensions/content-blocks.js
@@ -53,7 +53,7 @@ export const contentBlocks = function () {
 
       // NOTE: this regex must match the output created in markdown-process-demos.js
       const demoRegex = new RegExp(
-        /<\?php start="demo-block" gtsFilename="(.*?)"(?: classicFilename="(.*?)")? hbs="(.*?)" js="(.*?)" gts="(.*?)" compactGts="(.*?)" custom="(.*?)" customLang="(.*?)" hidePreview="(.*?)" expanded="(.*?)" \?>\n?/,
+        /<\?php start="demo-block" classicComponentId="(.*?)" gtsComponentId="(.*?)" hbs="(.*?)" js="(.*?)" gts="(.*?)" compactGts="(.*?)" custom="(.*?)" customLang="(.*?)" hidePreview="(.*?)" expanded="(.*?)" \?>\n?/,
         'g',
       );
 
@@ -61,8 +61,8 @@ export const contentBlocks = function () {
         demoRegex,
         function (
           _match,
-          gtsFilename,
-          classicFilename,
+          classicComponentId,
+          gtsComponentId,
           hbsSnippet,
           jsSnippet,
           gtsSnippet,
@@ -72,7 +72,7 @@ export const contentBlocks = function () {
           hidePreview,
           expanded,
         ) {
-          return `<Doc::CodeGroup @gtsFilename="${gtsFilename}" @classicFilename="${classicFilename || ''}" @hbsSnippet="${hbsSnippet}" @jsSnippet="${jsSnippet}" @gtsSnippet="${gtsSnippet}" @compactGtsSnippet="${compactGtsSnippet}" @customSnippet="${customSnippet}" @customLang="${customLang}" @hidePreview="${hidePreview}" @isExpanded="${expanded}">\n`;
+          return `<Doc::CodeGroup @classicComponentId="${classicComponentId}" @gtsComponentId="${gtsComponentId}" @hbsSnippet="${hbsSnippet}" @jsSnippet="${jsSnippet}" @gtsSnippet="${gtsSnippet}" @compactGtsSnippet="${compactGtsSnippet}" @customSnippet="${customSnippet}" @customLang="${customLang}" @hidePreview="${hidePreview}" @isExpanded="${expanded}">\n`;
         },
       );
 

--- a/website/app/shared/showdown-extensions/content-blocks.js
+++ b/website/app/shared/showdown-extensions/content-blocks.js
@@ -53,7 +53,7 @@ export const contentBlocks = function () {
 
       // NOTE: this regex must match the output created in markdown-process-demos.js
       const demoRegex = new RegExp(
-        /<\?php start="demo-block" filename="(.*?)"(?: gtsFilename="(.*?)")? hbs="(.*?)" js="(.*?)" gts="(.*?)" compactGts="(.*?)" custom="(.*?)" customLang="(.*?)" hidePreview="(.*?)" expanded="(.*?)" \?>\n?/,
+        /<\?php start="demo-block" gtsFilename="(.*?)"(?: classicFilename="(.*?)")? hbs="(.*?)" js="(.*?)" gts="(.*?)" compactGts="(.*?)" custom="(.*?)" customLang="(.*?)" hidePreview="(.*?)" expanded="(.*?)" \?>\n?/,
         'g',
       );
 
@@ -61,8 +61,8 @@ export const contentBlocks = function () {
         demoRegex,
         function (
           _match,
-          filename,
           gtsFilename,
+          classicFilename,
           hbsSnippet,
           jsSnippet,
           gtsSnippet,
@@ -72,7 +72,7 @@ export const contentBlocks = function () {
           hidePreview,
           expanded,
         ) {
-          return `<Doc::CodeGroup @filename="${filename}" @gtsFilename="${gtsFilename || ''}" @hbsSnippet="${hbsSnippet}" @jsSnippet="${jsSnippet}" @gtsSnippet="${gtsSnippet}" @compactGtsSnippet="${compactGtsSnippet}" @customSnippet="${customSnippet}" @customLang="${customLang}" @hidePreview="${hidePreview}" @isExpanded="${expanded}">\n`;
+          return `<Doc::CodeGroup @gtsFilename="${gtsFilename}" @classicFilename="${classicFilename || ''}" @hbsSnippet="${hbsSnippet}" @jsSnippet="${jsSnippet}" @gtsSnippet="${gtsSnippet}" @compactGtsSnippet="${compactGtsSnippet}" @customSnippet="${customSnippet}" @customLang="${customLang}" @hidePreview="${hidePreview}" @isExpanded="${expanded}">\n`;
         },
       );
 

--- a/website/app/shared/showdown-extensions/content-blocks.js
+++ b/website/app/shared/showdown-extensions/content-blocks.js
@@ -63,16 +63,16 @@ export const contentBlocks = function () {
           _match,
           filename,
           gtsFilename,
-          hbs,
-          js,
-          gts,
-          compactGts,
-          custom,
+          hbsSnippet,
+          jsSnippet,
+          gtsSnippet,
+          compactGtsSnippet,
+          customSnippet,
           customLang,
           hidePreview,
           expanded,
         ) {
-          return `<Doc::CodeGroup @filename="${filename}" @gtsFilename="${gtsFilename || ''}" @hbsSnippet="${hbs}" @jsSnippet="${js}" @gtsSnippet="${gts}" @compactGtsSnippet="${compactGts}" @customSnippet="${custom}" @customLang="${customLang}" @hidePreview="${hidePreview}" @isExpanded="${expanded}">\n`;
+          return `<Doc::CodeGroup @filename="${filename}" @gtsFilename="${gtsFilename || ''}" @hbsSnippet="${hbsSnippet}" @jsSnippet="${jsSnippet}" @gtsSnippet="${gtsSnippet}" @compactGtsSnippet="${compactGtsSnippet}" @customSnippet="${customSnippet}" @customLang="${customLang}" @hidePreview="${hidePreview}" @isExpanded="${expanded}">\n`;
         },
       );
 

--- a/website/docs/components/accordion/partials/code/code-snippets/accordion-size.gts
+++ b/website/docs/components/accordion/partials/code/code-snippets/accordion-size.gts
@@ -5,7 +5,7 @@ import { HdsAccordion } from '@hashicorp/design-system-components/components';
 const LocalComponent: TemplateOnlyComponent = <template>
   <HdsAccordion @size="large" as |A|>
     <A.Item>
-      <:toggle>Item one</:toggle>
+      <:toggle>DIFFERENT COMPONENT</:toggle>
       <:content>
         Additional content for item one
       </:content>

--- a/website/docs/components/accordion/partials/code/code-snippets/accordion-size.gts
+++ b/website/docs/components/accordion/partials/code/code-snippets/accordion-size.gts
@@ -5,7 +5,7 @@ import { HdsAccordion } from '@hashicorp/design-system-components/components';
 const LocalComponent: TemplateOnlyComponent = <template>
   <HdsAccordion @size="large" as |A|>
     <A.Item>
-      <:toggle>DIFFERENT COMPONENT</:toggle>
+      <:toggle>Item one</:toggle>
       <:content>
         Additional content for item one
       </:content>

--- a/website/docs/getting-started/for-engineers/index.md
+++ b/website/docs/getting-started/for-engineers/index.md
@@ -68,11 +68,11 @@ Import the CSS by adding this configuration in `ember-cli-build.js`.
 
 If you are are using single file components (i.e., `.gts` or `.gjs` files), the components need to be individually imported into the file for them to render. All components can be imported from the `@hashicorp/design-system-components/components` path. To use a component's signature, you must import it from the definition file.
 
-[[code-snippets/sample-component expanded=true]]
+[[code-snippets/sample-component execute=false expanded=true]]
 
 In the rare cases where you need to use an HDS modifier, they are only exported from their definition file
 
-[[code-snippets/sample-imports expanded=true]]
+[[code-snippets/sample-imports execute=false expanded=true]]
 
 For more information on single file components, see the Ember docs:
 * [Intro to components](https://guides.emberjs.com/release/components/introducing-components/)

--- a/website/lib/markdown/index.js
+++ b/website/lib/markdown/index.js
@@ -29,7 +29,7 @@ module.exports = {
   treeForApp() {
     let backingClasses = new Funnel('docs', {
       destDir: 'components',
-      include: ['**/*.js'],
+      include: ['**/*.js', '**/code-snippets/**/*.gts'],
     });
     return new MergeTrees([backingClasses]);
   },

--- a/website/lib/markdown/markdown-process-demos.js
+++ b/website/lib/markdown/markdown-process-demos.js
@@ -20,7 +20,7 @@ const demoBlockRegex =
  * Example input path: "var/folders/68/g3fv_h7538xcqf6nd48jm8m40000gn/T/broccoli-59163KsQiVU7Es4GZ/out-158-funnel/components/accordion/partials/code/code-snippets/accordion-expand-all.classic"
  */
 const fileNameRegex =
-  /((?:getting-started|foundations|components|layouts|utilities|overrides|patterns|testing).*?)\.(?:hbs|js|gts)/;
+  /((?:getting-started|foundations|components|layouts|utilities|overrides|patterns|testing).*?)(?:\.hbs|\.gts)$/;
 
 const SUPPORTED_FILE_EXTENSIONS = [
   '.classic.hbs',
@@ -159,8 +159,8 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
             customLang: '',
           };
 
-          let classicFilenameToForward = '';
-          let gtsFilenameToForward = '';
+          let classicComponentIdToForward = '';
+          let gtsComponentIdToForward = '';
 
           SUPPORTED_FILE_EXTENSIONS.forEach((ext) => {
             const fileToCheck = `${fileName.trim()}${ext}`;
@@ -172,7 +172,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
 
               if (ext === '.classic.hbs') {
                 codeSnippets.hbsSnippet = escapeCode(stripAllIgnores(code));
-                classicFilenameToForward = getComponentIdFromPath(filePath);
+                classicComponentIdToForward = getComponentIdFromPath(filePath);
               }
 
               if (ext === '.classic.js' || ext === '.js') {
@@ -184,7 +184,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
                 codeSnippets.compactGtsSnippet = escapeCode(
                   stripAllIgnores(getCompactGtsSnippet(code)),
                 );
-                gtsFilenameToForward = getComponentIdFromPath(filePath);
+                gtsComponentIdToForward = getComponentIdFromPath(filePath);
               }
 
               if (
@@ -201,7 +201,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
           });
 
           // NOTE: if change this, also need to change the regex in content-blocks.js
-          return `\n<?php start="demo-block" gtsFilename="${gtsFilenameToForward}" classicFilename="${classicFilenameToForward}" hbs="${codeSnippets.hbsSnippet}" js="${codeSnippets.jsSnippet}" gts="${codeSnippets.gtsSnippet}" compactGts="${codeSnippets.compactGtsSnippet}" custom="${codeSnippets.customSnippet}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
+          return `\n<?php start="demo-block" classicComponentId="${classicComponentIdToForward}" gtsComponentId="${gtsComponentIdToForward}" hbs="${codeSnippets.hbsSnippet}" js="${codeSnippets.jsSnippet}" gts="${codeSnippets.gtsSnippet}" compactGts="${codeSnippets.compactGtsSnippet}" custom="${codeSnippets.customSnippet}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
         },
       );
 

--- a/website/lib/markdown/markdown-process-demos.js
+++ b/website/lib/markdown/markdown-process-demos.js
@@ -156,6 +156,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
           };
 
           let fileNameToForward = '';
+          let gtsFileNameToForward = '';
 
           SUPPORTED_FILE_EXTENSIONS.forEach((ext) => {
             const fileToCheck = `${fileName.trim()}${ext}`;
@@ -181,6 +182,13 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
                 codeSnippets.compactGts = escapeCode(
                   stripAllIgnores(getCompactGtsSnippet(code)),
                 );
+
+                gtsFileNameToForward = filePath.match(fileNameRegex)?.[1] || '';
+
+                // if there is no classic snippet, forward the gts component path for rendering preview
+                if (!fileNameToForward) {
+                  fileNameToForward = gtsFileNameToForward;
+                }
               }
 
               if (
@@ -197,7 +205,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
           });
 
           // NOTE: if change this, also need to change the regex in content-blocks.js
-          return `\n<?php start="demo-block" filename="${fileNameToForward}" hbs="${codeSnippets.hbs}" js="${codeSnippets.js}" gts="${codeSnippets.gts}" compactGts="${codeSnippets.compactGts}" custom="${codeSnippets.custom}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
+          return `\n<?php start="demo-block" filename="${fileNameToForward}" gtsFilename="${gtsFileNameToForward}" hbs="${codeSnippets.hbs}" js="${codeSnippets.js}" gts="${codeSnippets.gts}" compactGts="${codeSnippets.compactGts}" custom="${codeSnippets.custom}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
         },
       );
 

--- a/website/lib/markdown/markdown-process-demos.js
+++ b/website/lib/markdown/markdown-process-demos.js
@@ -124,6 +124,10 @@ function getCompactGtsSnippet(code) {
   return dedentedLines.join('\n');
 }
 
+function getComponentIdFromPath(filePath) {
+  return filePath.match(fileNameRegex)?.[1] || '';
+}
+
 class MarkdownReplaceDemoBlocks extends Multifilter {
   build() {
     const inputFolder = this.inputPaths[0];
@@ -155,8 +159,8 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
             customLang: '',
           };
 
-          let fileNameToForward = '';
-          let gtsFileNameToForward = '';
+          let classicFilenameToForward = '';
+          let gtsFilenameToForward = '';
 
           SUPPORTED_FILE_EXTENSIONS.forEach((ext) => {
             const fileToCheck = `${fileName.trim()}${ext}`;
@@ -168,9 +172,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
 
               if (ext === '.classic.hbs') {
                 codeSnippets.hbs = escapeCode(stripAllIgnores(code));
-
-                // need to use the classic.hbs file path for forwarding because the DynamicTemplate relies on the hbs/js files to render the preview - so the fileName must include the .classic extension
-                fileNameToForward = filePath.match(fileNameRegex)?.[1];
+                classicFilenameToForward = getComponentIdFromPath(filePath);
               }
 
               if (ext === '.classic.js' || ext === '.js') {
@@ -182,13 +184,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
                 codeSnippets.compactGts = escapeCode(
                   stripAllIgnores(getCompactGtsSnippet(code)),
                 );
-
-                gtsFileNameToForward = filePath.match(fileNameRegex)?.[1] || '';
-
-                // if there is no classic snippet, forward the gts component path for rendering preview
-                if (!fileNameToForward) {
-                  fileNameToForward = gtsFileNameToForward;
-                }
+                gtsFilenameToForward = getComponentIdFromPath(filePath);
               }
 
               if (
@@ -204,8 +200,14 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
             }
           });
 
+          // Keep both forwarded ids explicit:
+          // - `filename` keeps classic preview lookup behavior (`*.classic`).
+          // - `gtsFilename` points to the modern component module (`*.gts`).
+          // If only a modern snippet exists, `filename` falls back to the gts id.
+          const filenameToForward = classicFilenameToForward || gtsFilenameToForward;
+
           // NOTE: if change this, also need to change the regex in content-blocks.js
-          return `\n<?php start="demo-block" filename="${fileNameToForward}" gtsFilename="${gtsFileNameToForward}" hbs="${codeSnippets.hbs}" js="${codeSnippets.js}" gts="${codeSnippets.gts}" compactGts="${codeSnippets.compactGts}" custom="${codeSnippets.custom}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
+          return `\n<?php start="demo-block" filename="${filenameToForward}" gtsFilename="${gtsFilenameToForward}" hbs="${codeSnippets.hbs}" js="${codeSnippets.js}" gts="${codeSnippets.gts}" compactGts="${codeSnippets.compactGts}" custom="${codeSnippets.custom}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
         },
       );
 

--- a/website/lib/markdown/markdown-process-demos.js
+++ b/website/lib/markdown/markdown-process-demos.js
@@ -200,15 +200,8 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
             }
           });
 
-          // Keep both forwarded ids explicit:
-          // - `filename` keeps classic preview lookup behavior (`*.classic`).
-          // - `gtsFilename` points to the modern component module (`*.gts`).
-          // If only a modern snippet exists, `filename` falls back to the gts id.
-          const filenameToForward =
-            classicFilenameToForward || gtsFilenameToForward;
-
           // NOTE: if change this, also need to change the regex in content-blocks.js
-          return `\n<?php start="demo-block" filename="${filenameToForward}" gtsFilename="${gtsFilenameToForward}" hbs="${codeSnippets.hbsSnippet}" js="${codeSnippets.jsSnippet}" gts="${codeSnippets.gtsSnippet}" compactGts="${codeSnippets.compactGtsSnippet}" custom="${codeSnippets.customSnippet}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
+          return `\n<?php start="demo-block" gtsFilename="${gtsFilenameToForward}" classicFilename="${classicFilenameToForward}" hbs="${codeSnippets.hbsSnippet}" js="${codeSnippets.jsSnippet}" gts="${codeSnippets.gtsSnippet}" compactGts="${codeSnippets.compactGtsSnippet}" custom="${codeSnippets.customSnippet}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
         },
       );
 

--- a/website/lib/markdown/markdown-process-demos.js
+++ b/website/lib/markdown/markdown-process-demos.js
@@ -151,11 +151,11 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
           const shouldHidePreview = shouldExecute === 'false' ? true : false;
 
           const codeSnippets = {
-            hbs: '',
-            js: '',
-            gts: '',
-            compactGts: '',
-            custom: '',
+            hbsSnippet: '',
+            jsSnippet: '',
+            gtsSnippet: '',
+            compactGtsSnippet: '',
+            customSnippet: '',
             customLang: '',
           };
 
@@ -171,17 +171,17 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
               dependencies.push(filePath);
 
               if (ext === '.classic.hbs') {
-                codeSnippets.hbs = escapeCode(stripAllIgnores(code));
+                codeSnippets.hbsSnippet = escapeCode(stripAllIgnores(code));
                 classicFilenameToForward = getComponentIdFromPath(filePath);
               }
 
               if (ext === '.classic.js' || ext === '.js') {
-                codeSnippets.js = escapeCode(stripAllIgnores(code));
+                codeSnippets.jsSnippet = escapeCode(stripAllIgnores(code));
               }
 
               if (ext === '.gts') {
-                codeSnippets.gts = escapeCode(stripAllIgnores(code));
-                codeSnippets.compactGts = escapeCode(
+                codeSnippets.gtsSnippet = escapeCode(stripAllIgnores(code));
+                codeSnippets.compactGtsSnippet = escapeCode(
                   stripAllIgnores(getCompactGtsSnippet(code)),
                 );
                 gtsFilenameToForward = getComponentIdFromPath(filePath);
@@ -194,7 +194,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
                 ext === '.html' ||
                 ext === '.jsx'
               ) {
-                codeSnippets.custom = escapeCode(code);
+                codeSnippets.customSnippet = escapeCode(code);
                 codeSnippets.customLang = ext.substring(1); // remove the dot from the extension
               }
             }
@@ -204,10 +204,11 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
           // - `filename` keeps classic preview lookup behavior (`*.classic`).
           // - `gtsFilename` points to the modern component module (`*.gts`).
           // If only a modern snippet exists, `filename` falls back to the gts id.
-          const filenameToForward = classicFilenameToForward || gtsFilenameToForward;
+          const filenameToForward =
+            classicFilenameToForward || gtsFilenameToForward;
 
           // NOTE: if change this, also need to change the regex in content-blocks.js
-          return `\n<?php start="demo-block" filename="${filenameToForward}" gtsFilename="${gtsFilenameToForward}" hbs="${codeSnippets.hbs}" js="${codeSnippets.js}" gts="${codeSnippets.gts}" compactGts="${codeSnippets.compactGts}" custom="${codeSnippets.custom}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
+          return `\n<?php start="demo-block" filename="${filenameToForward}" gtsFilename="${gtsFilenameToForward}" hbs="${codeSnippets.hbsSnippet}" js="${codeSnippets.jsSnippet}" gts="${codeSnippets.gtsSnippet}" compactGts="${codeSnippets.compactGtsSnippet}" custom="${codeSnippets.customSnippet}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
         },
       );
 

--- a/website/lib/markdown/markdown-process-demos.js
+++ b/website/lib/markdown/markdown-process-demos.js
@@ -159,8 +159,8 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
             customLang: '',
           };
 
-          let classicComponentIdToForward = '';
-          let gtsComponentIdToForward = '';
+          let classicComponentId = '';
+          let gtsComponentId = '';
 
           SUPPORTED_FILE_EXTENSIONS.forEach((ext) => {
             const fileToCheck = `${fileName.trim()}${ext}`;
@@ -172,7 +172,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
 
               if (ext === '.classic.hbs') {
                 codeSnippets.hbsSnippet = escapeCode(stripAllIgnores(code));
-                classicComponentIdToForward = getComponentIdFromPath(filePath);
+                classicComponentId = getComponentIdFromPath(filePath);
               }
 
               if (ext === '.classic.js' || ext === '.js') {
@@ -184,7 +184,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
                 codeSnippets.compactGtsSnippet = escapeCode(
                   stripAllIgnores(getCompactGtsSnippet(code)),
                 );
-                gtsComponentIdToForward = getComponentIdFromPath(filePath);
+                gtsComponentId = getComponentIdFromPath(filePath);
               }
 
               if (
@@ -201,7 +201,7 @@ class MarkdownReplaceDemoBlocks extends Multifilter {
           });
 
           // NOTE: if change this, also need to change the regex in content-blocks.js
-          return `\n<?php start="demo-block" classicComponentId="${classicComponentIdToForward}" gtsComponentId="${gtsComponentIdToForward}" hbs="${codeSnippets.hbsSnippet}" js="${codeSnippets.jsSnippet}" gts="${codeSnippets.gtsSnippet}" compactGts="${codeSnippets.compactGtsSnippet}" custom="${codeSnippets.customSnippet}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
+          return `\n<?php start="demo-block" classicComponentId="${classicComponentId}" gtsComponentId="${gtsComponentId}" hbs="${codeSnippets.hbsSnippet}" js="${codeSnippets.jsSnippet}" gts="${codeSnippets.gtsSnippet}" compactGts="${codeSnippets.compactGtsSnippet}" custom="${codeSnippets.customSnippet}" customLang="${codeSnippets.customLang}" hidePreview="${shouldHidePreview}" expanded="${isExpanded}" ?><?php end="demo-block" ?>\n`;
         },
       );
 


### PR DESCRIPTION
### :pushpin: Summary

Currently, in the code group component - the preview is only ever the hbs version of the snippet. When you are on the gts snippet, it still renders the hbs version. This PR updates the component to actually render the gts component when the gts tab is active.

Currently, there is a difference in the Accordion size demo so it is easier to verify the new behavior, this will be reverted before the PR merges.

**[PREVIEW](https://hds-website-git-hds-5833-dynamic-template-refactor-hashicorp.vercel.app/components/accordion?tab=code#size)**

### :camera_flash: Screenshots

**Before**
<img width="841" height="450" alt="Screenshot 2026-06-23 at 3 58 00 PM" src="https://github.com/user-attachments/assets/7ab5608d-8a0b-4c55-ac1e-7d7842f197ed" />


**After**
<img width="828" height="409" alt="Screenshot 2026-06-23 at 3 58 09 PM" src="https://github.com/user-attachments/assets/39d9477d-e91d-49e6-bbd4-aac138ef0bd4" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5833](https://hashicorp.atlassian.net/browse/HDS-5833)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5833]: https://hashicorp.atlassian.net/browse/HDS-5833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ