### PR TITLE
[Project Solar / Phase 1 / Migration] Fix dropdown item focus ring

### DIFF
--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -300,10 +300,18 @@
     margin: 4px 0;
     padding: 7px 8px; // 7px=8px-1px(accounting for the transparent border)
 
-    // keep focus ring in sync with the padding
-    &::before {
-      top: 0;
-      bottom: 0;
+    &:focus-visible,
+    &.mock-focus {
+      &::before {
+        border: none;
+        outline: none;
+        box-shadow: var(--token-focus-ring-action-box-shadow);
+        inset: 0 -4px 0 -4px; // account for vertical margin
+
+        @include hds-apply-only-if-carbon() {
+          inset: -4px -8px -4px -8px; // account for link standalone vertical margin and footer padding
+        }
+      }
     }
   }
 
@@ -388,6 +396,7 @@
     &:focus-visible,
     &.mock-focus {
       color: var(--current-color-focus);
+      outline: none;
 
       &::after {
         left: 4px;

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -303,13 +303,11 @@
     &:focus-visible,
     &.mock-focus {
       &::before {
-        border: none;
-        outline: none;
-        box-shadow: var(--token-focus-ring-action-box-shadow);
-        inset: 0 -4px 0 -4px; // account for vertical margin
+        inset: 0 -4px 0 -4px;
 
         @include hds-apply-only-if-carbon() {
-          inset: -4px -8px -4px -8px; // account for link standalone vertical margin and footer padding
+          inset: -2px -6px -2px -6px;
+          outline-width: 2px;
         }
       }
     }

--- a/showcase/app/components/page-carbonization/foundations/focus-ring/index.gts
+++ b/showcase/app/components/page-carbonization/foundations/focus-ring/index.gts
@@ -46,10 +46,12 @@ import {
   HdsDropdown,
   HdsDropdownToggleButton,
   HdsDropdownToggleIcon,
+  HdsDropdownHeader,
   HdsDropdownListItemInteractive,
   HdsDropdownListItemCheckmark,
   HdsDropdownListItemCheckbox,
   HdsDropdownListItemRadio,
+  HdsDropdownFooter,
   HdsFilterBarTabs,
   HdsFormCheckboxBase,
   HdsFormFileInputBase,
@@ -682,6 +684,138 @@ const FocusRingCarbonizationIndex: TemplateOnlyComponent = <template>
                   Lorem ipsum
                 </HdsDropdownListItemRadio>
               </ul>
+            </div>
+          </SF.Item>
+        </ShwFlex>
+      </:theming>
+    </ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @label="Header/Footer">
+      <:theming>
+        <ShwFlex @direction="column" as |SF|>
+          <SF.Item>
+            <div class="hds-dropdown__content">
+              <HdsDropdownHeader
+                @hasDivider={{true}}
+                mock-state-value="focus"
+                mock-state-selector="button"
+              >
+                <HdsButton
+                  @text="Apply filters"
+                  @isFullWidth={{true}}
+                  @size="small"
+                />
+              </HdsDropdownHeader>
+              <ul class="hds-dropdown__list">
+                <HdsDropdownListItemInteractive
+                >Lorem</HdsDropdownListItemInteractive>
+                <HdsDropdownListItemInteractive
+                >Ipsum</HdsDropdownListItemInteractive>
+              </ul>
+              <HdsDropdownFooter
+                @hasDivider={{true}}
+                mock-state-value="focus"
+                mock-state-selector="button"
+              >
+                <HdsButton
+                  @text="Apply filters"
+                  @isFullWidth={{true}}
+                  @size="small"
+                />
+              </HdsDropdownFooter>
+            </div>
+          </SF.Item>
+        </ShwFlex>
+      </:theming>
+    </ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @hideThemeLabels={{true}}>
+      <:theming>
+        <ShwFlex @direction="column" as |SF|>
+          <SF.Item>
+            <div class="hds-dropdown__content">
+              <HdsDropdownHeader
+                @hasDivider={{true}}
+                mock-state-value="focus"
+                mock-state-selector="button"
+              >
+                <HdsButtonSet>
+                  <HdsButton
+                    @text="Apply"
+                    @isFullWidth={{true}}
+                    @size="small"
+                  />
+                  <HdsButton
+                    @text="Cancel"
+                    @color="secondary"
+                    @isFullWidth={{true}}
+                    @size="small"
+                  />
+                </HdsButtonSet>
+              </HdsDropdownHeader>
+              <ul class="hds-dropdown__list">
+                <HdsDropdownListItemInteractive
+                >Lorem</HdsDropdownListItemInteractive>
+                <HdsDropdownListItemInteractive
+                >Ipsum</HdsDropdownListItemInteractive>
+              </ul>
+              <HdsDropdownFooter
+                @hasDivider={{true}}
+                mock-state-value="focus"
+                mock-state-selector="button"
+              >
+                <HdsButtonSet>
+                  <HdsButton
+                    @text="Apply"
+                    @isFullWidth={{true}}
+                    @size="small"
+                  />
+                  <HdsButton
+                    @text="Cancel"
+                    @color="secondary"
+                    @isFullWidth={{true}}
+                    @size="small"
+                  />
+                </HdsButtonSet>
+              </HdsDropdownFooter>
+            </div>
+          </SF.Item>
+        </ShwFlex>
+      </:theming>
+    </ShwCarbonizationComparisonGrid>
+    <ShwCarbonizationComparisonGrid @hideThemeLabels={{true}}>
+      <:theming>
+        <ShwFlex @direction="column" as |SF|>
+          <SF.Item>
+            <div class="hds-dropdown__content">
+              <HdsDropdownHeader
+                @hasDivider={{true}}
+                mock-state-value="focus"
+                mock-state-selector="a"
+              >
+                <HdsLinkStandalone
+                  @icon="list"
+                  @text="Organizations"
+                  @color="secondary"
+                  @href="#"
+                />
+              </HdsDropdownHeader>
+              <ul class="hds-dropdown__list">
+                <HdsDropdownListItemInteractive
+                >Lorem</HdsDropdownListItemInteractive>
+                <HdsDropdownListItemInteractive
+                >Ipsum</HdsDropdownListItemInteractive>
+              </ul>
+              <HdsDropdownFooter
+                @hasDivider={{true}}
+                mock-state-value="focus"
+                mock-state-selector="a"
+              >
+                <HdsLinkStandalone
+                  @icon="list"
+                  @text="Organizations"
+                  @color="secondary"
+                  @href="#"
+                />
+              </HdsDropdownFooter>
             </div>
           </SF.Item>
         </ShwFlex>

--- a/showcase/app/components/page-foundations/focus-ring/sub-sections/components.gts
+++ b/showcase/app/components/page-foundations/focus-ring/sub-sections/components.gts
@@ -44,10 +44,12 @@ import {
   HdsDropdown,
   HdsDropdownToggleButton,
   HdsDropdownToggleIcon,
+  HdsDropdownHeader,
   HdsDropdownListItemInteractive,
   HdsDropdownListItemCheckmark,
   HdsDropdownListItemCheckbox,
   HdsDropdownListItemRadio,
+  HdsDropdownFooter,
   HdsFilterBarTabs,
   HdsFormCheckboxBase,
   HdsFormFileInputBase,
@@ -562,6 +564,110 @@ const SubSectionComponents: TemplateOnlyComponent = <template>
             Lorem ipsum
           </HdsDropdownListItemRadio>
         </ul>
+      </div>
+    </SF.Item>
+  </ShwFlex>
+
+  <ShwTextBody>Header/Footer</ShwTextBody>
+  <ShwFlex @direction="column" as |SF|>
+    <SF.Item @label="Single button">
+      <div class="hds-dropdown__content">
+        <HdsDropdownHeader
+          @hasDivider={{true}}
+          mock-state-value="focus"
+          mock-state-selector="button"
+        >
+          <HdsButton
+            @text="Apply filters"
+            @isFullWidth={{true}}
+            @size="small"
+          />
+        </HdsDropdownHeader>
+        <ul class="hds-dropdown__list">
+          <HdsDropdownListItemInteractive>Lorem</HdsDropdownListItemInteractive>
+          <HdsDropdownListItemInteractive>Ipsum</HdsDropdownListItemInteractive>
+        </ul>
+        <HdsDropdownFooter
+          @hasDivider={{true}}
+          mock-state-value="focus"
+          mock-state-selector="button"
+        >
+          <HdsButton
+            @text="Apply filters"
+            @isFullWidth={{true}}
+            @size="small"
+          />
+        </HdsDropdownFooter>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Button group">
+      <div class="hds-dropdown__content">
+        <HdsDropdownHeader
+          @hasDivider={{true}}
+          mock-state-value="focus"
+          mock-state-selector="button"
+        >
+          <HdsButtonSet>
+            <HdsButton @text="Apply" @isFullWidth={{true}} @size="small" />
+            <HdsButton
+              @text="Cancel"
+              @color="secondary"
+              @isFullWidth={{true}}
+              @size="small"
+            />
+          </HdsButtonSet>
+        </HdsDropdownHeader>
+        <ul class="hds-dropdown__list">
+          <HdsDropdownListItemInteractive>Lorem</HdsDropdownListItemInteractive>
+          <HdsDropdownListItemInteractive>Ipsum</HdsDropdownListItemInteractive>
+        </ul>
+        <HdsDropdownFooter
+          @hasDivider={{true}}
+          mock-state-value="focus"
+          mock-state-selector="button"
+        >
+          <HdsButtonSet>
+            <HdsButton @text="Apply" @isFullWidth={{true}} @size="small" />
+            <HdsButton
+              @text="Cancel"
+              @color="secondary"
+              @isFullWidth={{true}}
+              @size="small"
+            />
+          </HdsButtonSet>
+        </HdsDropdownFooter>
+      </div>
+    </SF.Item>
+    <SF.Item @label="Link secondary">
+      <div class="hds-dropdown__content">
+        <HdsDropdownHeader
+          @hasDivider={{true}}
+          mock-state-value="focus"
+          mock-state-selector="a"
+        >
+          <HdsLinkStandalone
+            @icon="list"
+            @text="Organizations"
+            @color="secondary"
+            @href="#"
+          />
+        </HdsDropdownHeader>
+        <ul class="hds-dropdown__list">
+          <HdsDropdownListItemInteractive>Lorem</HdsDropdownListItemInteractive>
+          <HdsDropdownListItemInteractive>Ipsum</HdsDropdownListItemInteractive>
+        </ul>
+        <HdsDropdownFooter
+          @hasDivider={{true}}
+          mock-state-value="focus"
+          mock-state-selector="a"
+        >
+          <HdsLinkStandalone
+            @icon="list"
+            @text="Organizations"
+            @color="secondary"
+            @href="#"
+          />
+        </HdsDropdownFooter>
       </div>
     </SF.Item>
   </ShwFlex>

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -5008,11 +5008,20 @@ button.hds-button[href]::after {
   margin: 4px 0;
   padding: 7px 8px;
 }
-.hds-dropdown__header > .hds-link-standalone::before,
-.hds-dropdown__footer > .hds-link-standalone::before {
-  top: 0;
-  bottom: 0;
+.hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-dropdown__header > .hds-link-standalone.mock-focus::before,
+.hds-dropdown__footer > .hds-link-standalone:focus-visible::before,
+.hds-dropdown__footer > .hds-link-standalone.mock-focus::before {
+  inset: 0px -4px 0px -4px;
+  outline: none;
+  box-shadow: var(--token-focus-ring-action-box-shadow);
+  border: none;
 }
+.hds-theme-light .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-light .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-light .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-light .hds-dropdown__footer > .hds-link-standalone.mock-focus::before,
+.hds-theme-dark .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-dark .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-dark .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-dark .hds-dropdown__footer > .hds-link-standalone.mock-focus::before,
+.hds-theme-system .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-system .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-system .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-system .hds-dropdown__footer > .hds-link-standalone.mock-focus::before {
+  inset: -4px -8px -4px -8px;
+}
+
 .hds-dropdown__header > .hds-button,
 .hds-dropdown__header > .hds-form-text-input,
 .hds-dropdown__footer > .hds-button,
@@ -5134,6 +5143,7 @@ button.hds-button[href]::after {
 .hds-dropdown-list-item--variant-radio .hds-dropdown-list-item__label:focus-visible,
 .hds-dropdown-list-item--variant-radio .hds-dropdown-list-item__label.mock-focus {
   color: var(--current-color-focus);
+  outline: none;
 }
 .hds-dropdown-list-item--variant-interactive a:focus-visible::after, .hds-dropdown-list-item--variant-interactive a.mock-focus::after,
 .hds-dropdown-list-item--variant-interactive button:focus-visible::after,

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -5011,15 +5011,13 @@ button.hds-button[href]::after {
 .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-dropdown__header > .hds-link-standalone.mock-focus::before,
 .hds-dropdown__footer > .hds-link-standalone:focus-visible::before,
 .hds-dropdown__footer > .hds-link-standalone.mock-focus::before {
-  inset: 0px -4px 0px -4px;
-  outline: none;
-  box-shadow: var(--token-focus-ring-action-box-shadow);
-  border: none;
+  inset: 0 -4px 0 -4px;
 }
 .hds-theme-light .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-light .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-light .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-light .hds-dropdown__footer > .hds-link-standalone.mock-focus::before,
 .hds-theme-dark .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-dark .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-dark .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-dark .hds-dropdown__footer > .hds-link-standalone.mock-focus::before,
 .hds-theme-system .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-system .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-system .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-system .hds-dropdown__footer > .hds-link-standalone.mock-focus::before {
-  inset: -4px -8px -4px -8px;
+  inset: -2px -6px -2px -6px;
+  outline-width: 2px;
 }
 
 .hds-dropdown__header > .hds-button,

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -5821,15 +5821,13 @@ button.hds-button[href]::after {
 .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-dropdown__header > .hds-link-standalone.mock-focus::before,
 .hds-dropdown__footer > .hds-link-standalone:focus-visible::before,
 .hds-dropdown__footer > .hds-link-standalone.mock-focus::before {
-  inset: 0px -4px 0px -4px;
-  outline: none;
-  box-shadow: var(--token-focus-ring-action-box-shadow);
-  border: none;
+  inset: 0 -4px 0 -4px;
 }
 .hds-theme-light .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-light .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-light .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-light .hds-dropdown__footer > .hds-link-standalone.mock-focus::before,
 .hds-theme-dark .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-dark .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-dark .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-dark .hds-dropdown__footer > .hds-link-standalone.mock-focus::before,
 .hds-theme-system .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-system .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-system .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-system .hds-dropdown__footer > .hds-link-standalone.mock-focus::before {
-  inset: -4px -8px -4px -8px;
+  inset: -2px -6px -2px -6px;
+  outline-width: 2px;
 }
 
 .hds-dropdown__header > .hds-button,

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -5818,11 +5818,20 @@ button.hds-button[href]::after {
   margin: 4px 0;
   padding: 7px 8px;
 }
-.hds-dropdown__header > .hds-link-standalone::before,
-.hds-dropdown__footer > .hds-link-standalone::before {
-  top: 0;
-  bottom: 0;
+.hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-dropdown__header > .hds-link-standalone.mock-focus::before,
+.hds-dropdown__footer > .hds-link-standalone:focus-visible::before,
+.hds-dropdown__footer > .hds-link-standalone.mock-focus::before {
+  inset: 0px -4px 0px -4px;
+  outline: none;
+  box-shadow: var(--token-focus-ring-action-box-shadow);
+  border: none;
 }
+.hds-theme-light .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-light .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-light .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-light .hds-dropdown__footer > .hds-link-standalone.mock-focus::before,
+.hds-theme-dark .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-dark .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-dark .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-dark .hds-dropdown__footer > .hds-link-standalone.mock-focus::before,
+.hds-theme-system .hds-dropdown__header > .hds-link-standalone:focus-visible::before, .hds-theme-system .hds-dropdown__header > .hds-link-standalone.mock-focus::before, .hds-theme-system .hds-dropdown__footer > .hds-link-standalone:focus-visible::before, .hds-theme-system .hds-dropdown__footer > .hds-link-standalone.mock-focus::before {
+  inset: -4px -8px -4px -8px;
+}
+
 .hds-dropdown__header > .hds-button,
 .hds-dropdown__header > .hds-form-text-input,
 .hds-dropdown__footer > .hds-button,
@@ -5944,6 +5953,7 @@ button.hds-button[href]::after {
 .hds-dropdown-list-item--variant-radio .hds-dropdown-list-item__label:focus-visible,
 .hds-dropdown-list-item--variant-radio .hds-dropdown-list-item__label.mock-focus {
   color: var(--current-color-focus);
+  outline: none;
 }
 .hds-dropdown-list-item--variant-interactive a:focus-visible::after, .hds-dropdown-list-item--variant-interactive a.mock-focus::after,
 .hds-dropdown-list-item--variant-interactive button:focus-visible::after,


### PR DESCRIPTION
### :pushpin: Summary

This PR fixes a design bug with the `HdsDropdown` list item and footer link focus states.

[PREVIEW](https://hds-showcase-git-project-solar-phase-1dchyundr-7e5dcf-hashicorp.vercel.app/carbonization/components/dropdown)

### Detailed description

#### List item interactive

Currently the intended focus state for the dropdown list item is a custom design to match the Carbon focus ring. The styles for this style are properly done. However, because the focus styles for the list item do not set `outline :none` the native focus ring is preventing the custom style from being visible.

This PR adds `outline: none` to hide the native focus ring and show the expected focus ring.

**Note:** This issue is only visible when using the keyboard to focus on items through the `:focus-visible` selector. The issue is not seen in the `mock-focus` examples because those don't apply the native focus ring. 

#### Footer link

Currently the Footer link uses the `LinkStandalone` focus style since that is the component it uses internally. However this means the focus style for the footer link does not align to that of the other dropdown items. 

This PR updates the focus style to match that of the interactive list items

### :camera_flash: Screenshots

#### List item

**Before**
<img width="489" height="569" alt="Screenshot 2026-07-02 at 10 59 17 AM" src="https://github.com/user-attachments/assets/eaffbe0a-052d-43e1-af4f-ac0749a12d8e" />

**After**
<img width="467" height="564" alt="Screenshot 2026-07-02 at 10 59 35 AM" src="https://github.com/user-attachments/assets/5926fe72-ae46-4bb2-b1fe-615ead26898e" />

#### Footer link

**Before**
<img width="493" height="511" alt="Screenshot 2026-07-02 at 2 36 45 PM" src="https://github.com/user-attachments/assets/efb04557-f77c-4700-bfd8-c731f5b6fe26" />

**After**
<img width="493" alt="Screenshot 2026-07-02 at 2 37 07 PM" src="https://github.com/user-attachments/assets/8b383c91-865f-481a-baab-28c4463c266e" />


***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>