### PR TITLE
Update labeler to include `packages/mcp`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,10 @@ packages/tokens:
   - changed-files:
     - any-glob-to-any-file:
       - packages/tokens/**/*
+packages/mcp:
+  - changed-files:
+    - any-glob-to-any-file:
+      - packages/mcp/**/*
 showcase:
   - changed-files:
     - any-glob-to-any-file:


### PR DESCRIPTION
### :pushpin: Summary

Update our automatic labeler to include `packages/mcp` to help us filter PRs easily

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6141](https://hashicorp.atlassian.net/browse/HDS-6141)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6141]: https://hashicorp.atlassian.net/browse/HDS-6141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ