### PR TITLE
MCP - Prompt architecture

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -110,9 +110,9 @@ const main = async (): Promise<void> => {
   try {
     const server = buildServer();
 
-    registerPrompts(server);
-
     shutdown = installLifecycleHandlers(server).shutdown;
+
+    registerPrompts(server);
 
     const transport = new StdioServerTransport();
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -8,6 +8,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { dirname, resolve } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { registerPrompts } from "./prompts/index.js";
 
 const currentFilePath = fileURLToPath(import.meta.url);
 const currentDirectoryPath = dirname(currentFilePath);
@@ -108,6 +109,8 @@ const main = async (): Promise<void> => {
 
   try {
     const server = buildServer();
+
+    registerPrompts(server);
 
     shutdown = installLifecycleHandlers(server).shutdown;
 

--- a/packages/mcp/src/prompts/index.ts
+++ b/packages/mcp/src/prompts/index.ts
@@ -4,8 +4,7 @@
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { McpPrompt } from "./types.ts";
-
+import type { McpPrompt } from "./types.js";
 const PROMPTS: McpPrompt[] = [];
 
 export function registerPrompts(server: McpServer) {

--- a/packages/mcp/src/prompts/index.ts
+++ b/packages/mcp/src/prompts/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpPrompt } from "./types.ts";
+
+const PROMPTS: McpPrompt[] = [];
+
+export function registerPrompts(server: McpServer) {
+  for (const prompt of PROMPTS) {
+    server.registerPrompt(prompt);
+  }
+
+  // registerComponentUsagePrompt(server, store);
+}

--- a/packages/mcp/src/prompts/index.ts
+++ b/packages/mcp/src/prompts/index.ts
@@ -10,8 +10,13 @@ const PROMPTS: McpPrompt[] = [];
 
 export function registerPrompts(server: McpServer) {
   for (const prompt of PROMPTS) {
+<<<<<<< Updated upstream
     server.registerPrompt(prompt);
   }
 
   // registerComponentUsagePrompt(server, store);
+=======
+    server.registerPrompt(prompt.name, prompt.config, prompt.callback);
+  }
+>>>>>>> Stashed changes
 }

--- a/packages/mcp/src/prompts/index.ts
+++ b/packages/mcp/src/prompts/index.ts
@@ -10,13 +10,6 @@ const PROMPTS: McpPrompt[] = [];
 
 export function registerPrompts(server: McpServer) {
   for (const prompt of PROMPTS) {
-<<<<<<< Updated upstream
-    server.registerPrompt(prompt);
-  }
-
-  // registerComponentUsagePrompt(server, store);
-=======
     server.registerPrompt(prompt.name, prompt.config, prompt.callback);
   }
->>>>>>> Stashed changes
 }

--- a/packages/mcp/src/prompts/types.ts
+++ b/packages/mcp/src/prompts/types.ts
@@ -1,0 +1,27 @@
+import type { ZodRawShapeCompat } from "./args.ts";
+
+export type PromptTextMessage = {
+  role: "user" | "assistant";
+  content: {
+    type: "text";
+    text: string;
+  };
+};
+
+export type PromptResourceLinkMessage = {
+  role: "user" | "assistant";
+  content: {
+    type: "resource_link";
+    uri: string;
+    name: string;
+    description?: string;
+    mimeType?: string;
+  };
+};
+
+export interface McpPrompt<Args extends PromptArgsRawShape> {
+  id: string;
+  name: string;
+  description?: string;
+  messages: PromptMessage[];
+}

--- a/packages/mcp/src/prompts/types.ts
+++ b/packages/mcp/src/prompts/types.ts
@@ -1,27 +1,12 @@
-import type { ZodRawShapeCompat } from "./args.ts";
+import type { PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
 
-export type PromptTextMessage = {
-  role: "user" | "assistant";
-  content: {
-    type: "text";
-    text: string;
-  };
-};
-
-export type PromptResourceLinkMessage = {
-  role: "user" | "assistant";
-  content: {
-    type: "resource_link";
-    uri: string;
-    name: string;
-    description?: string;
-    mimeType?: string;
-  };
-};
-
-export interface McpPrompt<Args extends PromptArgsRawShape> {
-  id: string;
+export interface McpPrompt<Args extends ZodRawShapeCompat = ZodRawShapeCompat> {
   name: string;
-  description?: string;
-  messages: PromptMessage[];
+  config: {
+    title?: string;
+    description?: string;
+    argsSchema: Args;
+  };
+  callback: PromptCallback<Args>;
 }

--- a/packages/mcp/src/prompts/types.ts
+++ b/packages/mcp/src/prompts/types.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import type { PromptCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds MCP prompt-registration infrastructure and wires it into server startup.

### :hammer_and_wrench: Detailed description

- Adds `registerPrompts(server)` in `packages/mcp/src/prompts/index.ts` with a central `PROMPTS` registry (currently empty) and loops through it to register prompts.  
- Introduces `McpPrompt` typing in `packages/mcp/src/prompts/types.ts` for prompt name/config/callback shape consistency.  
- Updates MCP server bootstrap in `packages/mcp/src/index.ts` to import and invoke `registerPrompts(server)` before connecting transport.  
- No behavior change yet for end users: this is scaffolding to support adding concrete MCP prompts in follow-up PRs.

### :copilot: Copilot instructions

- Confirm prompt registration is initialized at the correct lifecycle point in `packages/mcp/src/index.ts`.  
- Validate `McpPrompt` type constraints and compatibility with `server.registerPrompt(...)`.  
- Check for module-resolution/type import issues in `packages/mcp/src/prompts/index.ts` and `packages/mcp/src/prompts/types.ts`.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6501](https://hashicorp.atlassian.net/browse/HDS-6501)
Figma file: [if it applies]

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6501]: https://hashicorp.atlassian.net/browse/HDS-6501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ