### PR TITLE
[Spike] reproduce modal close issue

### DIFF
--- a/packages/components/src/components/hds/app-frame/index.gts
+++ b/packages/components/src/components/hds/app-frame/index.gts
@@ -68,24 +68,23 @@ export default class HdsAppFrame extends Component<HdsAppFrameSignature> {
 
   <template>
     <div class={{this.classNames}} ...attributes>
-      {{#if this.hasHeader}}
-        {{yield (hash Header=HdsAppFrameHeader)}}
-      {{/if}}
-      {{#if this.hasSidebar}}
-        {{yield (hash Sidebar=HdsAppFrameSidebar)}}
-      {{/if}}
-      {{!
+      {{!--
         IMPORTANT: since the modals may be injected via portal or in-element with code that lives in the "main" container,
         the "modal" container needs to be present in the DOM _before_ the "main" block, otherwise it may cause errors
         where the target DOM element is not found (for example in tests where the modal may be immediately opened on first render).
+
+        All sub-components are yielded in a single hash to avoid multiple {{yield}} calls, which would cause any
+        content placed directly in the block (e.g. a modal with {{#if}}) to be instantiated once per yield.
+      --}}
+      {{yield
+        (hash
+          Header=HdsAppFrameHeader
+          Sidebar=HdsAppFrameSidebar
+          Modals=HdsAppFrameModals
+          Main=HdsAppFrameMain
+          Footer=HdsAppFrameFooter
+        )
       }}
-      {{#if this.hasModals}}
-        {{yield (hash Modals=HdsAppFrameModals)}}
-      {{/if}}
-      {{yield (hash Main=HdsAppFrameMain)}}
-      {{#if this.hasFooter}}
-        {{yield (hash Footer=HdsAppFrameFooter)}}
-      {{/if}}
     </div>
   </template>
 }

--- a/packages/components/src/components/hds/modal/index.gts
+++ b/packages/components/src/components/hds/modal/index.gts
@@ -115,13 +115,17 @@ export default class HdsModal extends Component<HdsModalSignature> {
   }
 
   private _performCloseCleanup(caller: string = 'unknown'): void {
-    console.log(`[HdsModal] _performCloseCleanup called from: ${caller} | _isOpen=${String(this._isOpen)} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
+    console.log(
+      `[HdsModal] _performCloseCleanup called from: ${caller} | _isOpen=${String(this._isOpen)} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`
+    );
     this._isOpen = false;
 
     // Reset page `overflow` property
     if (this._body) {
       this._body.style.removeProperty('overflow');
-      console.log(`[HdsModal] _performCloseCleanup: overflow removed, body.overflow now="${document.body.style.getPropertyValue('overflow')}"`);
+      console.log(
+        `[HdsModal] _performCloseCleanup: overflow removed, body.overflow now="${document.body.style.getPropertyValue('overflow')}"`
+      );
       if (this._bodyInitialOverflowValue === '') {
         if (this._body.style.length === 0) {
           this._body.removeAttribute('style');
@@ -133,7 +137,9 @@ export default class HdsModal extends Component<HdsModalSignature> {
         );
       }
     } else {
-      console.warn('[HdsModal] _performCloseCleanup: this._body is falsy — overflow NOT restored!');
+      console.warn(
+        '[HdsModal] _performCloseCleanup: this._body is falsy — overflow NOT restored!'
+      );
     }
 
     // Return focus to a specific element (if provided)
@@ -143,11 +149,15 @@ export default class HdsModal extends Component<HdsModalSignature> {
         initiator.focus();
       }
     }
-    console.log(`[HdsModal] _performCloseCleanup done from: ${caller} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
+    console.log(
+      `[HdsModal] _performCloseCleanup done from: ${caller} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`
+    );
   }
 
   registerOnCloseCallback = (event: Event): void => {
-    console.log(`[HdsModal] registerOnCloseCallback fired | _isOpen=${String(this._isOpen)} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
+    console.log(
+      `[HdsModal] registerOnCloseCallback fired | _isOpen=${String(this._isOpen)} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`
+    );
     if (
       !this.isDismissDisabled &&
       this.args.onClose &&
@@ -155,7 +165,9 @@ export default class HdsModal extends Component<HdsModalSignature> {
     ) {
       console.log('[HdsModal] registerOnCloseCallback: calling args.onClose');
       this.args.onClose(event);
-      console.log(`[HdsModal] registerOnCloseCallback: args.onClose returned | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
+      console.log(
+        `[HdsModal] registerOnCloseCallback: args.onClose returned | body.overflow="${document.body.style.getPropertyValue('overflow')}"`
+      );
     }
 
     // If the dismissal of the modal is disabled, we keep the modal open/visible otherwise we mark it as closed
@@ -170,7 +182,9 @@ export default class HdsModal extends Component<HdsModalSignature> {
     } else {
       this._performCloseCleanup('registerOnCloseCallback');
     }
-    console.log(`[HdsModal] registerOnCloseCallback done | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
+    console.log(
+      `[HdsModal] registerOnCloseCallback done | body.overflow="${document.body.style.getPropertyValue('overflow')}"`
+    );
   };
 
   private _registerDialog = modifier((element: HTMLDialogElement) => {
@@ -227,13 +241,19 @@ export default class HdsModal extends Component<HdsModalSignature> {
     });
 
     return () => {
-      console.log(`[HdsModal] _registerDialog TEARDOWN | _isOpen=${String(this._isOpen)} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
+      console.log(
+        `[HdsModal] _registerDialog TEARDOWN | _isOpen=${String(this._isOpen)} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`
+      );
       // if the <dialog> is removed from the dom while open we emulate the close event
       if (this._isOpen) {
-        console.log('[HdsModal] _registerDialog teardown: _isOpen=true, calling _performCloseCleanup');
+        console.log(
+          '[HdsModal] _registerDialog teardown: _isOpen=true, calling _performCloseCleanup'
+        );
         this._performCloseCleanup('teardown');
       } else {
-        console.log('[HdsModal] _registerDialog teardown: _isOpen=false, skipping _performCloseCleanup');
+        console.log(
+          '[HdsModal] _registerDialog teardown: _isOpen=false, skipping _performCloseCleanup'
+        );
       }
 
       this._element?.removeEventListener(
@@ -257,14 +277,18 @@ export default class HdsModal extends Component<HdsModalSignature> {
   });
 
   open = (): void => {
-    console.log(`[HdsModal] open() called | body.overflow before="${document.body.style.getPropertyValue('overflow')}"`);
+    console.log(
+      `[HdsModal] open() called | body.overflow before="${document.body.style.getPropertyValue('overflow')}"`
+    );
     // Make modal dialog visible using the native `showModal` method
     this._element.showModal();
     this._isOpen = true;
 
     // Prevent page from scrolling when the dialog is open
     if (this._body) this._body.style.setProperty('overflow', 'hidden');
-    console.log(`[HdsModal] open() done | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
+    console.log(
+      `[HdsModal] open() done | body.overflow="${document.body.style.getPropertyValue('overflow')}"`
+    );
 
     // Call "onOpen" callback function
     if (this.args.onOpen && typeof this.args.onOpen === 'function') {

--- a/packages/components/src/components/hds/modal/index.gts
+++ b/packages/components/src/components/hds/modal/index.gts
@@ -114,12 +114,14 @@ export default class HdsModal extends Component<HdsModalSignature> {
     return classes.join(' ');
   }
 
-  private _performCloseCleanup(): void {
+  private _performCloseCleanup(caller: string = 'unknown'): void {
+    console.log(`[HdsModal] _performCloseCleanup called from: ${caller} | _isOpen=${String(this._isOpen)} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
     this._isOpen = false;
 
     // Reset page `overflow` property
     if (this._body) {
       this._body.style.removeProperty('overflow');
+      console.log(`[HdsModal] _performCloseCleanup: overflow removed, body.overflow now="${document.body.style.getPropertyValue('overflow')}"`);
       if (this._bodyInitialOverflowValue === '') {
         if (this._body.style.length === 0) {
           this._body.removeAttribute('style');
@@ -130,6 +132,8 @@ export default class HdsModal extends Component<HdsModalSignature> {
           this._bodyInitialOverflowValue
         );
       }
+    } else {
+      console.warn('[HdsModal] _performCloseCleanup: this._body is falsy — overflow NOT restored!');
     }
 
     // Return focus to a specific element (if provided)
@@ -139,15 +143,19 @@ export default class HdsModal extends Component<HdsModalSignature> {
         initiator.focus();
       }
     }
+    console.log(`[HdsModal] _performCloseCleanup done from: ${caller} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
   }
 
   registerOnCloseCallback = (event: Event): void => {
+    console.log(`[HdsModal] registerOnCloseCallback fired | _isOpen=${String(this._isOpen)} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
     if (
       !this.isDismissDisabled &&
       this.args.onClose &&
       typeof this.args.onClose === 'function'
     ) {
+      console.log('[HdsModal] registerOnCloseCallback: calling args.onClose');
       this.args.onClose(event);
+      console.log(`[HdsModal] registerOnCloseCallback: args.onClose returned | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
     }
 
     // If the dismissal of the modal is disabled, we keep the modal open/visible otherwise we mark it as closed
@@ -160,8 +168,9 @@ export default class HdsModal extends Component<HdsModalSignature> {
         this._element.showModal();
       }
     } else {
-      this._performCloseCleanup();
+      this._performCloseCleanup('registerOnCloseCallback');
     }
+    console.log(`[HdsModal] registerOnCloseCallback done | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
   };
 
   private _registerDialog = modifier((element: HTMLDialogElement) => {
@@ -218,9 +227,13 @@ export default class HdsModal extends Component<HdsModalSignature> {
     });
 
     return () => {
+      console.log(`[HdsModal] _registerDialog TEARDOWN | _isOpen=${String(this._isOpen)} | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
       // if the <dialog> is removed from the dom while open we emulate the close event
       if (this._isOpen) {
-        this._performCloseCleanup();
+        console.log('[HdsModal] _registerDialog teardown: _isOpen=true, calling _performCloseCleanup');
+        this._performCloseCleanup('teardown');
+      } else {
+        console.log('[HdsModal] _registerDialog teardown: _isOpen=false, skipping _performCloseCleanup');
       }
 
       this._element?.removeEventListener(
@@ -244,12 +257,14 @@ export default class HdsModal extends Component<HdsModalSignature> {
   });
 
   open = (): void => {
+    console.log(`[HdsModal] open() called | body.overflow before="${document.body.style.getPropertyValue('overflow')}"`);
     // Make modal dialog visible using the native `showModal` method
     this._element.showModal();
     this._isOpen = true;
 
     // Prevent page from scrolling when the dialog is open
     if (this._body) this._body.style.setProperty('overflow', 'hidden');
+    console.log(`[HdsModal] open() done | body.overflow="${document.body.style.getPropertyValue('overflow')}"`);
 
     // Call "onOpen" callback function
     if (this.args.onOpen && typeof this.args.onOpen === 'function') {

--- a/showcase/app/router.ts
+++ b/showcase/app/router.ts
@@ -132,6 +132,7 @@ Router.map(function () {
         this.route('demo-full-app-frame-with-app-header-and-app-side-nav');
         this.route('demo-full-app-frame-with-advanced-table');
         this.route('demo-full-app-frame-with-advanced-table-filtering');
+        this.route('demo-full-app-frame-with-functional-modal');
       });
     });
     this.route('flex');

--- a/showcase/app/templates/page-layouts/app-frame/frameless/demo-full-app-frame-with-functional-modal.gts
+++ b/showcase/app/templates/page-layouts/app-frame/frameless/demo-full-app-frame-with-functional-modal.gts
@@ -1,0 +1,73 @@
+/**
+ * Copyright IBM Corp. 2021, 2026
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Component from '@glimmer/component';
+import { pageTitle } from 'ember-page-title';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+import ShwPlaceholder from 'showcase/components/shw/placeholder';
+
+import {
+  HdsAppFrame,
+  HdsModal,
+  HdsButtonSet,
+  HdsButton,
+} from '@hashicorp/design-system-components/components';
+
+export default class PageLayoutsAppFrameFramelessDemoFullAppFrameWithModal extends Component {
+  @tracked isModalOpen = true;
+
+  handleModalClose = () => {
+    this.isModalOpen = false;
+  };
+
+  <template>
+    {{pageTitle "AppFrame Component - Frameless"}}
+
+    <HdsAppFrame as |Frame|>
+      <Frame.Header>
+        <ShwPlaceholder @height="60px" @text="header" @background="#e5ffd2" />
+      </Frame.Header>
+      <Frame.Sidebar>
+        <ShwPlaceholder
+          @width="120px"
+          @height="100%"
+          @text="sidebar"
+          @background="#e4c5f3"
+        />
+      </Frame.Sidebar>
+      <Frame.Main>
+        <ShwPlaceholder @height="200vh" @text="main" @background="#d2f4ff" />
+      </Frame.Main>
+      {{#if this.isModalOpen}}
+        <HdsModal @onClose={{this.handleModalClose}} as |M|>
+          <M.Header>Demo modal</M.Header>
+          <M.Body>
+            <ShwPlaceholder
+              @width="100%"
+              @height="100%"
+              @text="modal"
+              @background="#ffffffb5"
+            />
+          </M.Body>
+          <M.Footer as |MFooter|>
+            <HdsButtonSet>
+              <HdsButton
+                @color="secondary"
+                @text="Close"
+                {{on "click" MFooter.close}}
+              />
+              <HdsButton @text="Submit" {{on "click" MFooter.close}} />
+            </HdsButtonSet>
+          </M.Footer>
+        </HdsModal>
+      {{/if}}
+      <Frame.Footer>
+        <ShwPlaceholder @height="60px" @text="footer" @background="#fff8d2" />
+      </Frame.Footer>
+    </HdsAppFrame>
+  </template>
+}


### PR DESCRIPTION
### :pushpin: Summary

This came up when @pkj-web was using Helios for his project. We noticed that when the Modal wasn't within one of the yielded AppFrame components, it would work but scroll isn't properly restored when it closes. The fix is to either put it within a yielded component (like AF.Main) or to move it outside the AppFrame entirely.

Not sure this is a bug or not and if this is something we should address (I can't think of a time when the Modal would be used in this way in a consumer's app), but thought I would make a reproduction so we can discuss.

To reproduce the issue:
* Go to: https://hds-showcase-git-spike-modal-app-frame-hashicorp.vercel.app/layouts/app-frame/frameless/demo-full-app-frame-with-functional-modal
* Close the modal
* Notice you cant scroll the page

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>