### PR TITLE
 `SegmentedGroup` - Fix border-radius of nested icon-only Dropdown (HDS-6477)

### DIFF
--- a/.changeset/new-things-clean.md
+++ b/.changeset/new-things-clean.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`SegmentedGroup` - Fixed border radius styling issue of icon-only Dropdowns when used within `SegmentedGroup`

--- a/packages/components/src/styles/components/segmented-group.scss
+++ b/packages/components/src/styles/components/segmented-group.scss
@@ -20,8 +20,9 @@
 
       &::before,
       .hds-dropdown-toggle-button,
+      .hds-dropdown-toggle-button::before,
       .hds-dropdown-toggle-icon,
-      .hds-dropdown-toggle-button::before {
+      .hds-dropdown-toggle-icon::before {
         border-top-right-radius: inherit;
         border-bottom-right-radius: inherit;
       }
@@ -34,8 +35,9 @@
 
       &::before,
       .hds-dropdown-toggle-button,
+      .hds-dropdown-toggle-button::before,
       .hds-dropdown-toggle-icon,
-      .hds-dropdown-toggle-button::before {
+      .hds-dropdown-toggle-icon::before {
         border-top-left-radius: inherit;
         border-bottom-left-radius: inherit;
       }
@@ -47,14 +49,17 @@
 
       &::before,
       .hds-dropdown-toggle-button,
-      .hds-dropdown-toggle-button::before {
+      .hds-dropdown-toggle-button::before,
+      .hds-dropdown-toggle-icon,
+      .hds-dropdown-toggle-icon::before {
         border-radius: inherit;
       }
     }
 
     &:focus,
     &.mock-focus,
-    .hds-dropdown-toggle-button:focus {
+    .hds-dropdown-toggle-button:focus,
+    .hds-dropdown-toggle-icon:focus {
       z-index: 1;
     }
   }

--- a/packages/components/src/styles/components/segmented-group.scss
+++ b/packages/components/src/styles/components/segmented-group.scss
@@ -20,6 +20,7 @@
 
       &::before,
       .hds-dropdown-toggle-button,
+      .hds-dropdown-toggle-icon,
       .hds-dropdown-toggle-button::before {
         border-top-right-radius: inherit;
         border-bottom-right-radius: inherit;
@@ -33,6 +34,7 @@
 
       &::before,
       .hds-dropdown-toggle-button,
+      .hds-dropdown-toggle-icon,
       .hds-dropdown-toggle-button::before {
         border-top-left-radius: inherit;
         border-bottom-left-radius: inherit;

--- a/showcase/app/components/page-components/segmented-group/sub-sections/content.gts
+++ b/showcase/app/components/page-components/segmented-group/sub-sections/content.gts
@@ -92,7 +92,6 @@ const SubSectionContent: TemplateOnlyComponent = <template>
         <SGR.TextInput aria-label="segmented-text-input-dropdown-leading" />
       </HdsSegmentedGroup>
     </SG.Item>
-
     <SG.Item @label="Icon Dropdown trailing">
       <HdsSegmentedGroup as |SGR|>
         <SGR.TextInput aria-label="segmented-text-input-dropdown-trailing" />
@@ -270,6 +269,17 @@ const SubSectionContent: TemplateOnlyComponent = <template>
             </HdsButtonSet>
           </D.Footer>
         </SGR.Dropdown>
+      </HdsSegmentedGroup>
+    </SG.Item>
+    <SG.Item @label="Input, Icon Dropdown, Button">
+      <HdsSegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-input-dropdown-button" />
+        <SGR.Dropdown as |D|>
+          <D.ToggleIcon @icon="user" @text="user menu" />
+          <D.Title @text="Signed In" />
+          <D.Description @text="email@domain.com" />
+        </SGR.Dropdown>
+        <SGR.Button @color="secondary" @text="Button" />
       </HdsSegmentedGroup>
     </SG.Item>
   </ShwGrid>

--- a/showcase/app/components/page-components/segmented-group/sub-sections/content.gts
+++ b/showcase/app/components/page-components/segmented-group/sub-sections/content.gts
@@ -92,6 +92,27 @@ const SubSectionContent: TemplateOnlyComponent = <template>
         <SGR.TextInput aria-label="segmented-text-input-dropdown-leading" />
       </HdsSegmentedGroup>
     </SG.Item>
+
+    <SG.Item @label="Icon Dropdown trailing">
+      <HdsSegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-text-input-dropdown-trailing" />
+        <SGR.Dropdown as |D|>
+          <D.ToggleIcon @icon="user" @text="user menu" />
+          <D.Title @text="Signed In" />
+          <D.Description @text="email@domain.com" />
+        </SGR.Dropdown>
+      </HdsSegmentedGroup>
+    </SG.Item>
+    <SG.Item @label="Icon Dropdown leading">
+      <HdsSegmentedGroup as |SGR|>
+        <SGR.Dropdown as |D|>
+          <D.ToggleIcon @icon="user" @text="user menu" />
+          <D.Title @text="Signed In" />
+          <D.Description @text="email@domain.com" />
+        </SGR.Dropdown>
+        <SGR.TextInput aria-label="segmented-text-input-dropdown-leading" />
+      </HdsSegmentedGroup>
+    </SG.Item>
   </ShwGrid>
 
   <ShwDivider @level={{2}} />

--- a/showcase/app/components/page-components/segmented-group/sub-sections/states.gts
+++ b/showcase/app/components/page-components/segmented-group/sub-sections/states.gts
@@ -133,6 +133,20 @@ const SubSectionStates: TemplateOnlyComponent = <template>
         </SGR.Select>
       </HdsSegmentedGroup>
     </SG.Item>
+    <SG.Item @label="Icon Dropdown focused">
+      <HdsSegmentedGroup as |SGR|>
+        <SGR.TextInput aria-label="segmented-text-input-dropdown-trailing" />
+        <SGR.Dropdown as |D|>
+          <D.ToggleIcon
+            @icon="user"
+            @text="user menu"
+            mock-state-value="focus"
+          />
+          <D.Title @text="Signed In" />
+          <D.Description @text="email@domain.com" />
+        </SGR.Dropdown>
+      </HdsSegmentedGroup>
+    </SG.Item>
   </ShwGrid>
 
   <ShwDivider @level={{2}} />
@@ -254,6 +268,20 @@ const SubSectionStates: TemplateOnlyComponent = <template>
           <D.ToggleButton @color="secondary" @text="Dropdown" />
           <D.Interactive @href="#">Dropdown Item</D.Interactive>
         </SGR.Dropdown>
+      </HdsSegmentedGroup>
+    </SG.Item>
+    <SG.Item @label="Icon Dropdown focused">
+      <HdsSegmentedGroup as |SGR|>
+        <SGR.Dropdown as |D|>
+          <D.ToggleIcon
+            @icon="user"
+            @text="user menu"
+            mock-state-value="focus"
+          />
+          <D.Title @text="Signed In" />
+          <D.Description @text="email@domain.com" />
+        </SGR.Dropdown>
+        <SGR.TextInput aria-label="segmented-text-input-dropdown-leading" />
       </HdsSegmentedGroup>
     </SG.Item>
   </ShwGrid>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR fixes the border-radius styling of icon-only `Dropdown` components when used within the `SegmentedGroup` component.

**Preview**: https://hds-showcase-git-kristin-hds-6477-segemented-g-1341a4-hashicorp.vercel.app/components/segmented-group

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :copilot: Copilot instructions
Specific instructions for Copilot when reviewing the PR

### :camera_flash: Screenshots
Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

* Jira ticket: [HDS-6477](https://hashicorp.atlassian.net/browse/HDS-6477)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6477]: https://hashicorp.atlassian.net/browse/HDS-6477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ