### PR TITLE
bumped `figma-api` to `2.2.1-beta` (security fixes)

### DIFF
--- a/packages/flight-icons/package.json
+++ b/packages/flight-icons/package.json
@@ -46,7 +46,7 @@
     "dotenv": "^16.4.7",
     "eslint": "^9.27.0",
     "globals": "^16.1.0",
-    "figma-api": "^2.2.0-beta",
+    "figma-api": "^2.2.1-beta",
     "fs-extra": "^11.2.0",
     "lodash": "^4.18.1",
     "mini-svg-data-uri": "^1.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,8 +418,8 @@ importers:
         specifier: ^9.27.0
         version: 9.32.0
       figma-api:
-        specifier: ^2.2.0-beta
-        version: 2.2.0-beta
+        specifier: ^2.2.1-beta
+        version: 2.2.1-beta
       fs-extra:
         specifier: ^11.2.0
         version: 11.3.0
@@ -4538,8 +4538,8 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
@@ -7366,8 +7366,8 @@ packages:
       picomatch:
         optional: true
 
-  figma-api@2.2.0-beta:
-    resolution: {integrity: sha512-ryyGKR4uv6cAks3jBESKuFGEcK8AMSRddkQA+7fhWHrvPLb+rtNGUp5ztTbBEWFwRgOYiDkE+V3c6Pjcl01o1A==}
+  figma-api@2.2.1-beta:
+    resolution: {integrity: sha512-gK/8/O0fj+kqJglJHzVVktXo299aYt2NHXpIrQ0mlb2N+CqK1npqhdqUss51QXTafUdMA4MJqwCBZMsxQuff+Q==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -9350,10 +9350,6 @@ packages:
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-db@1.53.0:
-    resolution: {integrity: sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==}
     engines: {node: '>= 0.6'}
 
   mime-db@1.54.0:
@@ -12586,7 +12582,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.1
+      debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -13390,7 +13386,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16432,7 +16428,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16756,13 +16752,15 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios@1.15.2:
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   b4a@1.6.7: {}
 
@@ -18398,7 +18396,7 @@ snapshots:
 
   compressible@2.0.18:
     dependencies:
-      mime-db: 1.53.0
+      mime-db: 1.54.0
 
   compression@1.8.0:
     dependencies:
@@ -20171,7 +20169,7 @@ snapshots:
 
   ember-in-element-polyfill@1.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-version-checker: 5.1.2
@@ -21249,7 +21247,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -21327,7 +21325,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       cookie: 0.4.2
-      debug: 4.4.1
+      debug: 4.4.3
       jsdom: 19.0.0
       resolve: 1.22.10
       simple-dom: 1.4.0
@@ -21379,12 +21377,13 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  figma-api@2.2.0-beta:
+  figma-api@2.2.1-beta:
     dependencies:
       '@figma/rest-api-spec': 0.37.0
-      axios: 1.15.2
+      axios: 1.18.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   figures@2.0.0:
     dependencies:
@@ -21791,7 +21790,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -22250,14 +22249,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -22272,14 +22271,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -22763,7 +22762,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -23999,8 +23998,6 @@ snapshots:
       picomatch: 4.0.4
 
   mime-db@1.52.0: {}
-
-  mime-db@1.53.0: {}
 
   mime-db@1.54.0: {}
 
@@ -25825,7 +25822,7 @@ snapshots:
   socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -25846,7 +25843,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
### :pushpin: Summary

This PR bumps the `figma-api` dependency to its latest version

### :hammer_and_wrench: Detailed description

In this PR I have:
- bumped `figma-api` to `2.2.1-beta` (security fixes)

After the update, I have run `pnpm sync && pnpm build` to make sure everything was still working as expected.

### :link: External links

Jira ticket (related): https://hashicorp.atlassian.net/browse/HDS-5912

***

### :eyes: Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>