### PR TITLE
Component catalog - Accordion

### DIFF
--- a/packages/mcp/src/catalogs/components/catalog.json
+++ b/packages/mcp/src/catalogs/components/catalog.json
@@ -1,0 +1,138 @@
+{
+  "updatedAt": "2026-07-01T20:25:05.109Z",
+  "components": [
+    {
+      "name": "HdsAccordion",
+      "description": "The `Accordion` component serves as a wrapper to group one or more `Accordion::Item` components.",
+      "args": [
+        {
+          "name": "forceState",
+          "type": "'open' | 'close'",
+          "required": false,
+          "description": "Controls the state of all items within the accordion group, allowing all items to be expanded or collapsed simultaneously."
+        },
+        {
+          "name": "size",
+          "type": "'small' | 'medium' | 'large'",
+          "required": false,
+          "default": "medium",
+          "description": "Specifies the size of the accordion."
+        },
+        {
+          "name": "titleTag",
+          "type": "'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'",
+          "required": false,
+          "default": "div",
+          "description": "Specifies the HTML tag used to wrap the content of each Accordion Item's toggle block."
+        },
+        {
+          "name": "type",
+          "type": "'card' | 'flush'",
+          "required": false,
+          "default": "card",
+          "description": "Determines the style of the accordion."
+        }
+      ],
+      "blocks": [
+        {
+          "name": "default",
+          "yields": [
+            {
+              "name": "Item",
+              "type": "WithBoundArgs< typeof HdsAccordionItem, 'titleTag' | 'size' | 'type' | 'forceState' >",
+              "kind": "component",
+              "componentName": "HdsAccordionItem",
+              "boundArgs": [
+                "titleTag",
+                "size",
+                "type",
+                "forceState"
+              ],
+              "description": "The `Accordion::Item` component, yielded as contextual component."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HdsAccordionItem",
+      "description": "The `Accordion::Item` component, yielded as contextual component.",
+      "args": [
+        {
+          "name": "ariaLabel",
+          "type": "string",
+          "required": false,
+          "default": "\"Toggle display\"",
+          "description": "Accepts a string. The `ariaLabel` value is applied to the HTML button which controls visibility of the content block content."
+        },
+        {
+          "name": "containsInteractive",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Controls whether the entire toggle block is interactive for toggling the content display or whether only the chevron button itself is interactive which allows for adding other interactive content in the toggle area."
+        },
+        {
+          "name": "forceState",
+          "type": "'open' | 'close'",
+          "required": false,
+          "description": "Controls the state of an `Accordion::Item` after the initial render by overriding its current state."
+        },
+        {
+          "name": "isOpen",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Toggles the visibility of the content. To display content on page load, set the value to `true`."
+        },
+        {
+          "name": "isStatic",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Removes the ability to interact with the toggle and hides the chevron element when set to `true`."
+        },
+        {
+          "name": "onClickToggle",
+          "type": "(event: MouseEvent, ...args: any[]) => void",
+          "required": false,
+          "description": "Callback function invoked when the toggle is clicked."
+        },
+        {
+          "name": "size",
+          "type": "'small' | 'medium' | 'large'",
+          "required": false,
+          "default": "medium"
+        },
+        {
+          "name": "titleTag",
+          "type": "'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'",
+          "required": false,
+          "default": "div"
+        },
+        {
+          "name": "type",
+          "type": "'card' | 'flush'",
+          "required": false,
+          "default": "card"
+        }
+      ],
+      "blocks": [
+        {
+          "name": "content",
+          "yields": [
+            {
+              "name": "close",
+              "type": "(...args: any[]) => void",
+              "kind": "function",
+              "description": "A function to programmatically close the `Accordion::Item`."
+            }
+          ]
+        },
+        {
+          "name": "toggle"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/mcp/src/catalogs/components/catalog.json
+++ b/packages/mcp/src/catalogs/components/catalog.json
@@ -9,28 +9,26 @@
           "name": "forceState",
           "type": "'open' | 'close'",
           "required": false,
-          "description": "Controls the state of all items within the accordion group, allowing all items to be expanded or collapsed simultaneously."
-        },
+          "description": "Controls the state of all items within a group. Can be used to expand or collapse all items at once."
+        }
         {
           "name": "size",
           "type": "'small' | 'medium' | 'large'",
           "required": false,
-          "default": "medium",
-          "description": "Specifies the size of the accordion."
+          "default": "medium"
         },
         {
           "name": "titleTag",
           "type": "'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'",
           "required": false,
           "default": "div",
-          "description": "Specifies the HTML tag used to wrap the content of each Accordion Item's toggle block."
+          "description": "The HTML tag that wraps the content of each Accordion Item \"toggle\" block."
         },
         {
           "name": "type",
           "type": "'card' | 'flush'",
           "required": false,
-          "default": "card",
-          "description": "Determines the style of the accordion."
+          "default": "card"
         }
       ],
       "blocks": [
@@ -48,7 +46,7 @@
                 "type",
                 "forceState"
               ],
-              "description": "The `Accordion::Item` component, yielded as contextual component."
+              "description": "`Accordion::Item` yielded as contextual component."
             }
           ]
         }

--- a/packages/mcp/src/catalogs/components/schema.ts
+++ b/packages/mcp/src/catalogs/components/schema.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { z } from "zod";
+
+const catalogArgSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1),
+  required: z.boolean().optional(),
+  description: z.string().optional(),
+  default: z.string().optional(),
+});
+
+const catalogBlockYieldSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1),
+  kind: z.enum(["component", "function", "value"]).optional(),
+  componentName: z.string().min(1).optional(),
+  boundArgs: z.array(z.string().min(1)).optional(),
+  description: z.string().optional(),
+});
+
+const catalogBlockSchema = z.object({
+  name: z.string().min(1),
+  yields: z.array(catalogBlockYieldSchema).optional(),
+});
+
+const catalogDesignSchema = z.object({
+  figmaUrl: z.string().url(),
+  nodeId: z.string().min(1).optional(),
+  fileKey: z.string().min(1).optional(),
+});
+
+const catalogComponentSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  design: catalogDesignSchema.optional(),
+  args: z.array(catalogArgSchema).optional(),
+  blocks: z.array(catalogBlockSchema).optional(),
+});
+
+export const componentCatalogSchema = z.object({
+  updatedAt: z.string().datetime(),
+  components: z.array(catalogComponentSchema),
+});
+
+export type ComponentCatalog = z.infer<typeof componentCatalogSchema>;
+export type ComponentCatalogComponent = ComponentCatalog["components"][number];


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR documents the Accordion component group in the MCP component manifest file.

### :copilot: Copilot instructions

- Treat packages/mcp/src/catalogs/components/catalog.json as generated data; review source-of-truth docs/types, not prose style preferences.
- For component/arg/yield description, verify it matches website/docs/components/**/partials/code/component-api.md wording and meaning (no invented behavior).
- For default, require exact match to docs <C.Property ... @default="..."> when present; missing or different defaults are errors.
- For args, avoid duplicate info in description that is already encoded in type/default; keep behavioral nuance and constraints.
- For blocks, allow only name and yields; block-level descriptions should not be added.
- For yields, confirm name, type, kind, componentName, and boundArgs come from component signature parsing (packages/components/scripts/generate-component-catalog.mjs), not guessed from docs.
- If docs claim contextual yields not present in parsed signatures, classify as docs inconsistency (non-blocking) rather than schema/content corruption.
- Flag placeholders like "description": "TODO" as failures: enrichment did not resolve docs content.
- Ensure final catalog conforms to packages/mcp/src/catalogs/components/schema.ts; schema-valid output is required before accepting additions.
- Prefer exact docs text (minus context-only phrases like “see below”) over paraphrased rewrites when filling descriptions.

### :camera_flash: Screenshots

<!-- Screenshots always help, especially if this PR will change what renders to the browser -->

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6500](https://hashicorp.atlassian.net/browse/HDS-6500)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6500]: https://hashicorp.atlassian.net/browse/HDS-6500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ