### PR TITLE
[Project Solar / Phase 1 / Follow-up] Handle structured `comments`

### DIFF
--- a/packages/tokens/dist/docs/products/themed-tokens.json
+++ b/packages/tokens/dist/docs/products/themed-tokens.json
@@ -5908,9 +5908,6 @@
         "cds-g90": "inset 0 0 0 3px #5990ff",
         "cds-g100": "inset 0 0 0 3px #5990ff"
       },
-      "comments": {
-        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-      },
       "original": {
         "$value": "inset 0 0 0 {focus-ring.width.internal} {color.focus.action.internal}, 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
         "$modes": {
@@ -5953,6 +5950,9 @@
           "cds-g10": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
           "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
           "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
+        },
+        "comments": {
+          "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
         "key": "{focus-ring.critical.box-shadow}"
       },
@@ -6831,9 +6831,7 @@
           0.9
         ]
       },
-      "comments": {
-        "hds": "the values correspond to the `ease` timing function, the browser's default"
-      },
+      "comment": "the values correspond to the `ease` timing function, the browser's default",
       "original": {
         "$type": "cubicBezier",
         "$value": [
@@ -6877,6 +6875,7 @@
         "comments": {
           "hds": "the values correspond to the `ease` timing function, the browser's default"
         },
+        "comment": "the values correspond to the `ease` timing function, the browser's default",
         "key": "{accordion.item.toggle.icon.transition.timing-function}"
       },
       "name": "hds-accordion-item-toggle-icon-transition-timing-function",
@@ -11300,9 +11299,6 @@
       "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
       "$type": "color",
       "$value": "#ffffff",
-      "comments": {
-        "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.high-contrast}",
@@ -11520,10 +11516,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "we don't use `warning-on-surface` for accessibility (better contrast)",
       "original": {
         "$type": "color",
         "$value": "{color.palette.amber-400}",
@@ -11538,6 +11531,7 @@
           "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "we don't use `warning-on-surface` for accessibility (better contrast)",
         "key": "{badge.foreground.color.warning.filled}"
       },
       "name": "hds-badge-foreground-color-warning-filled",
@@ -11583,9 +11577,6 @@
         "cds-g10": "#8a3800",
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
-      },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
       "original": {
         "$type": "color",
@@ -12041,7 +12032,6 @@
       "key": "{badge.surface.color.warning.filled}",
       "$type": "color",
       "$value": "#fbeabf",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "#fbeabf",
         "cds-g0": "#ffd9be",
@@ -12049,13 +12039,10 @@
         "cds-g90": "#8a3800",
         "cds-g100": "#8a3800"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "original": {
         "$type": "color",
         "$value": "{color.palette.amber-100}",
-        "comment": "we don't use `surface-warning` for accessibility (better contrast)",
         "$modes": {
           "default": "{color.palette.amber-100}",
           "cds-g0": "{carbon.color.orange.20}",
@@ -12064,8 +12051,10 @@
           "cds-g100": "{carbon.color.orange.70}"
         },
         "comments": {
+          "hds": "we don't use `surface-warning` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "we don't use `surface-warning` for accessibility (better contrast)",
         "key": "{badge.surface.color.warning.filled}"
       },
       "name": "hds-badge-surface-color-warning-filled",
@@ -12090,9 +12079,6 @@
         "cds-g10": "#8a3800",
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
-      },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
       "original": {
         "$type": "color",
@@ -13278,10 +13264,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
       "original": {
         "$type": "number",
         "$value": 0.9286,
@@ -13296,6 +13279,7 @@
           "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
         "key": "{button.typography.line-height.small}"
       },
       "name": "hds-button-typography-line-height-small",
@@ -13320,10 +13304,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "16px/14px ~ 1.1429",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "16px/14px ~ 1.1429",
       "original": {
         "$type": "number",
         "$value": 1.1429,
@@ -13338,6 +13319,7 @@
           "hds": "16px/14px ~ 1.1429",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "16px/14px ~ 1.1429",
         "key": "{button.typography.line-height.medium}"
       },
       "name": "hds-button-typography-line-height-medium",
@@ -13362,10 +13344,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "24px/16px = 1.5",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "24px/16px = 1.5",
       "original": {
         "$type": "number",
         "$value": 1.5,
@@ -13380,6 +13359,7 @@
           "hds": "24px/16px = 1.5",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "24px/16px = 1.5",
         "key": "{button.typography.line-height.large}"
       },
       "name": "hds-button-typography-line-height-large",
@@ -13957,9 +13937,6 @@
       "key": "{button.foreground.color.tertiary.disabled}",
       "$type": "color",
       "$value": "#8c909c",
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.disabled}",
@@ -14130,9 +14107,6 @@
         "cds-g10": "#8d8d8d",
         "cds-g90": "rgba(255, 255, 255, 0.25)",
         "cds-g100": "rgba(255, 255, 255, 0.25)"
-      },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
       "original": {
         "$type": "color",
@@ -14857,9 +14831,6 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.surface.interactive-disabled}",
@@ -15317,9 +15288,6 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
       "original": {
         "$type": "color",
         "$value": "transparent",
@@ -15462,9 +15430,6 @@
         "cds-g10": "#c6c6c6",
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
-      },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
       "original": {
         "$type": "color",
@@ -16917,9 +16882,7 @@
           "$type": "font-size"
         }
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-      },
+      "comment": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline",
       "original": {
         "$type": "font-size",
         "$value": "{typography.body-100.font-size}",
@@ -16957,6 +16920,7 @@
         "comments": {
           "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
         },
+        "comment": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline",
         "key": "{dialog-primitive.header.tagline.typography.font-size}"
       },
       "name": "hds-dialog-primitive-header-tagline-typography-font-size",
@@ -16982,9 +16946,7 @@
         "cds-g90": 1.33333,
         "cds-g100": 1.33333
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-      },
+      "comment": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline",
       "original": {
         "$type": "number",
         "$value": "{typography.body-100.line-height}",
@@ -16998,6 +16960,7 @@
         "comments": {
           "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
         },
+        "comment": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline",
         "key": "{dialog-primitive.header.tagline.typography.line-height}"
       },
       "name": "hds-dialog-primitive-header-tagline-typography-line-height",
@@ -17023,9 +16986,7 @@
         "cds-g90": 400,
         "cds-g100": 400
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
-      },
+      "comment": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title",
       "original": {
         "$type": "font-weight",
         "$value": "{typography.font-weight.semibold}",
@@ -17039,6 +17000,7 @@
         "comments": {
           "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
         },
+        "comment": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title",
         "key": "{dialog-primitive.header.title.typography.font-weight}"
       },
       "name": "hds-dialog-primitive-header-title-typography-font-weight",
@@ -31612,9 +31574,7 @@
         "cds-g90": "inset 0 0 0 2px #0f62fe",
         "cds-g100": "inset 0 0 0 2px #0f62fe"
       },
-      "comments": {
-        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-      },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "original": {
         "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
         "$modes": {
@@ -31627,6 +31587,7 @@
         "comments": {
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
+        "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
         "key": "{focus-ring.action.box-shadow}"
       },
       "name": "hds-focus-ring-action-box-shadow",
@@ -31649,6 +31610,7 @@
         "cds-g90": "inset 0 0 0 2px #0f62fe",
         "cds-g100": "inset 0 0 0 2px #0f62fe"
       },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "original": {
         "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "$modes": {
@@ -31658,6 +31620,10 @@
           "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
           "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
         },
+        "comments": {
+          "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
+        },
+        "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
         "key": "{focus-ring.critical.box-shadow}"
       },
       "name": "hds-focus-ring-critical-box-shadow",
@@ -32534,9 +32500,6 @@
           0.38,
           0.9
         ]
-      },
-      "comments": {
-        "hds": "the values correspond to the `ease` timing function, the browser's default"
       },
       "original": {
         "$type": "cubicBezier",
@@ -37014,9 +36977,6 @@
       "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
       "$type": "color",
       "$value": "#ffffff",
-      "comments": {
-        "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.high-contrast}",
@@ -37234,10 +37194,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.70}",
@@ -37252,6 +37209,7 @@
           "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.foreground.color.warning.filled}"
       },
       "name": "hds-badge-foreground-color-warning-filled",
@@ -37298,9 +37256,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.70}",
@@ -37314,6 +37270,7 @@
         "comments": {
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.foreground.color.warning.outlined}"
       },
       "name": "hds-badge-foreground-color-warning-outlined",
@@ -37755,7 +37712,6 @@
       "key": "{badge.surface.color.warning.filled}",
       "$type": "color",
       "$value": "#ffd9be",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "#ffd9be",
         "cds-g0": "#ffd9be",
@@ -37763,13 +37719,10 @@
         "cds-g90": "#8a3800",
         "cds-g100": "#8a3800"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.20}",
-        "comment": "we don't use `surface-warning` for accessibility (better contrast)",
         "$modes": {
           "default": "{color.palette.amber-100}",
           "cds-g0": "{carbon.color.orange.20}",
@@ -37778,8 +37731,10 @@
           "cds-g100": "{carbon.color.orange.70}"
         },
         "comments": {
+          "hds": "we don't use `surface-warning` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.surface.color.warning.filled}"
       },
       "name": "hds-badge-surface-color-warning-filled",
@@ -37805,9 +37760,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.70}",
@@ -37821,6 +37774,7 @@
         "comments": {
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.surface.color.warning.inverted}"
       },
       "name": "hds-badge-surface-color-warning-inverted",
@@ -38992,10 +38946,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -39010,6 +38961,7 @@
           "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.small}"
       },
       "name": "hds-button-typography-line-height-small",
@@ -39034,10 +38986,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "16px/14px ~ 1.1429",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -39052,6 +39001,7 @@
           "hds": "16px/14px ~ 1.1429",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.medium}"
       },
       "name": "hds-button-typography-line-height-medium",
@@ -39076,10 +39026,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "24px/16px = 1.5",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -39094,6 +39041,7 @@
           "hds": "24px/16px = 1.5",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.large}"
       },
       "name": "hds-button-typography-line-height-large",
@@ -39671,9 +39619,6 @@
       "key": "{button.foreground.color.tertiary.disabled}",
       "$type": "color",
       "$value": "rgba(22, 22, 22, 0.25)",
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.disabled}",
@@ -39845,9 +39790,7 @@
         "cds-g90": "rgba(255, 255, 255, 0.25)",
         "cds-g100": "rgba(255, 255, 255, 0.25)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.white.textOnColorDisabled}",
@@ -39861,6 +39804,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.foreground.color.disabled}"
       },
       "name": "hds-button-foreground-color-disabled",
@@ -40571,9 +40515,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.white}",
@@ -40587,6 +40529,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.surface.color.disabled}"
       },
       "name": "hds-button-surface-color-disabled",
@@ -41031,9 +40974,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.white}",
@@ -41047,6 +40988,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.border.color.tertiary.disabled}"
       },
       "name": "hds-button-border-color-tertiary-disabled",
@@ -41177,9 +41119,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.white}",
@@ -41193,6 +41133,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.border.color.disabled}"
       },
       "name": "hds-button-border-color-disabled",
@@ -42631,9 +42572,6 @@
           "$type": "font-size"
         }
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-      },
       "unit": "rem",
       "original": {
         "$type": "font-size",
@@ -42698,9 +42636,6 @@
         "cds-g90": 1.33333,
         "cds-g100": 1.33333
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-      },
       "original": {
         "$type": "number",
         "$value": "{carbon.typography.label01.line-height}",
@@ -42738,9 +42673,6 @@
         "cds-g10": 400,
         "cds-g90": 400,
         "cds-g100": 400
-      },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
       },
       "original": {
         "$type": "font-weight",
@@ -57328,9 +57260,7 @@
         "cds-g90": "inset 0 0 0 2px #0f62fe",
         "cds-g100": "inset 0 0 0 2px #0f62fe"
       },
-      "comments": {
-        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-      },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "original": {
         "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
         "$modes": {
@@ -57343,6 +57273,7 @@
         "comments": {
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
+        "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
         "key": "{focus-ring.action.box-shadow}"
       },
       "name": "hds-focus-ring-action-box-shadow",
@@ -57365,6 +57296,7 @@
         "cds-g90": "inset 0 0 0 2px #0f62fe",
         "cds-g100": "inset 0 0 0 2px #0f62fe"
       },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "original": {
         "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "$modes": {
@@ -57374,6 +57306,10 @@
           "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
           "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
         },
+        "comments": {
+          "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
+        },
+        "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
         "key": "{focus-ring.critical.box-shadow}"
       },
       "name": "hds-focus-ring-critical-box-shadow",
@@ -58250,9 +58186,6 @@
           0.38,
           0.9
         ]
-      },
-      "comments": {
-        "hds": "the values correspond to the `ease` timing function, the browser's default"
       },
       "original": {
         "$type": "cubicBezier",
@@ -62730,9 +62663,6 @@
       "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
       "$type": "color",
       "$value": "#ffffff",
-      "comments": {
-        "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.high-contrast}",
@@ -62950,10 +62880,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.70}",
@@ -62968,6 +62895,7 @@
           "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.foreground.color.warning.filled}"
       },
       "name": "hds-badge-foreground-color-warning-filled",
@@ -63014,9 +62942,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.70}",
@@ -63030,6 +62956,7 @@
         "comments": {
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.foreground.color.warning.outlined}"
       },
       "name": "hds-badge-foreground-color-warning-outlined",
@@ -63471,7 +63398,6 @@
       "key": "{badge.surface.color.warning.filled}",
       "$type": "color",
       "$value": "#ffd9be",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "#ffd9be",
         "cds-g0": "#ffd9be",
@@ -63479,13 +63405,10 @@
         "cds-g90": "#8a3800",
         "cds-g100": "#8a3800"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.20}",
-        "comment": "we don't use `surface-warning` for accessibility (better contrast)",
         "$modes": {
           "default": "{color.palette.amber-100}",
           "cds-g0": "{carbon.color.orange.20}",
@@ -63494,8 +63417,10 @@
           "cds-g100": "{carbon.color.orange.70}"
         },
         "comments": {
+          "hds": "we don't use `surface-warning` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.surface.color.warning.filled}"
       },
       "name": "hds-badge-surface-color-warning-filled",
@@ -63521,9 +63446,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.70}",
@@ -63537,6 +63460,7 @@
         "comments": {
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.surface.color.warning.inverted}"
       },
       "name": "hds-badge-surface-color-warning-inverted",
@@ -64708,10 +64632,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -64726,6 +64647,7 @@
           "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.small}"
       },
       "name": "hds-button-typography-line-height-small",
@@ -64750,10 +64672,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "16px/14px ~ 1.1429",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -64768,6 +64687,7 @@
           "hds": "16px/14px ~ 1.1429",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.medium}"
       },
       "name": "hds-button-typography-line-height-medium",
@@ -64792,10 +64712,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "24px/16px = 1.5",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -64810,6 +64727,7 @@
           "hds": "24px/16px = 1.5",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.large}"
       },
       "name": "hds-button-typography-line-height-large",
@@ -65387,9 +65305,6 @@
       "key": "{button.foreground.color.tertiary.disabled}",
       "$type": "color",
       "$value": "rgba(22, 22, 22, 0.25)",
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.disabled}",
@@ -65561,9 +65476,7 @@
         "cds-g90": "rgba(255, 255, 255, 0.25)",
         "cds-g100": "rgba(255, 255, 255, 0.25)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.g10.textOnColorDisabled}",
@@ -65577,6 +65490,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.foreground.color.disabled}"
       },
       "name": "hds-button-foreground-color-disabled",
@@ -66287,9 +66201,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.g10}",
@@ -66303,6 +66215,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.surface.color.disabled}"
       },
       "name": "hds-button-surface-color-disabled",
@@ -66747,9 +66660,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.g10}",
@@ -66763,6 +66674,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.border.color.tertiary.disabled}"
       },
       "name": "hds-button-border-color-tertiary-disabled",
@@ -66893,9 +66805,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.g10}",
@@ -66909,6 +66819,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.border.color.disabled}"
       },
       "name": "hds-button-border-color-disabled",
@@ -68347,9 +68258,6 @@
           "$type": "font-size"
         }
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-      },
       "unit": "rem",
       "original": {
         "$type": "font-size",
@@ -68414,9 +68322,6 @@
         "cds-g90": 1.33333,
         "cds-g100": 1.33333
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-      },
       "original": {
         "$type": "number",
         "$value": "{carbon.typography.label01.line-height}",
@@ -68454,9 +68359,6 @@
         "cds-g10": 400,
         "cds-g90": 400,
         "cds-g100": 400
-      },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
       },
       "original": {
         "$type": "font-weight",
@@ -83044,9 +82946,7 @@
         "cds-g90": "inset 0 0 0 2px #ffffff",
         "cds-g100": "inset 0 0 0 2px #ffffff"
       },
-      "comments": {
-        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-      },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "original": {
         "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
         "$modes": {
@@ -83059,6 +82959,7 @@
         "comments": {
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
+        "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
         "key": "{focus-ring.action.box-shadow}"
       },
       "name": "hds-focus-ring-action-box-shadow",
@@ -83081,6 +82982,7 @@
         "cds-g90": "inset 0 0 0 2px #ffffff",
         "cds-g100": "inset 0 0 0 2px #ffffff"
       },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "original": {
         "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "$modes": {
@@ -83090,6 +82992,10 @@
           "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
           "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
         },
+        "comments": {
+          "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
+        },
+        "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
         "key": "{focus-ring.critical.box-shadow}"
       },
       "name": "hds-focus-ring-critical-box-shadow",
@@ -83966,9 +83872,6 @@
           0.38,
           0.9
         ]
-      },
-      "comments": {
-        "hds": "the values correspond to the `ease` timing function, the browser's default"
       },
       "original": {
         "$type": "cubicBezier",
@@ -88446,9 +88349,6 @@
       "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
       "$type": "color",
       "$value": "#161616",
-      "comments": {
-        "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.high-contrast}",
@@ -88666,10 +88566,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.20}",
@@ -88684,6 +88581,7 @@
           "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.foreground.color.warning.filled}"
       },
       "name": "hds-badge-foreground-color-warning-filled",
@@ -88730,9 +88628,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.20}",
@@ -88746,6 +88642,7 @@
         "comments": {
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.foreground.color.warning.outlined}"
       },
       "name": "hds-badge-foreground-color-warning-outlined",
@@ -89187,7 +89084,6 @@
       "key": "{badge.surface.color.warning.filled}",
       "$type": "color",
       "$value": "#8a3800",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "#ffd9be",
         "cds-g0": "#ffd9be",
@@ -89195,13 +89091,10 @@
         "cds-g90": "#8a3800",
         "cds-g100": "#8a3800"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.70}",
-        "comment": "we don't use `surface-warning` for accessibility (better contrast)",
         "$modes": {
           "default": "{color.palette.amber-100}",
           "cds-g0": "{carbon.color.orange.20}",
@@ -89210,8 +89103,10 @@
           "cds-g100": "{carbon.color.orange.70}"
         },
         "comments": {
+          "hds": "we don't use `surface-warning` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.surface.color.warning.filled}"
       },
       "name": "hds-badge-surface-color-warning-filled",
@@ -89237,9 +89132,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.20}",
@@ -89253,6 +89146,7 @@
         "comments": {
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.surface.color.warning.inverted}"
       },
       "name": "hds-badge-surface-color-warning-inverted",
@@ -90424,10 +90318,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -90442,6 +90333,7 @@
           "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.small}"
       },
       "name": "hds-button-typography-line-height-small",
@@ -90466,10 +90358,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "16px/14px ~ 1.1429",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -90484,6 +90373,7 @@
           "hds": "16px/14px ~ 1.1429",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.medium}"
       },
       "name": "hds-button-typography-line-height-medium",
@@ -90508,10 +90398,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "24px/16px = 1.5",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -90526,6 +90413,7 @@
           "hds": "24px/16px = 1.5",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.large}"
       },
       "name": "hds-button-typography-line-height-large",
@@ -91103,9 +90991,6 @@
       "key": "{button.foreground.color.tertiary.disabled}",
       "$type": "color",
       "$value": "rgba(244, 244, 244, 0.25)",
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.disabled}",
@@ -91277,9 +91162,7 @@
         "cds-g90": "rgba(255, 255, 255, 0.25)",
         "cds-g100": "rgba(255, 255, 255, 0.25)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.g90.textOnColorDisabled}",
@@ -91293,6 +91176,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.foreground.color.disabled}"
       },
       "name": "hds-button-foreground-color-disabled",
@@ -92003,9 +91887,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.g90}",
@@ -92019,6 +91901,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.surface.color.disabled}"
       },
       "name": "hds-button-surface-color-disabled",
@@ -92463,9 +92346,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.g90}",
@@ -92479,6 +92360,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.border.color.tertiary.disabled}"
       },
       "name": "hds-button-border-color-tertiary-disabled",
@@ -92609,9 +92491,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.g90}",
@@ -92625,6 +92505,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.border.color.disabled}"
       },
       "name": "hds-button-border-color-disabled",
@@ -94063,9 +93944,6 @@
           "$type": "font-size"
         }
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-      },
       "unit": "rem",
       "original": {
         "$type": "font-size",
@@ -94130,9 +94008,6 @@
         "cds-g90": 1.33333,
         "cds-g100": 1.33333
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-      },
       "original": {
         "$type": "number",
         "$value": "{carbon.typography.label01.line-height}",
@@ -94170,9 +94045,6 @@
         "cds-g10": 400,
         "cds-g90": 400,
         "cds-g100": 400
-      },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
       },
       "original": {
         "$type": "font-weight",
@@ -108760,9 +108632,7 @@
         "cds-g90": "inset 0 0 0 2px #ffffff",
         "cds-g100": "inset 0 0 0 2px #ffffff"
       },
-      "comments": {
-        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-      },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "original": {
         "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
         "$modes": {
@@ -108775,6 +108645,7 @@
         "comments": {
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
+        "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
         "key": "{focus-ring.action.box-shadow}"
       },
       "name": "hds-focus-ring-action-box-shadow",
@@ -108797,6 +108668,7 @@
         "cds-g90": "inset 0 0 0 2px #ffffff",
         "cds-g100": "inset 0 0 0 2px #ffffff"
       },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "original": {
         "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "$modes": {
@@ -108806,6 +108678,10 @@
           "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
           "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
         },
+        "comments": {
+          "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
+        },
+        "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
         "key": "{focus-ring.critical.box-shadow}"
       },
       "name": "hds-focus-ring-critical-box-shadow",
@@ -109682,9 +109558,6 @@
           0.38,
           0.9
         ]
-      },
-      "comments": {
-        "hds": "the values correspond to the `ease` timing function, the browser's default"
       },
       "original": {
         "$type": "cubicBezier",
@@ -114162,9 +114035,6 @@
       "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
       "$type": "color",
       "$value": "#161616",
-      "comments": {
-        "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.high-contrast}",
@@ -114382,10 +114252,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.20}",
@@ -114400,6 +114267,7 @@
           "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.foreground.color.warning.filled}"
       },
       "name": "hds-badge-foreground-color-warning-filled",
@@ -114446,9 +114314,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.20}",
@@ -114462,6 +114328,7 @@
         "comments": {
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.foreground.color.warning.outlined}"
       },
       "name": "hds-badge-foreground-color-warning-outlined",
@@ -114903,7 +114770,6 @@
       "key": "{badge.surface.color.warning.filled}",
       "$type": "color",
       "$value": "#8a3800",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "#ffd9be",
         "cds-g0": "#ffd9be",
@@ -114911,13 +114777,10 @@
         "cds-g90": "#8a3800",
         "cds-g100": "#8a3800"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.70}",
-        "comment": "we don't use `surface-warning` for accessibility (better contrast)",
         "$modes": {
           "default": "{color.palette.amber-100}",
           "cds-g0": "{carbon.color.orange.20}",
@@ -114926,8 +114789,10 @@
           "cds-g100": "{carbon.color.orange.70}"
         },
         "comments": {
+          "hds": "we don't use `surface-warning` for accessibility (better contrast)",
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.surface.color.warning.filled}"
       },
       "name": "hds-badge-surface-color-warning-filled",
@@ -114953,9 +114818,7 @@
         "cds-g90": "#ffd9be",
         "cds-g100": "#ffd9be"
       },
-      "comments": {
-        "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-      },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "original": {
         "$type": "color",
         "$value": "{carbon.color.orange.20}",
@@ -114969,6 +114832,7 @@
         "comments": {
           "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
         },
+        "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
         "key": "{badge.surface.color.warning.inverted}"
       },
       "name": "hds-badge-surface-color-warning-inverted",
@@ -116140,10 +116004,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -116158,6 +116019,7 @@
           "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.small}"
       },
       "name": "hds-button-typography-line-height-small",
@@ -116182,10 +116044,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "16px/14px ~ 1.1429",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -116200,6 +116059,7 @@
           "hds": "16px/14px ~ 1.1429",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.medium}"
       },
       "name": "hds-button-typography-line-height-medium",
@@ -116224,10 +116084,7 @@
         "cds-g90": 1.2858,
         "cds-g100": 1.2858
       },
-      "comments": {
-        "hds": "24px/16px = 1.5",
-        "cds": "18px/14px ~ 1.2858"
-      },
+      "comment": "18px/14px ~ 1.2858",
       "original": {
         "$type": "number",
         "$value": 1.2858,
@@ -116242,6 +116099,7 @@
           "hds": "24px/16px = 1.5",
           "cds": "18px/14px ~ 1.2858"
         },
+        "comment": "18px/14px ~ 1.2858",
         "key": "{button.typography.line-height.large}"
       },
       "name": "hds-button-typography-line-height-large",
@@ -116819,9 +116677,6 @@
       "key": "{button.foreground.color.tertiary.disabled}",
       "$type": "color",
       "$value": "rgba(244, 244, 244, 0.25)",
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
       "original": {
         "$type": "color",
         "$value": "{color.foreground.disabled}",
@@ -116993,9 +116848,7 @@
         "cds-g90": "rgba(255, 255, 255, 0.25)",
         "cds-g100": "rgba(255, 255, 255, 0.25)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.g100.textOnColorDisabled}",
@@ -117009,6 +116862,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.foreground.color.disabled}"
       },
       "name": "hds-button-foreground-color-disabled",
@@ -117719,9 +117573,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.g100}",
@@ -117735,6 +117587,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.surface.color.disabled}"
       },
       "name": "hds-button-surface-color-disabled",
@@ -118179,9 +118032,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.g100}",
@@ -118195,6 +118046,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.border.color.tertiary.disabled}"
       },
       "name": "hds-button-border-color-tertiary-disabled",
@@ -118325,9 +118177,7 @@
         "cds-g90": "rgba(141, 141, 141, 0.3)",
         "cds-g100": "rgba(141, 141, 141, 0.3)"
       },
-      "comments": {
-        "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-      },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "original": {
         "$type": "color",
         "$value": "{carbon.themes.buttonTokens.buttonDisabled.g100}",
@@ -118341,6 +118191,7 @@
         "comments": {
           "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
         },
+        "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
         "key": "{button.border.color.disabled}"
       },
       "name": "hds-button-border-color-disabled",
@@ -119779,9 +119630,6 @@
           "$type": "font-size"
         }
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-      },
       "unit": "rem",
       "original": {
         "$type": "font-size",
@@ -119846,9 +119694,6 @@
         "cds-g90": 1.33333,
         "cds-g100": 1.33333
       },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-      },
       "original": {
         "$type": "number",
         "$value": "{carbon.typography.label01.line-height}",
@@ -119886,9 +119731,6 @@
         "cds-g10": 400,
         "cds-g90": 400,
         "cds-g100": 400
-      },
-      "comments": {
-        "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
       },
       "original": {
         "$type": "font-weight",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
@@ -5901,9 +5901,7 @@
       "cds-g90": "inset 0 0 0 2px #0f62fe",
       "cds-g100": "inset 0 0 0 2px #0f62fe"
     },
-    "comments": {
-      "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-    },
+    "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
       "$modes": {
@@ -5916,6 +5914,7 @@
       "comments": {
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "key": "{focus-ring.action.box-shadow}"
     },
     "name": "hds-focus-ring-action-box-shadow",
@@ -5938,6 +5937,7 @@
       "cds-g90": "inset 0 0 0 2px #0f62fe",
       "cds-g100": "inset 0 0 0 2px #0f62fe"
     },
+    "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
       "$modes": {
@@ -5947,6 +5947,10 @@
         "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
       },
+      "comments": {
+        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
+      },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "key": "{focus-ring.critical.box-shadow}"
     },
     "name": "hds-focus-ring-critical-box-shadow",
@@ -6823,9 +6827,6 @@
         0.38,
         0.9
       ]
-    },
-    "comments": {
-      "hds": "the values correspond to the `ease` timing function, the browser's default"
     },
     "original": {
       "$type": "cubicBezier",
@@ -11303,9 +11304,6 @@
     "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
     "$type": "color",
     "$value": "#ffffff",
-    "comments": {
-      "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.high-contrast}",
@@ -11523,10 +11521,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.70}",
@@ -11541,6 +11536,7 @@
         "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.foreground.color.warning.filled}"
     },
     "name": "hds-badge-foreground-color-warning-filled",
@@ -11587,9 +11583,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.70}",
@@ -11603,6 +11597,7 @@
       "comments": {
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.foreground.color.warning.outlined}"
     },
     "name": "hds-badge-foreground-color-warning-outlined",
@@ -12044,7 +12039,6 @@
     "key": "{badge.surface.color.warning.filled}",
     "$type": "color",
     "$value": "#ffd9be",
-    "comment": "we don't use `surface-warning` for accessibility (better contrast)",
     "$modes": {
       "default": "#ffd9be",
       "cds-g0": "#ffd9be",
@@ -12052,13 +12046,10 @@
       "cds-g90": "#8a3800",
       "cds-g100": "#8a3800"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.20}",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "{color.palette.amber-100}",
         "cds-g0": "{carbon.color.orange.20}",
@@ -12067,8 +12058,10 @@
         "cds-g100": "{carbon.color.orange.70}"
       },
       "comments": {
+        "hds": "we don't use `surface-warning` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.surface.color.warning.filled}"
     },
     "name": "hds-badge-surface-color-warning-filled",
@@ -12094,9 +12087,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.70}",
@@ -12110,6 +12101,7 @@
       "comments": {
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.surface.color.warning.inverted}"
     },
     "name": "hds-badge-surface-color-warning-inverted",
@@ -13281,10 +13273,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13299,6 +13288,7 @@
         "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.small}"
     },
     "name": "hds-button-typography-line-height-small",
@@ -13323,10 +13313,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "16px/14px ~ 1.1429",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13341,6 +13328,7 @@
         "hds": "16px/14px ~ 1.1429",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.medium}"
     },
     "name": "hds-button-typography-line-height-medium",
@@ -13365,10 +13353,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "24px/16px = 1.5",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13383,6 +13368,7 @@
         "hds": "24px/16px = 1.5",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.large}"
     },
     "name": "hds-button-typography-line-height-large",
@@ -13960,9 +13946,6 @@
     "key": "{button.foreground.color.tertiary.disabled}",
     "$type": "color",
     "$value": "rgba(22, 22, 22, 0.25)",
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.disabled}",
@@ -14134,9 +14117,7 @@
       "cds-g90": "rgba(255, 255, 255, 0.25)",
       "cds-g100": "rgba(255, 255, 255, 0.25)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.white.textOnColorDisabled}",
@@ -14150,6 +14131,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.foreground.color.disabled}"
     },
     "name": "hds-button-foreground-color-disabled",
@@ -14860,9 +14842,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.white}",
@@ -14876,6 +14856,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.surface.color.disabled}"
     },
     "name": "hds-button-surface-color-disabled",
@@ -15320,9 +15301,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.white}",
@@ -15336,6 +15315,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.border.color.tertiary.disabled}"
     },
     "name": "hds-button-border-color-tertiary-disabled",
@@ -15466,9 +15446,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.white}",
@@ -15482,6 +15460,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.border.color.disabled}"
     },
     "name": "hds-button-border-color-disabled",
@@ -16920,9 +16899,6 @@
         "$type": "font-size"
       }
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-    },
     "unit": "rem",
     "original": {
       "$type": "font-size",
@@ -16987,9 +16963,6 @@
       "cds-g90": 1.33333,
       "cds-g100": 1.33333
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-    },
     "original": {
       "$type": "number",
       "$value": "{carbon.typography.label01.line-height}",
@@ -17027,9 +17000,6 @@
       "cds-g10": 400,
       "cds-g90": 400,
       "cds-g100": 400
-    },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
     },
     "original": {
       "$type": "font-weight",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
@@ -5901,9 +5901,7 @@
       "cds-g90": "inset 0 0 0 2px #0f62fe",
       "cds-g100": "inset 0 0 0 2px #0f62fe"
     },
-    "comments": {
-      "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-    },
+    "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
       "$modes": {
@@ -5916,6 +5914,7 @@
       "comments": {
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "key": "{focus-ring.action.box-shadow}"
     },
     "name": "hds-focus-ring-action-box-shadow",
@@ -5938,6 +5937,7 @@
       "cds-g90": "inset 0 0 0 2px #0f62fe",
       "cds-g100": "inset 0 0 0 2px #0f62fe"
     },
+    "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
       "$modes": {
@@ -5947,6 +5947,10 @@
         "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
       },
+      "comments": {
+        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
+      },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "key": "{focus-ring.critical.box-shadow}"
     },
     "name": "hds-focus-ring-critical-box-shadow",
@@ -6823,9 +6827,6 @@
         0.38,
         0.9
       ]
-    },
-    "comments": {
-      "hds": "the values correspond to the `ease` timing function, the browser's default"
     },
     "original": {
       "$type": "cubicBezier",
@@ -11303,9 +11304,6 @@
     "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
     "$type": "color",
     "$value": "#ffffff",
-    "comments": {
-      "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.high-contrast}",
@@ -11523,10 +11521,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.70}",
@@ -11541,6 +11536,7 @@
         "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.foreground.color.warning.filled}"
     },
     "name": "hds-badge-foreground-color-warning-filled",
@@ -11587,9 +11583,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.70}",
@@ -11603,6 +11597,7 @@
       "comments": {
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.foreground.color.warning.outlined}"
     },
     "name": "hds-badge-foreground-color-warning-outlined",
@@ -12044,7 +12039,6 @@
     "key": "{badge.surface.color.warning.filled}",
     "$type": "color",
     "$value": "#ffd9be",
-    "comment": "we don't use `surface-warning` for accessibility (better contrast)",
     "$modes": {
       "default": "#ffd9be",
       "cds-g0": "#ffd9be",
@@ -12052,13 +12046,10 @@
       "cds-g90": "#8a3800",
       "cds-g100": "#8a3800"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.20}",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "{color.palette.amber-100}",
         "cds-g0": "{carbon.color.orange.20}",
@@ -12067,8 +12058,10 @@
         "cds-g100": "{carbon.color.orange.70}"
       },
       "comments": {
+        "hds": "we don't use `surface-warning` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.surface.color.warning.filled}"
     },
     "name": "hds-badge-surface-color-warning-filled",
@@ -12094,9 +12087,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.70}",
@@ -12110,6 +12101,7 @@
       "comments": {
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.surface.color.warning.inverted}"
     },
     "name": "hds-badge-surface-color-warning-inverted",
@@ -13281,10 +13273,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13299,6 +13288,7 @@
         "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.small}"
     },
     "name": "hds-button-typography-line-height-small",
@@ -13323,10 +13313,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "16px/14px ~ 1.1429",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13341,6 +13328,7 @@
         "hds": "16px/14px ~ 1.1429",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.medium}"
     },
     "name": "hds-button-typography-line-height-medium",
@@ -13365,10 +13353,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "24px/16px = 1.5",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13383,6 +13368,7 @@
         "hds": "24px/16px = 1.5",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.large}"
     },
     "name": "hds-button-typography-line-height-large",
@@ -13960,9 +13946,6 @@
     "key": "{button.foreground.color.tertiary.disabled}",
     "$type": "color",
     "$value": "rgba(22, 22, 22, 0.25)",
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.disabled}",
@@ -14134,9 +14117,7 @@
       "cds-g90": "rgba(255, 255, 255, 0.25)",
       "cds-g100": "rgba(255, 255, 255, 0.25)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.g10.textOnColorDisabled}",
@@ -14150,6 +14131,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.foreground.color.disabled}"
     },
     "name": "hds-button-foreground-color-disabled",
@@ -14860,9 +14842,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.g10}",
@@ -14876,6 +14856,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.surface.color.disabled}"
     },
     "name": "hds-button-surface-color-disabled",
@@ -15320,9 +15301,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.g10}",
@@ -15336,6 +15315,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.border.color.tertiary.disabled}"
     },
     "name": "hds-button-border-color-tertiary-disabled",
@@ -15466,9 +15446,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.g10}",
@@ -15482,6 +15460,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.border.color.disabled}"
     },
     "name": "hds-button-border-color-disabled",
@@ -16920,9 +16899,6 @@
         "$type": "font-size"
       }
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-    },
     "unit": "rem",
     "original": {
       "$type": "font-size",
@@ -16987,9 +16963,6 @@
       "cds-g90": 1.33333,
       "cds-g100": 1.33333
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-    },
     "original": {
       "$type": "number",
       "$value": "{carbon.typography.label01.line-height}",
@@ -17027,9 +17000,6 @@
       "cds-g10": 400,
       "cds-g90": 400,
       "cds-g100": 400
-    },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
     },
     "original": {
       "$type": "font-weight",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
@@ -5901,9 +5901,7 @@
       "cds-g90": "inset 0 0 0 2px #ffffff",
       "cds-g100": "inset 0 0 0 2px #ffffff"
     },
-    "comments": {
-      "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-    },
+    "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
       "$modes": {
@@ -5916,6 +5914,7 @@
       "comments": {
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "key": "{focus-ring.action.box-shadow}"
     },
     "name": "hds-focus-ring-action-box-shadow",
@@ -5938,6 +5937,7 @@
       "cds-g90": "inset 0 0 0 2px #ffffff",
       "cds-g100": "inset 0 0 0 2px #ffffff"
     },
+    "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
       "$modes": {
@@ -5947,6 +5947,10 @@
         "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
       },
+      "comments": {
+        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
+      },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "key": "{focus-ring.critical.box-shadow}"
     },
     "name": "hds-focus-ring-critical-box-shadow",
@@ -6823,9 +6827,6 @@
         0.38,
         0.9
       ]
-    },
-    "comments": {
-      "hds": "the values correspond to the `ease` timing function, the browser's default"
     },
     "original": {
       "$type": "cubicBezier",
@@ -11303,9 +11304,6 @@
     "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
     "$type": "color",
     "$value": "#161616",
-    "comments": {
-      "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.high-contrast}",
@@ -11523,10 +11521,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.20}",
@@ -11541,6 +11536,7 @@
         "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.foreground.color.warning.filled}"
     },
     "name": "hds-badge-foreground-color-warning-filled",
@@ -11587,9 +11583,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.20}",
@@ -11603,6 +11597,7 @@
       "comments": {
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.foreground.color.warning.outlined}"
     },
     "name": "hds-badge-foreground-color-warning-outlined",
@@ -12044,7 +12039,6 @@
     "key": "{badge.surface.color.warning.filled}",
     "$type": "color",
     "$value": "#8a3800",
-    "comment": "we don't use `surface-warning` for accessibility (better contrast)",
     "$modes": {
       "default": "#ffd9be",
       "cds-g0": "#ffd9be",
@@ -12052,13 +12046,10 @@
       "cds-g90": "#8a3800",
       "cds-g100": "#8a3800"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.70}",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "{color.palette.amber-100}",
         "cds-g0": "{carbon.color.orange.20}",
@@ -12067,8 +12058,10 @@
         "cds-g100": "{carbon.color.orange.70}"
       },
       "comments": {
+        "hds": "we don't use `surface-warning` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.surface.color.warning.filled}"
     },
     "name": "hds-badge-surface-color-warning-filled",
@@ -12094,9 +12087,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.20}",
@@ -12110,6 +12101,7 @@
       "comments": {
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.surface.color.warning.inverted}"
     },
     "name": "hds-badge-surface-color-warning-inverted",
@@ -13281,10 +13273,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13299,6 +13288,7 @@
         "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.small}"
     },
     "name": "hds-button-typography-line-height-small",
@@ -13323,10 +13313,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "16px/14px ~ 1.1429",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13341,6 +13328,7 @@
         "hds": "16px/14px ~ 1.1429",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.medium}"
     },
     "name": "hds-button-typography-line-height-medium",
@@ -13365,10 +13353,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "24px/16px = 1.5",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13383,6 +13368,7 @@
         "hds": "24px/16px = 1.5",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.large}"
     },
     "name": "hds-button-typography-line-height-large",
@@ -13960,9 +13946,6 @@
     "key": "{button.foreground.color.tertiary.disabled}",
     "$type": "color",
     "$value": "rgba(244, 244, 244, 0.25)",
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.disabled}",
@@ -14134,9 +14117,7 @@
       "cds-g90": "rgba(255, 255, 255, 0.25)",
       "cds-g100": "rgba(255, 255, 255, 0.25)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.g100.textOnColorDisabled}",
@@ -14150,6 +14131,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.foreground.color.disabled}"
     },
     "name": "hds-button-foreground-color-disabled",
@@ -14860,9 +14842,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.g100}",
@@ -14876,6 +14856,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.surface.color.disabled}"
     },
     "name": "hds-button-surface-color-disabled",
@@ -15320,9 +15301,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.g100}",
@@ -15336,6 +15315,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.border.color.tertiary.disabled}"
     },
     "name": "hds-button-border-color-tertiary-disabled",
@@ -15466,9 +15446,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.g100}",
@@ -15482,6 +15460,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.border.color.disabled}"
     },
     "name": "hds-button-border-color-disabled",
@@ -16920,9 +16899,6 @@
         "$type": "font-size"
       }
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-    },
     "unit": "rem",
     "original": {
       "$type": "font-size",
@@ -16987,9 +16963,6 @@
       "cds-g90": 1.33333,
       "cds-g100": 1.33333
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-    },
     "original": {
       "$type": "number",
       "$value": "{carbon.typography.label01.line-height}",
@@ -17027,9 +17000,6 @@
       "cds-g10": 400,
       "cds-g90": 400,
       "cds-g100": 400
-    },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
     },
     "original": {
       "$type": "font-weight",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
@@ -5901,9 +5901,7 @@
       "cds-g90": "inset 0 0 0 2px #ffffff",
       "cds-g100": "inset 0 0 0 2px #ffffff"
     },
-    "comments": {
-      "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-    },
+    "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
       "$modes": {
@@ -5916,6 +5914,7 @@
       "comments": {
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "key": "{focus-ring.action.box-shadow}"
     },
     "name": "hds-focus-ring-action-box-shadow",
@@ -5938,6 +5937,7 @@
       "cds-g90": "inset 0 0 0 2px #ffffff",
       "cds-g100": "inset 0 0 0 2px #ffffff"
     },
+    "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
       "$modes": {
@@ -5947,6 +5947,10 @@
         "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
       },
+      "comments": {
+        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
+      },
+      "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
       "key": "{focus-ring.critical.box-shadow}"
     },
     "name": "hds-focus-ring-critical-box-shadow",
@@ -6823,9 +6827,6 @@
         0.38,
         0.9
       ]
-    },
-    "comments": {
-      "hds": "the values correspond to the `ease` timing function, the browser's default"
     },
     "original": {
       "$type": "cubicBezier",
@@ -11303,9 +11304,6 @@
     "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
     "$type": "color",
     "$value": "#161616",
-    "comments": {
-      "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.high-contrast}",
@@ -11523,10 +11521,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.20}",
@@ -11541,6 +11536,7 @@
         "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.foreground.color.warning.filled}"
     },
     "name": "hds-badge-foreground-color-warning-filled",
@@ -11587,9 +11583,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.20}",
@@ -11603,6 +11597,7 @@
       "comments": {
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.foreground.color.warning.outlined}"
     },
     "name": "hds-badge-foreground-color-warning-outlined",
@@ -12044,7 +12039,6 @@
     "key": "{badge.surface.color.warning.filled}",
     "$type": "color",
     "$value": "#8a3800",
-    "comment": "we don't use `surface-warning` for accessibility (better contrast)",
     "$modes": {
       "default": "#ffd9be",
       "cds-g0": "#ffd9be",
@@ -12052,13 +12046,10 @@
       "cds-g90": "#8a3800",
       "cds-g100": "#8a3800"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.70}",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "{color.palette.amber-100}",
         "cds-g0": "{carbon.color.orange.20}",
@@ -12067,8 +12058,10 @@
         "cds-g100": "{carbon.color.orange.70}"
       },
       "comments": {
+        "hds": "we don't use `surface-warning` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.surface.color.warning.filled}"
     },
     "name": "hds-badge-surface-color-warning-filled",
@@ -12094,9 +12087,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
     "original": {
       "$type": "color",
       "$value": "{carbon.color.orange.20}",
@@ -12110,6 +12101,7 @@
       "comments": {
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead",
       "key": "{badge.surface.color.warning.inverted}"
     },
     "name": "hds-badge-surface-color-warning-inverted",
@@ -13281,10 +13273,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13299,6 +13288,7 @@
         "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.small}"
     },
     "name": "hds-button-typography-line-height-small",
@@ -13323,10 +13313,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "16px/14px ~ 1.1429",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13341,6 +13328,7 @@
         "hds": "16px/14px ~ 1.1429",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.medium}"
     },
     "name": "hds-button-typography-line-height-medium",
@@ -13365,10 +13353,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "24px/16px = 1.5",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "18px/14px ~ 1.2858",
     "original": {
       "$type": "number",
       "$value": 1.2858,
@@ -13383,6 +13368,7 @@
         "hds": "24px/16px = 1.5",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "18px/14px ~ 1.2858",
       "key": "{button.typography.line-height.large}"
     },
     "name": "hds-button-typography-line-height-large",
@@ -13960,9 +13946,6 @@
     "key": "{button.foreground.color.tertiary.disabled}",
     "$type": "color",
     "$value": "rgba(244, 244, 244, 0.25)",
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.disabled}",
@@ -14134,9 +14117,7 @@
       "cds-g90": "rgba(255, 255, 255, 0.25)",
       "cds-g100": "rgba(255, 255, 255, 0.25)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.g90.textOnColorDisabled}",
@@ -14150,6 +14131,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.foreground.color.disabled}"
     },
     "name": "hds-button-foreground-color-disabled",
@@ -14860,9 +14842,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.g90}",
@@ -14876,6 +14856,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.surface.color.disabled}"
     },
     "name": "hds-button-surface-color-disabled",
@@ -15320,9 +15301,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.g90}",
@@ -15336,6 +15315,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.border.color.tertiary.disabled}"
     },
     "name": "hds-button-border-color-tertiary-disabled",
@@ -15466,9 +15446,7 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
+    "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
     "original": {
       "$type": "color",
       "$value": "{carbon.themes.buttonTokens.buttonDisabled.g90}",
@@ -15482,6 +15460,7 @@
       "comments": {
         "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
       },
+      "comment": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products",
       "key": "{button.border.color.disabled}"
     },
     "name": "hds-button-border-color-disabled",
@@ -16920,9 +16899,6 @@
         "$type": "font-size"
       }
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-    },
     "unit": "rem",
     "original": {
       "$type": "font-size",
@@ -16987,9 +16963,6 @@
       "cds-g90": 1.33333,
       "cds-g100": 1.33333
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-    },
     "original": {
       "$type": "number",
       "$value": "{carbon.typography.label01.line-height}",
@@ -17027,9 +17000,6 @@
       "cds-g10": 400,
       "cds-g90": 400,
       "cds-g100": 400
-    },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
     },
     "original": {
       "$type": "font-weight",

--- a/packages/tokens/dist/docs/products/themed-tokens/default.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/default.json
@@ -5907,9 +5907,6 @@
       "cds-g90": "inset 0 0 0 3px #5990ff",
       "cds-g100": "inset 0 0 0 3px #5990ff"
     },
-    "comments": {
-      "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-    },
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.internal} {color.focus.action.internal}, 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
       "$modes": {
@@ -5952,6 +5949,9 @@
         "cds-g10": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
+      },
+      "comments": {
+        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "key": "{focus-ring.critical.box-shadow}"
     },
@@ -6830,9 +6830,7 @@
         0.9
       ]
     },
-    "comments": {
-      "hds": "the values correspond to the `ease` timing function, the browser's default"
-    },
+    "comment": "the values correspond to the `ease` timing function, the browser's default",
     "original": {
       "$type": "cubicBezier",
       "$value": [
@@ -6876,6 +6874,7 @@
       "comments": {
         "hds": "the values correspond to the `ease` timing function, the browser's default"
       },
+      "comment": "the values correspond to the `ease` timing function, the browser's default",
       "key": "{accordion.item.toggle.icon.transition.timing-function}"
     },
     "name": "hds-accordion-item-toggle-icon-transition-timing-function",
@@ -11299,9 +11298,6 @@
     "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
     "$type": "color",
     "$value": "#ffffff",
-    "comments": {
-      "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.high-contrast}",
@@ -11519,10 +11515,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "we don't use `warning-on-surface` for accessibility (better contrast)",
     "original": {
       "$type": "color",
       "$value": "{color.palette.amber-400}",
@@ -11537,6 +11530,7 @@
         "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "we don't use `warning-on-surface` for accessibility (better contrast)",
       "key": "{badge.foreground.color.warning.filled}"
     },
     "name": "hds-badge-foreground-color-warning-filled",
@@ -11582,9 +11576,6 @@
       "cds-g10": "#8a3800",
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
-    },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
     },
     "original": {
       "$type": "color",
@@ -12040,7 +12031,6 @@
     "key": "{badge.surface.color.warning.filled}",
     "$type": "color",
     "$value": "#fbeabf",
-    "comment": "we don't use `surface-warning` for accessibility (better contrast)",
     "$modes": {
       "default": "#fbeabf",
       "cds-g0": "#ffd9be",
@@ -12048,13 +12038,10 @@
       "cds-g90": "#8a3800",
       "cds-g100": "#8a3800"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "we don't use `surface-warning` for accessibility (better contrast)",
     "original": {
       "$type": "color",
       "$value": "{color.palette.amber-100}",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "{color.palette.amber-100}",
         "cds-g0": "{carbon.color.orange.20}",
@@ -12063,8 +12050,10 @@
         "cds-g100": "{carbon.color.orange.70}"
       },
       "comments": {
+        "hds": "we don't use `surface-warning` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "key": "{badge.surface.color.warning.filled}"
     },
     "name": "hds-badge-surface-color-warning-filled",
@@ -12089,9 +12078,6 @@
       "cds-g10": "#8a3800",
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
-    },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
     },
     "original": {
       "$type": "color",
@@ -13277,10 +13263,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
     "original": {
       "$type": "number",
       "$value": 0.9286,
@@ -13295,6 +13278,7 @@
         "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
       "key": "{button.typography.line-height.small}"
     },
     "name": "hds-button-typography-line-height-small",
@@ -13319,10 +13303,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "16px/14px ~ 1.1429",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "16px/14px ~ 1.1429",
     "original": {
       "$type": "number",
       "$value": 1.1429,
@@ -13337,6 +13318,7 @@
         "hds": "16px/14px ~ 1.1429",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "16px/14px ~ 1.1429",
       "key": "{button.typography.line-height.medium}"
     },
     "name": "hds-button-typography-line-height-medium",
@@ -13361,10 +13343,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "24px/16px = 1.5",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "24px/16px = 1.5",
     "original": {
       "$type": "number",
       "$value": 1.5,
@@ -13379,6 +13358,7 @@
         "hds": "24px/16px = 1.5",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "24px/16px = 1.5",
       "key": "{button.typography.line-height.large}"
     },
     "name": "hds-button-typography-line-height-large",
@@ -13956,9 +13936,6 @@
     "key": "{button.foreground.color.tertiary.disabled}",
     "$type": "color",
     "$value": "#8c909c",
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.disabled}",
@@ -14129,9 +14106,6 @@
       "cds-g10": "#8d8d8d",
       "cds-g90": "rgba(255, 255, 255, 0.25)",
       "cds-g100": "rgba(255, 255, 255, 0.25)"
-    },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
     },
     "original": {
       "$type": "color",
@@ -14856,9 +14830,6 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.surface.interactive-disabled}",
@@ -15316,9 +15287,6 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "transparent",
@@ -15461,9 +15429,6 @@
       "cds-g10": "#c6c6c6",
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
-    },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
     },
     "original": {
       "$type": "color",
@@ -16916,9 +16881,7 @@
         "$type": "font-size"
       }
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-    },
+    "comment": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline",
     "original": {
       "$type": "font-size",
       "$value": "{typography.body-100.font-size}",
@@ -16956,6 +16919,7 @@
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "comment": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline",
       "key": "{dialog-primitive.header.tagline.typography.font-size}"
     },
     "name": "hds-dialog-primitive-header-tagline-typography-font-size",
@@ -16981,9 +16945,7 @@
       "cds-g90": 1.33333,
       "cds-g100": 1.33333
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-    },
+    "comment": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline",
     "original": {
       "$type": "number",
       "$value": "{typography.body-100.line-height}",
@@ -16997,6 +16959,7 @@
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
       },
+      "comment": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline",
       "key": "{dialog-primitive.header.tagline.typography.line-height}"
     },
     "name": "hds-dialog-primitive-header-tagline-typography-line-height",
@@ -17022,9 +16985,7 @@
       "cds-g90": 400,
       "cds-g100": 400
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
-    },
+    "comment": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title",
     "original": {
       "$type": "font-weight",
       "$value": "{typography.font-weight.semibold}",
@@ -17038,6 +16999,7 @@
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
       },
+      "comment": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title",
       "key": "{dialog-primitive.header.title.typography.font-weight}"
     },
     "name": "hds-dialog-primitive-header-title-typography-font-weight",

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -5907,9 +5907,6 @@
       "cds-g90": "inset 0 0 0 3px #5990ff",
       "cds-g100": "inset 0 0 0 3px #5990ff"
     },
-    "comments": {
-      "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
-    },
     "original": {
       "$value": "inset 0 0 0 {focus-ring.width.internal} {color.focus.action.internal}, 0 0 0 {focus-ring.width.external} {color.focus.action.external}",
       "$modes": {
@@ -5952,6 +5949,9 @@
         "cds-g10": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
         "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
+      },
+      "comments": {
+        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "key": "{focus-ring.critical.box-shadow}"
     },
@@ -6830,9 +6830,7 @@
         0.9
       ]
     },
-    "comments": {
-      "hds": "the values correspond to the `ease` timing function, the browser's default"
-    },
+    "comment": "the values correspond to the `ease` timing function, the browser's default",
     "original": {
       "$type": "cubicBezier",
       "$value": [
@@ -6876,6 +6874,7 @@
       "comments": {
         "hds": "the values correspond to the `ease` timing function, the browser's default"
       },
+      "comment": "the values correspond to the `ease` timing function, the browser's default",
       "key": "{accordion.item.toggle.icon.transition.timing-function}"
     },
     "name": "hds-accordion-item-toggle-icon-transition-timing-function",
@@ -11299,9 +11298,6 @@
     "key": "{badge.foreground.color.neutral-dark-mode.outlined}",
     "$type": "color",
     "$value": "#ffffff",
-    "comments": {
-      "cds": "In Figma the `cds` value uses a token `Tag/HighContrast/TagColor` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.high-contrast}",
@@ -11519,10 +11515,7 @@
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
     },
-    "comments": {
-      "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "we don't use `warning-on-surface` for accessibility (better contrast)",
     "original": {
       "$type": "color",
       "$value": "{color.palette.amber-400}",
@@ -11537,6 +11530,7 @@
         "hds": "we don't use `warning-on-surface` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "we don't use `warning-on-surface` for accessibility (better contrast)",
       "key": "{badge.foreground.color.warning.filled}"
     },
     "name": "hds-badge-foreground-color-warning-filled",
@@ -11582,9 +11576,6 @@
       "cds-g10": "#8a3800",
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
-    },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
     },
     "original": {
       "$type": "color",
@@ -12040,7 +12031,6 @@
     "key": "{badge.surface.color.warning.filled}",
     "$type": "color",
     "$value": "#fbeabf",
-    "comment": "we don't use `surface-warning` for accessibility (better contrast)",
     "$modes": {
       "default": "#fbeabf",
       "cds-g0": "#ffd9be",
@@ -12048,13 +12038,10 @@
       "cds-g90": "#8a3800",
       "cds-g100": "#8a3800"
     },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
-    },
+    "comment": "we don't use `surface-warning` for accessibility (better contrast)",
     "original": {
       "$type": "color",
       "$value": "{color.palette.amber-100}",
-      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "$modes": {
         "default": "{color.palette.amber-100}",
         "cds-g0": "{carbon.color.orange.20}",
@@ -12063,8 +12050,10 @@
         "cds-g100": "{carbon.color.orange.70}"
       },
       "comments": {
+        "hds": "we don't use `surface-warning` for accessibility (better contrast)",
         "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
       },
+      "comment": "we don't use `surface-warning` for accessibility (better contrast)",
       "key": "{badge.surface.color.warning.filled}"
     },
     "name": "hds-badge-surface-color-warning-filled",
@@ -12089,9 +12078,6 @@
       "cds-g10": "#8a3800",
       "cds-g90": "#ffd9be",
       "cds-g100": "#ffd9be"
-    },
-    "comments": {
-      "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
     },
     "original": {
       "$type": "color",
@@ -13277,10 +13263,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
     "original": {
       "$type": "number",
       "$value": 0.9286,
@@ -13295,6 +13278,7 @@
         "hds": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants)",
       "key": "{button.typography.line-height.small}"
     },
     "name": "hds-button-typography-line-height-small",
@@ -13319,10 +13303,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "16px/14px ~ 1.1429",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "16px/14px ~ 1.1429",
     "original": {
       "$type": "number",
       "$value": 1.1429,
@@ -13337,6 +13318,7 @@
         "hds": "16px/14px ~ 1.1429",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "16px/14px ~ 1.1429",
       "key": "{button.typography.line-height.medium}"
     },
     "name": "hds-button-typography-line-height-medium",
@@ -13361,10 +13343,7 @@
       "cds-g90": 1.2858,
       "cds-g100": 1.2858
     },
-    "comments": {
-      "hds": "24px/16px = 1.5",
-      "cds": "18px/14px ~ 1.2858"
-    },
+    "comment": "24px/16px = 1.5",
     "original": {
       "$type": "number",
       "$value": 1.5,
@@ -13379,6 +13358,7 @@
         "hds": "24px/16px = 1.5",
         "cds": "18px/14px ~ 1.2858"
       },
+      "comment": "24px/16px = 1.5",
       "key": "{button.typography.line-height.large}"
     },
     "name": "hds-button-typography-line-height-large",
@@ -13956,9 +13936,6 @@
     "key": "{button.foreground.color.tertiary.disabled}",
     "$type": "color",
     "$value": "#8c909c",
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.foreground.disabled}",
@@ -14129,9 +14106,6 @@
       "cds-g10": "#8d8d8d",
       "cds-g90": "rgba(255, 255, 255, 0.25)",
       "cds-g100": "rgba(255, 255, 255, 0.25)"
-    },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
     },
     "original": {
       "$type": "color",
@@ -14856,9 +14830,6 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "{color.surface.interactive-disabled}",
@@ -15316,9 +15287,6 @@
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
     },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
-    },
     "original": {
       "$type": "color",
       "$value": "transparent",
@@ -15461,9 +15429,6 @@
       "cds-g10": "#c6c6c6",
       "cds-g90": "rgba(141, 141, 141, 0.3)",
       "cds-g100": "rgba(141, 141, 141, 0.3)"
-    },
-    "comments": {
-      "cds": "This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products"
     },
     "original": {
       "$type": "color",
@@ -16916,9 +16881,7 @@
         "$type": "font-size"
       }
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
-    },
+    "comment": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline",
     "original": {
       "$type": "font-size",
       "$value": "{typography.body-100.font-size}",
@@ -16956,6 +16919,7 @@
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline"
       },
+      "comment": "we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline",
       "key": "{dialog-primitive.header.tagline.typography.font-size}"
     },
     "name": "hds-dialog-primitive-header-tagline-typography-font-size",
@@ -16981,9 +16945,7 @@
       "cds-g90": 1.33333,
       "cds-g100": 1.33333
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
-    },
+    "comment": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline",
     "original": {
       "$type": "number",
       "$value": "{typography.body-100.line-height}",
@@ -16997,6 +16959,7 @@
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline"
       },
+      "comment": "we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline",
       "key": "{dialog-primitive.header.tagline.typography.line-height}"
     },
     "name": "hds-dialog-primitive-header-tagline-typography-line-height",
@@ -17022,9 +16985,7 @@
       "cds-g90": 400,
       "cds-g100": 400
     },
-    "comments": {
-      "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
-    },
+    "comment": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title",
     "original": {
       "$type": "font-weight",
       "$value": "{typography.font-weight.semibold}",
@@ -17038,6 +16999,7 @@
       "comments": {
         "hds": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title"
       },
+      "comment": "we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title",
       "key": "{dialog-primitive.header.title.typography.font-weight}"
     },
     "name": "hds-dialog-primitive-header-title-typography-font-weight",

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -80,7 +80,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     0.1,
     0.25,
     1
-  );
+  ); /** the values correspond to the `ease` timing function, the browser's default */
   --hds-accordion-item-toggle-padding-bottom-large: 16px;
   --hds-accordion-item-toggle-padding-bottom-medium: 12px;
   --hds-accordion-item-toggle-padding-bottom-small: 8px;
@@ -260,7 +260,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-badge-foreground-color-warning-filled: var(
     --hds-color-palette-amber-400
-  );
+  ); /** we don't use `warning-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-warning-outlined: var(
     --hds-color-foreground-warning
   );
@@ -476,9 +476,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 1rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.8125rem;
-  --hds-button-typography-line-height-large: 1.5;
-  --hds-button-typography-line-height-medium: 1.1429;
-  --hds-button-typography-line-height-small: 0.9286;
+  --hds-button-typography-line-height-large: 1.5; /** 24px/16px = 1.5 */
+  --hds-button-typography-line-height-medium: 1.1429; /** 16px/14px ~ 1.1429 */
+  --hds-button-typography-line-height-small: 0.9286; /** 14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants) */
   --hds-card-surface-color-primary: var(--hds-color-surface-primary);
   --hds-card-surface-color-secondary: var(--hds-color-surface-faint);
   --hds-code-block-border-color-primary: rgba(178, 182, 189, 0.2);
@@ -634,13 +634,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-dialog-primitive-border-color: rgba(0, 0, 0, 0);
   --hds-dialog-primitive-header-tagline-typography-font-size: var(
     --hds-typography-body-100-font-size
-  );
+  ); /** we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline */
   --hds-dialog-primitive-header-tagline-typography-line-height: var(
     --hds-typography-body-100-line-height
-  );
+  ); /** we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline */
   --hds-dialog-primitive-header-title-typography-font-weight: var(
     --hds-typography-font-weight-semibold
-  );
+  ); /** we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title */
   --hds-dialog-primitive-padding-horizontal: 24px;
   --hds-dialog-primitive-padding-vertical: 16px;
   --hds-dismiss-button-border-color-active: var(--hds-color-border-strong);
@@ -1140,8 +1140,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #161616;
     --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #0e6027;
-    --hds-badge-foreground-color-warning-filled: #8a3800;
-    --hds-badge-foreground-color-warning-outlined: #8a3800;
+    --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1160,8 +1160,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #0e6027;
-    --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #8a3800;
+    --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1186,7 +1186,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: #c6c6c6;
+    --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1195,13 +1195,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #0f62fe;
-    --hds-button-border-color-tertiary-disabled: #c6c6c6;
+    --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: #8d8d8d;
+    --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1235,7 +1235,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: #c6c6c6;
+    --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1254,9 +1254,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #f4f4f4;
     --hds-card-surface-color-secondary: #ffffff;
     --hds-code-block-border-color-primary: #c6c6c6;
@@ -1434,10 +1434,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #6f6f6f;
@@ -1757,8 +1757,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
     --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #a7f0ba;
-    --hds-badge-foreground-color-warning-filled: #ffd9be;
-    --hds-badge-foreground-color-warning-outlined: #ffd9be;
+    --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1777,8 +1777,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #a7f0ba;
-    --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #ffd9be;
+    --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1803,7 +1803,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1812,13 +1817,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #ffffff;
-    --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-tertiary-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+    --hds-button-foreground-color-disabled: rgba(
+      255,
+      255,
+      255,
+      0.25
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1852,7 +1867,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-surface-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1871,9 +1891,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #262626;
     --hds-card-surface-color-secondary: #393939;
     --hds-code-block-border-color-primary: #525252;
@@ -2051,10 +2071,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #a8a8a8;
@@ -2374,8 +2394,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2394,8 +2414,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -2420,7 +2440,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -2429,13 +2449,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -2469,7 +2489,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -2488,9 +2508,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #f4f4f4;
   --hds-card-surface-color-secondary: #ffffff;
   --hds-code-block-border-color-primary: #c6c6c6;
@@ -2667,10 +2687,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -2989,8 +3009,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -3009,8 +3029,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -3035,7 +3055,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -3044,13 +3069,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(
+    255,
+    255,
+    255,
+    0.25
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -3084,7 +3119,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -3103,9 +3143,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #262626;
   --hds-card-surface-color-secondary: #393939;
   --hds-code-block-border-color-primary: #525252;
@@ -3282,10 +3322,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #a8a8a8;
@@ -3603,8 +3643,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -3623,8 +3663,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -3649,7 +3689,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -3658,13 +3698,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -3698,7 +3738,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -3717,9 +3757,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #ffffff;
   --hds-card-surface-color-secondary: #f4f4f4;
   --hds-code-block-border-color-primary: #e0e0e0;
@@ -3896,10 +3936,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -4217,8 +4257,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -4237,8 +4277,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -4263,7 +4303,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -4272,13 +4317,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(
+    255,
+    255,
+    255,
+    0.25
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -4312,7 +4367,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -4331,9 +4391,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #393939;
   --hds-card-surface-color-secondary: #525252;
   --hds-code-block-border-color-primary: #6f6f6f;
@@ -4510,10 +4570,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #c6c6c6;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
@@ -68,7 +68,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     0.1,
     0.25,
     1
-  );
+  ); /** the values correspond to the `ease` timing function, the browser's default */
   --hds-accordion-item-toggle-padding-bottom-large: 16px;
   --hds-accordion-item-toggle-padding-bottom-medium: 12px;
   --hds-accordion-item-toggle-padding-bottom-small: 8px;
@@ -248,7 +248,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-badge-foreground-color-warning-filled: var(
     --hds-color-palette-amber-400
-  );
+  ); /** we don't use `warning-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-warning-outlined: var(
     --hds-color-foreground-warning
   );
@@ -464,9 +464,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 1rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.8125rem;
-  --hds-button-typography-line-height-large: 1.5;
-  --hds-button-typography-line-height-medium: 1.1429;
-  --hds-button-typography-line-height-small: 0.9286;
+  --hds-button-typography-line-height-large: 1.5; /** 24px/16px = 1.5 */
+  --hds-button-typography-line-height-medium: 1.1429; /** 16px/14px ~ 1.1429 */
+  --hds-button-typography-line-height-small: 0.9286; /** 14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants) */
   --hds-card-surface-color-primary: var(--hds-color-surface-primary);
   --hds-card-surface-color-secondary: var(--hds-color-surface-faint);
   --hds-code-block-border-color-primary: rgba(178, 182, 189, 0.2);
@@ -622,13 +622,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-dialog-primitive-border-color: rgba(0, 0, 0, 0);
   --hds-dialog-primitive-header-tagline-typography-font-size: var(
     --hds-typography-body-100-font-size
-  );
+  ); /** we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline */
   --hds-dialog-primitive-header-tagline-typography-line-height: var(
     --hds-typography-body-100-line-height
-  );
+  ); /** we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline */
   --hds-dialog-primitive-header-title-typography-font-weight: var(
     --hds-typography-font-weight-semibold
-  );
+  ); /** we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title */
   --hds-dialog-primitive-padding-horizontal: 24px;
   --hds-dialog-primitive-padding-vertical: 16px;
   --hds-dismiss-button-border-color-active: var(--hds-color-border-strong);
@@ -1128,8 +1128,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #161616;
     --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #0e6027;
-    --hds-badge-foreground-color-warning-filled: #8a3800;
-    --hds-badge-foreground-color-warning-outlined: #8a3800;
+    --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1148,8 +1148,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #0e6027;
-    --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #8a3800;
+    --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1174,7 +1174,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: #c6c6c6;
+    --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1183,13 +1183,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #0f62fe;
-    --hds-button-border-color-tertiary-disabled: #c6c6c6;
+    --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: #8d8d8d;
+    --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1223,7 +1223,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: #c6c6c6;
+    --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1242,9 +1242,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #f4f4f4;
     --hds-card-surface-color-secondary: #ffffff;
     --hds-code-block-border-color-primary: #c6c6c6;
@@ -1422,10 +1422,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #6f6f6f;
@@ -1745,8 +1745,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
     --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #a7f0ba;
-    --hds-badge-foreground-color-warning-filled: #ffd9be;
-    --hds-badge-foreground-color-warning-outlined: #ffd9be;
+    --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1765,8 +1765,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #a7f0ba;
-    --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #ffd9be;
+    --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1791,7 +1791,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1800,13 +1805,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #ffffff;
-    --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-tertiary-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+    --hds-button-foreground-color-disabled: rgba(
+      255,
+      255,
+      255,
+      0.25
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1840,7 +1855,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-surface-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1859,9 +1879,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #262626;
     --hds-card-surface-color-secondary: #393939;
     --hds-code-block-border-color-primary: #525252;
@@ -2039,10 +2059,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #a8a8a8;
@@ -2361,8 +2381,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2381,8 +2401,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -2407,7 +2427,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -2416,13 +2436,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -2456,7 +2476,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -2475,9 +2495,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #f4f4f4;
   --hds-card-surface-color-secondary: #ffffff;
   --hds-code-block-border-color-primary: #c6c6c6;
@@ -2654,10 +2674,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -2975,8 +2995,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2995,8 +3015,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -3021,7 +3041,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -3030,13 +3055,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(
+    255,
+    255,
+    255,
+    0.25
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -3070,7 +3105,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -3089,9 +3129,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #262626;
   --hds-card-surface-color-secondary: #393939;
   --hds-code-block-border-color-primary: #525252;
@@ -3268,10 +3308,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #a8a8a8;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
@@ -182,8 +182,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -202,8 +202,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -228,7 +228,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -237,13 +237,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -277,7 +277,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -296,9 +296,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #f4f4f4;
   --hds-card-surface-color-secondary: #ffffff;
   --hds-code-block-border-color-primary: #c6c6c6;
@@ -475,10 +475,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -797,8 +797,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #161616;
     --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #0e6027;
-    --hds-badge-foreground-color-warning-filled: #8a3800;
-    --hds-badge-foreground-color-warning-outlined: #8a3800;
+    --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -817,8 +817,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #0e6027;
-    --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #8a3800;
+    --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -843,7 +843,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: #c6c6c6;
+    --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -852,13 +852,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #0f62fe;
-    --hds-button-border-color-tertiary-disabled: #c6c6c6;
+    --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: #8d8d8d;
+    --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -892,7 +892,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: #c6c6c6;
+    --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -911,9 +911,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #f4f4f4;
     --hds-card-surface-color-secondary: #ffffff;
     --hds-code-block-border-color-primary: #c6c6c6;
@@ -1091,10 +1091,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #6f6f6f;
@@ -1414,8 +1414,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
     --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #a7f0ba;
-    --hds-badge-foreground-color-warning-filled: #ffd9be;
-    --hds-badge-foreground-color-warning-outlined: #ffd9be;
+    --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1434,8 +1434,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #a7f0ba;
-    --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #ffd9be;
+    --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1460,7 +1460,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1469,13 +1474,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #ffffff;
-    --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-tertiary-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+    --hds-button-foreground-color-disabled: rgba(
+      255,
+      255,
+      255,
+      0.25
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1509,7 +1524,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-surface-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1528,9 +1548,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #262626;
     --hds-card-surface-color-secondary: #393939;
     --hds-code-block-border-color-primary: #525252;
@@ -1708,10 +1728,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #a8a8a8;
@@ -2030,8 +2050,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2050,8 +2070,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -2076,7 +2096,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -2085,13 +2105,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -2125,7 +2145,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -2144,9 +2164,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #f4f4f4;
   --hds-card-surface-color-secondary: #ffffff;
   --hds-code-block-border-color-primary: #c6c6c6;
@@ -2323,10 +2343,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -2644,8 +2664,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2664,8 +2684,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -2690,7 +2710,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -2699,13 +2724,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(
+    255,
+    255,
+    255,
+    0.25
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -2739,7 +2774,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -2758,9 +2798,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #262626;
   --hds-card-surface-color-secondary: #393939;
   --hds-code-block-border-color-primary: #525252;
@@ -2937,10 +2977,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #a8a8a8;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
@@ -123,8 +123,8 @@
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -143,8 +143,8 @@
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -169,7 +169,7 @@
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -178,13 +178,13 @@
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -218,7 +218,7 @@
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -237,9 +237,9 @@
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #f4f4f4;
   --hds-card-surface-color-secondary: #ffffff;
   --hds-code-block-border-color-primary: #c6c6c6;
@@ -409,8 +409,8 @@
   --hds-elevation-low-box-shadow: none;
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-critical-external);
+  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
@@ -123,8 +123,8 @@
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -143,8 +143,8 @@
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -169,7 +169,7 @@
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -178,13 +178,13 @@
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -218,7 +218,7 @@
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -237,9 +237,9 @@
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #ffffff;
   --hds-card-surface-color-secondary: #f4f4f4;
   --hds-code-block-border-color-primary: #e0e0e0;
@@ -409,8 +409,8 @@
   --hds-elevation-low-box-shadow: none;
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-critical-external);
+  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
@@ -123,8 +123,8 @@
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -143,8 +143,8 @@
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -169,7 +169,7 @@
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -178,13 +178,13 @@
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -218,7 +218,7 @@
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -237,9 +237,9 @@
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #262626;
   --hds-card-surface-color-secondary: #393939;
   --hds-code-block-border-color-primary: #525252;
@@ -409,8 +409,8 @@
   --hds-elevation-low-box-shadow: none;
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-critical-external);
+  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #a8a8a8;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
@@ -123,8 +123,8 @@
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -143,8 +143,8 @@
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -169,7 +169,7 @@
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -178,13 +178,13 @@
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -218,7 +218,7 @@
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -237,9 +237,9 @@
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #393939;
   --hds-card-surface-color-secondary: #525252;
   --hds-code-block-border-color-primary: #6f6f6f;
@@ -409,8 +409,8 @@
   --hds-elevation-low-box-shadow: none;
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-critical-external);
+  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #c6c6c6;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
@@ -25,7 +25,7 @@
   --hds-accordion-item-toggle-icon-size-medium: 20px;
   --hds-accordion-item-toggle-icon-transform-rotate: -180deg;
   --hds-accordion-item-toggle-icon-transition-duration: 0.3s;
-  --hds-accordion-item-toggle-icon-transition-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1);
+  --hds-accordion-item-toggle-icon-transition-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1); /** the values correspond to the `ease` timing function, the browser's default */
   --hds-accordion-item-toggle-padding-bottom-large: 16px;
   --hds-accordion-item-toggle-padding-bottom-medium: 12px;
   --hds-accordion-item-toggle-padding-bottom-small: 8px;
@@ -123,7 +123,7 @@
   --hds-badge-foreground-color-neutral-outlined: var(--hds-color-foreground-primary);
   --hds-badge-foreground-color-success-filled: var(--hds-color-palette-green-400); /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: var(--hds-color-foreground-success);
-  --hds-badge-foreground-color-warning-filled: var(--hds-color-palette-amber-400);
+  --hds-badge-foreground-color-warning-filled: var(--hds-color-palette-amber-400); /** we don't use `warning-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-warning-outlined: var(--hds-color-foreground-warning);
   --hds-badge-gap-large: 6px;
   --hds-badge-gap-medium: 4px;
@@ -237,9 +237,9 @@
   --hds-button-typography-font-size-large: 1rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.8125rem;
-  --hds-button-typography-line-height-large: 1.5;
-  --hds-button-typography-line-height-medium: 1.1429;
-  --hds-button-typography-line-height-small: 0.9286;
+  --hds-button-typography-line-height-large: 1.5; /** 24px/16px = 1.5 */
+  --hds-button-typography-line-height-medium: 1.1429; /** 16px/14px ~ 1.1429 */
+  --hds-button-typography-line-height-small: 0.9286; /** 14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants) */
   --hds-card-surface-color-primary: var(--hds-color-surface-primary);
   --hds-card-surface-color-secondary: var(--hds-color-surface-faint);
   --hds-code-block-border-color-primary: rgba(178, 182, 189, 0.2);
@@ -369,9 +369,9 @@
   --hds-copy-button-surface-color-hover: var(--hds-button-surface-color-secondary-hover);
   --hds-css-color-transform-direction: 1; /** this is used in the CSS `color-transform` to control the direction of the lightness transformations */
   --hds-dialog-primitive-border-color: rgba(0, 0, 0, 0);
-  --hds-dialog-primitive-header-tagline-typography-font-size: var(--hds-typography-body-100-font-size);
-  --hds-dialog-primitive-header-tagline-typography-line-height: var(--hds-typography-body-100-line-height);
-  --hds-dialog-primitive-header-title-typography-font-weight: var(--hds-typography-font-weight-semibold);
+  --hds-dialog-primitive-header-tagline-typography-font-size: var(--hds-typography-body-100-font-size); /** we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline */
+  --hds-dialog-primitive-header-tagline-typography-line-height: var(--hds-typography-body-100-line-height); /** we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline */
+  --hds-dialog-primitive-header-title-typography-font-weight: var(--hds-typography-font-weight-semibold); /** we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title */
   --hds-dialog-primitive-padding-horizontal: 24px;
   --hds-dialog-primitive-padding-vertical: 16px;
   --hds-dismiss-button-border-color-active: var(--hds-color-border-strong);

--- a/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
@@ -31,7 +31,7 @@
       0.1,
       0.25,
       1
-    );
+    ); /** the values correspond to the `ease` timing function, the browser's default */
     --hds-accordion-item-toggle-padding-bottom-large: 16px;
     --hds-accordion-item-toggle-padding-bottom-medium: 12px;
     --hds-accordion-item-toggle-padding-bottom-small: 8px;
@@ -219,7 +219,7 @@
     );
     --hds-badge-foreground-color-warning-filled: var(
       --hds-color-palette-amber-400
-    );
+    ); /** we don't use `warning-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-warning-outlined: var(
       --hds-color-foreground-warning
     );
@@ -455,9 +455,9 @@
     --hds-button-typography-font-size-large: 1rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.8125rem;
-    --hds-button-typography-line-height-large: 1.5;
-    --hds-button-typography-line-height-medium: 1.1429;
-    --hds-button-typography-line-height-small: 0.9286;
+    --hds-button-typography-line-height-large: 1.5; /** 24px/16px = 1.5 */
+    --hds-button-typography-line-height-medium: 1.1429; /** 16px/14px ~ 1.1429 */
+    --hds-button-typography-line-height-small: 0.9286; /** 14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants) */
     --hds-card-surface-color-primary: var(--hds-color-surface-primary);
     --hds-card-surface-color-secondary: var(--hds-color-surface-faint);
     --hds-code-block-border-color-primary: rgba(178, 182, 189, 0.2);
@@ -627,13 +627,13 @@
     --hds-dialog-primitive-border-color: rgba(0, 0, 0, 0);
     --hds-dialog-primitive-header-tagline-typography-font-size: var(
       --hds-typography-body-100-font-size
-    );
+    ); /** we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline */
     --hds-dialog-primitive-header-tagline-typography-line-height: var(
       --hds-typography-body-100-line-height
-    );
+    ); /** we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline */
     --hds-dialog-primitive-header-title-typography-font-weight: var(
       --hds-typography-font-weight-semibold
-    );
+    ); /** we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title */
     --hds-dialog-primitive-padding-horizontal: 24px;
     --hds-dialog-primitive-padding-vertical: 16px;
     --hds-dismiss-button-border-color-active: var(--hds-color-border-strong);
@@ -1145,8 +1145,8 @@
     --hds-badge-foreground-color-neutral-outlined: #161616;
     --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #0e6027;
-    --hds-badge-foreground-color-warning-filled: #8a3800;
-    --hds-badge-foreground-color-warning-outlined: #8a3800;
+    --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1165,8 +1165,8 @@
     --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #0e6027;
-    --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #8a3800;
+    --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1191,7 +1191,7 @@
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: #c6c6c6;
+    --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1200,13 +1200,13 @@
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #0f62fe;
-    --hds-button-border-color-tertiary-disabled: #c6c6c6;
+    --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: #8d8d8d;
+    --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1240,7 +1240,7 @@
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: #c6c6c6;
+    --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1259,9 +1259,9 @@
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #f4f4f4;
     --hds-card-surface-color-secondary: #ffffff;
     --hds-code-block-border-color-primary: #c6c6c6;
@@ -1439,10 +1439,10 @@
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #6f6f6f;
@@ -1764,8 +1764,8 @@
     --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
     --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #a7f0ba;
-    --hds-badge-foreground-color-warning-filled: #ffd9be;
-    --hds-badge-foreground-color-warning-outlined: #ffd9be;
+    --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1784,8 +1784,8 @@
     --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #a7f0ba;
-    --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #ffd9be;
+    --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1810,7 +1810,12 @@
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1819,13 +1824,23 @@
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #ffffff;
-    --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-tertiary-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+    --hds-button-foreground-color-disabled: rgba(
+      255,
+      255,
+      255,
+      0.25
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1859,7 +1874,12 @@
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-surface-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1878,9 +1898,9 @@
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #262626;
     --hds-card-surface-color-secondary: #393939;
     --hds-code-block-border-color-primary: #525252;
@@ -2058,10 +2078,10 @@
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #a8a8a8;
@@ -2383,8 +2403,8 @@
     --hds-badge-foreground-color-neutral-outlined: #161616;
     --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #0e6027;
-    --hds-badge-foreground-color-warning-filled: #8a3800;
-    --hds-badge-foreground-color-warning-outlined: #8a3800;
+    --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -2403,8 +2423,8 @@
     --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #0e6027;
-    --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #8a3800;
+    --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -2429,7 +2449,7 @@
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: #c6c6c6;
+    --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -2438,13 +2458,13 @@
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #0f62fe;
-    --hds-button-border-color-tertiary-disabled: #c6c6c6;
+    --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: #8d8d8d;
+    --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -2478,7 +2498,7 @@
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: #c6c6c6;
+    --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -2497,9 +2517,9 @@
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #f4f4f4;
     --hds-card-surface-color-secondary: #ffffff;
     --hds-code-block-border-color-primary: #c6c6c6;
@@ -2677,10 +2697,10 @@
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #6f6f6f;
@@ -3002,8 +3022,8 @@
     --hds-badge-foreground-color-neutral-outlined: #161616;
     --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #0e6027;
-    --hds-badge-foreground-color-warning-filled: #8a3800;
-    --hds-badge-foreground-color-warning-outlined: #8a3800;
+    --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -3022,8 +3042,8 @@
     --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #0e6027;
-    --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #8a3800;
+    --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -3048,7 +3068,7 @@
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: #c6c6c6;
+    --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -3057,13 +3077,13 @@
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #0f62fe;
-    --hds-button-border-color-tertiary-disabled: #c6c6c6;
+    --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: #8d8d8d;
+    --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -3097,7 +3117,7 @@
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: #c6c6c6;
+    --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -3116,9 +3136,9 @@
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #ffffff;
     --hds-card-surface-color-secondary: #f4f4f4;
     --hds-code-block-border-color-primary: #e0e0e0;
@@ -3296,10 +3316,10 @@
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #6f6f6f;
@@ -3621,8 +3641,8 @@
     --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
     --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #a7f0ba;
-    --hds-badge-foreground-color-warning-filled: #ffd9be;
-    --hds-badge-foreground-color-warning-outlined: #ffd9be;
+    --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -3641,8 +3661,8 @@
     --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #a7f0ba;
-    --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #ffd9be;
+    --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -3667,7 +3687,12 @@
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -3676,13 +3701,23 @@
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #ffffff;
-    --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-tertiary-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+    --hds-button-foreground-color-disabled: rgba(
+      255,
+      255,
+      255,
+      0.25
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -3716,7 +3751,12 @@
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-surface-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -3735,9 +3775,9 @@
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #393939;
     --hds-card-surface-color-secondary: #525252;
     --hds-code-block-border-color-primary: #6f6f6f;
@@ -3915,10 +3955,10 @@
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #c6c6c6;
@@ -4240,8 +4280,8 @@
     --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
     --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #a7f0ba;
-    --hds-badge-foreground-color-warning-filled: #ffd9be;
-    --hds-badge-foreground-color-warning-outlined: #ffd9be;
+    --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -4260,8 +4300,8 @@
     --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #a7f0ba;
-    --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #ffd9be;
+    --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -4286,7 +4326,12 @@
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -4295,13 +4340,23 @@
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #ffffff;
-    --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-tertiary-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+    --hds-button-foreground-color-disabled: rgba(
+      255,
+      255,
+      255,
+      0.25
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -4335,7 +4390,12 @@
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-surface-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -4354,9 +4414,9 @@
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #262626;
     --hds-card-surface-color-secondary: #393939;
     --hds-code-block-border-color-primary: #525252;
@@ -4534,10 +4594,10 @@
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #a8a8a8;

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -224,7 +224,7 @@
   --hds-accordion-item-toggle-icon-size-medium: 20px;
   --hds-accordion-item-toggle-icon-size-large: 24px;
   --hds-accordion-item-toggle-icon-transform-rotate: -180deg;
-  --hds-accordion-item-toggle-icon-transition-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1);
+  --hds-accordion-item-toggle-icon-transition-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1); /** the values correspond to the `ease` timing function, the browser's default */
   --hds-accordion-item-toggle-icon-transition-duration: 0.3s;
   --hds-accordion-item-content-padding-top-small: 4px;
   --hds-accordion-item-content-padding-top-medium: 4px;
@@ -358,7 +358,7 @@
   --hds-badge-foreground-color-success-filled: #006619; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-inverted: #ffffff;
   --hds-badge-foreground-color-success-outlined: #008a22;
-  --hds-badge-foreground-color-warning-filled: #803d00;
+  --hds-badge-foreground-color-warning-filled: #803d00; /** we don't use `warning-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-warning-inverted: #ffffff;
   --hds-badge-foreground-color-warning-outlined: #bb5a00;
   --hds-badge-foreground-color-critical-filled: #940004; /** we don't use `critical-on-surface` for accessibility (better contrast) */
@@ -410,9 +410,9 @@
   --hds-button-typography-font-size-small: 0.8125rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-large: 1rem;
-  --hds-button-typography-line-height-small: 0.9286;
-  --hds-button-typography-line-height-medium: 1.1429;
-  --hds-button-typography-line-height-large: 1.5;
+  --hds-button-typography-line-height-small: 0.9286; /** 14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants) */
+  --hds-button-typography-line-height-medium: 1.1429; /** 16px/14px ~ 1.1429 */
+  --hds-button-typography-line-height-large: 1.5; /** 24px/16px = 1.5 */
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-hover: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -516,9 +516,9 @@
   --hds-dialog-primitive-padding-horizontal: 24px;
   --hds-dialog-primitive-padding-vertical: 16px;
   --hds-dialog-primitive-border-color: rgba(0, 0, 0, 0);
-  --hds-dialog-primitive-header-tagline-typography-font-size: 0.8125rem;
-  --hds-dialog-primitive-header-tagline-typography-line-height: 1.3846;
-  --hds-dialog-primitive-header-title-typography-font-weight: 600;
+  --hds-dialog-primitive-header-tagline-typography-font-size: 0.8125rem; /** we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline */
+  --hds-dialog-primitive-header-tagline-typography-line-height: 1.3846; /** we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline */
+  --hds-dialog-primitive-header-title-typography-font-weight: 600; /** we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title */
   --hds-dismiss-button-size: 24px;
   --hds-dismiss-button-foreground-color-default: #656a76;
   --hds-dismiss-button-foreground-color-active: #0c0c0e;

--- a/packages/tokens/scripts/build-parts/customFormatDocsJson.ts
+++ b/packages/tokens/scripts/build-parts/customFormatDocsJson.ts
@@ -18,6 +18,9 @@ export function customFormatDocsJsonFunction({ dictionary }: { dictionary: Dicti
     const outputToken = cloneDeep(token) as Record<string, unknown>;
     delete outputToken.filePath;
     delete outputToken.isSource;
+    // we remove the top-level "comments" prop (resolved into "comment" by the `resolve-comments-for-mode-*` preprocessor)
+    // it is still preserved under the "original" key though
+    delete outputToken.comments;
     output.push(outputToken);
   });
 

--- a/packages/tokens/scripts/build-parts/getStyleDictionaryConfig.ts
+++ b/packages/tokens/scripts/build-parts/getStyleDictionaryConfig.ts
@@ -65,8 +65,8 @@ export function getStyleDictionaryConfig({ target, mode }: { target: Target, mod
                 format: 'css/themed-tokens/with-root-selector/themed',
               }
             ],
-            // this has been registered in the `build` file
-            preprocessors: [`replace-value-for-mode-${mode}`],
+            // these have been registered in the `build` file
+            preprocessors: [`replace-value-for-mode-${mode}`, `resolve-comments-for-mode-${mode}`],
           },
           [`docs/themed-json--mode-${mode}`]: {
             buildPath: 'dist/docs/products/',
@@ -80,8 +80,8 @@ export function getStyleDictionaryConfig({ target, mode }: { target: Target, mod
                 filter: excludePrivateTokens,
               }
             ],
-            // this has been registered in the `build` file
-            preprocessors: [`replace-value-for-mode-${mode}`],
+            // these have been registered in the `build` file
+            preprocessors: [`replace-value-for-mode-${mode}`, `resolve-comments-for-mode-${mode}`],
           }
         }
       };
@@ -105,6 +105,8 @@ export function getStyleDictionaryConfig({ target, mode }: { target: Target, mod
             transformGroup: 'products/web',
             prefix: 'hds',
             basePxFontSize: 16,
+            // this has been registered in the `build` file (the standard tokens use the `default`/`hds` comments)
+            preprocessors: ['resolve-comments-for-mode-default'],
             files: [
               {
                 destination: 'tokens.css',
@@ -119,6 +121,8 @@ export function getStyleDictionaryConfig({ target, mode }: { target: Target, mod
             transformGroup: 'products/web',
             prefix: 'hds',
             basePxFontSize: 16,
+            // this has been registered in the `build` file (the standard tokens use the `default`/`hds` comments)
+            preprocessors: ['resolve-comments-for-mode-default'],
             files: [
               {
                 destination: 'tokens.json',
@@ -153,6 +157,8 @@ export function getStyleDictionaryConfig({ target, mode }: { target: Target, mod
           buildPath: `dist/cloud-email/`,
           'transformGroup': 'products/email',
           prefix: 'hds',
+          // this has been registered in the `build` file (the standard tokens use the `default`/`hds` comments)
+          preprocessors: ['resolve-comments-for-mode-default'],
           files: [
             {
               destination: 'tokens.scss',

--- a/packages/tokens/scripts/build-parts/preprocessorReplaceValueForMode.ts
+++ b/packages/tokens/scripts/build-parts/preprocessorReplaceValueForMode.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright IBM Corp. 2021, 2026
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import chalk from 'chalk';
+import { isEqual } from 'lodash-es';
+
+import type { DesignToken, Preprocessor } from 'style-dictionary/types';
+import type { Mode } from './getStyleDictionaryConfig.ts';
+
+// Higher-order function: takes a `mode` and returns a Style Dictionary preprocessor that recursively traverses the token
+// tree and replaces each themed token's `$value` with the corresponding colocated `$modes` theme value for that mode.
+export function preprocessorReplaceValueForMode(mode: Mode): Preprocessor['preprocessor'] {
+  return (dictionary, options) => {
+    // we get the `buildPath` from the `PlatformConfig` option (used only for the warning/error messages)
+    const buildPath = 'buildPath' in options ? options.buildPath : undefined;
+    // recursively traverse token objects and replace the `$value` with the corresponding colocated `$modes` theme value
+    // note: the `slice` is always an object (a token or a parent group)
+    function replaceModes(slice: DesignToken, tokenPath: string[]) {
+      if (slice.$modes) {
+        if (mode in slice.$modes) {
+          // extra validation to catch instances where the `default` mode value is different from the `$value`
+          // note: we use `isEqual` for a deep/structural comparison so that object values (eg. the new DTCG `dimension` format `{ value, unit }`)
+          // and array values (eg. the `cubicBezier` timing functions) don't trigger false positives when they are structurally equal
+          if (mode === 'default' && !isEqual(slice.$modes[mode], slice.$value)) {
+            console.warn(`⚠️ ${chalk.yellow.bold('WARNING')} - Found themed 'default' token '{${tokenPath.join('.')}}' with value different than '$value' (\`${JSON.stringify(slice.$modes[mode])}\` instead of the expected \`${JSON.stringify(slice.$value)}\`) - BuildPath: ${buildPath} - File: ${slice.filePath}`);
+          }
+          // note: a `$modes` entry resolves to one of two shapes, distinguished by whether it carries its own `$value`:
+          // 1) a "standard" value:
+          //      - a primitive value (eg. a number, a string, an alias, etc)
+          //      - an array (eg. the `cubicBezier` timing function like in `accordion.item.toggle.icon.transition.timing-function`)
+          //      - a DTCG object value (eg. the new `dimension` `{ value, unit }` shape) — which replaces `$value` directly.
+          // 2) a "property-override" object:
+          //      - by convention always an object that carries its own `$value`, optionally with sibling props (eg. `unit`/`alpha`, like in `color.palette.alpha-300`).
+          //        its keys override the token's own props, and a `null` value removes that prop from the token (eg. `{ "$value": "{…}", "alpha": null }` drops the alpha).
+          const modeValue = slice.$modes[mode];
+          const isPropertyOverrideObject = typeof modeValue === 'object' && modeValue !== null && !Array.isArray(modeValue) && '$value' in modeValue;
+          if (isPropertyOverrideObject) {
+            // we spread the override object's keys/values over the token's base keys/values
+            Object.keys(modeValue).forEach((key: string) => {
+              if (modeValue[key] === null) {
+                delete slice[key];
+              } else {
+                slice[key] = modeValue[key];
+              }
+            });
+          } else {
+            slice.$value = modeValue;
+          }
+        } else {
+          // we want to interrupt the execution of the script if one of the expected modes is missing
+          throw new Error(`❌ ${chalk.red.bold('ERROR')} - Found themed token '{${tokenPath.join('.')}}' without '${mode}' value - BuildPath: ${buildPath} - File: ${slice.filePath} - Path: ${tokenPath.join('.')} - ${JSON.stringify(slice, null, 2)}`);
+        }
+      } else {
+          Object.entries(slice).forEach(([key, value]) => {
+            if (typeof value === 'object') {
+              replaceModes(value, [...tokenPath, key]);
+            }
+          });
+      }
+      return slice;
+    }
+    return replaceModes(dictionary, []);
+  };
+}

--- a/packages/tokens/scripts/build-parts/preprocessorResolveComments.ts
+++ b/packages/tokens/scripts/build-parts/preprocessorResolveComments.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright IBM Corp. 2021, 2026
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import chalk from 'chalk';
+
+import type { DesignToken, Preprocessor } from 'style-dictionary/types';
+import type { Mode } from './getStyleDictionaryConfig.ts';
+
+// Higher-order function: takes a `mode` and returns a Style Dictionary preprocessor that recursively walks the whole
+// token tree and resolves each token's `comments` into `comment` for that mode.
+// Notice: unlike the value-replacement preprocessor (`replace-value-for-mode-*`), this traversal is NOT gated on `$modes`,
+// because `comments` can also be colocated with a plain `$value` (a token without `$modes`).
+export function preprocessorResolveCommentsForMode(mode: Mode): Preprocessor['preprocessor'] {
+  return (dictionary, options) => {
+    // we get the `buildPath` from the `PlatformConfig` option (used only for the warning message)
+    const buildPath = 'buildPath' in options ? options.buildPath : undefined;
+
+    function resolveComments(slice: DesignToken, tokenPath: string[]): void {
+      // a token node carries a `$value` and (potentially) a `$modes` map; anything else is a parent group
+      if ('$value' in slice || '$modes' in slice) {
+        // resolve the token's `comments` (if any) into its `comment` for this mode
+        if (slice.comments) {
+          resolveTokenComment(slice, mode);
+        }
+      } else {
+        // a `comments` object must live on a token node (colocated with `$value`/`$modes`), never on a parent group
+        if (slice.comments) {
+          console.warn(`⚠️ ${chalk.yellow.bold('WARNING')} - Found 'comments' on a non-token node '{${tokenPath.join('.')}}' (no '$value'/'$modes' sibling) - it will be ignored - BuildPath: ${buildPath} - File: ${slice.filePath}`);
+        }
+        Object.entries(slice).forEach(([key, value]) => {
+          if (typeof value === 'object') {
+            resolveComments(value, [...tokenPath, key]);
+          }
+        });
+      }
+    }
+
+    resolveComments(dictionary, []);
+    return dictionary;
+  };
+}
+
+function resolveTokenComment(token: DesignToken, mode: Mode): void {
+  const key = '$modes' in token && mode !== 'default' ? 'cds' : 'hds';
+  if (token.comments && token.comments[key]) {
+    token.comment = token.comments[key];
+  }
+}

--- a/packages/tokens/scripts/build.ts
+++ b/packages/tokens/scripts/build.ts
@@ -15,6 +15,7 @@ import { dirname } from 'path';
 
 import { targets, modes, getStyleDictionaryConfig } from './build-parts/getStyleDictionaryConfig.ts';
 import { preprocessorReplaceValueForMode } from './build-parts/preprocessorReplaceValueForMode.ts';
+import { preprocessorResolveCommentsForMode } from './build-parts/preprocessorResolveComments.ts';
 import { customFormatCssThemedTokensFunctionForTarget } from './build-parts/customFormatCssThemedTokens.ts';
 import { customFormatDocsJsonFunction } from './build-parts/customFormatDocsJson.ts';
 import { generateCssHelpers } from './build-parts/generateCssHelpers.ts';
@@ -39,6 +40,10 @@ for (const mode of modes) {
   StyleDictionary.registerPreprocessor({
     name: `replace-value-for-mode-${mode}`,
     preprocessor: preprocessorReplaceValueForMode(mode),
+  });
+  StyleDictionary.registerPreprocessor({
+    name: `resolve-comments-for-mode-${mode}`,
+    preprocessor: preprocessorResolveCommentsForMode(mode),
   });
 }
 

--- a/packages/tokens/scripts/build.ts
+++ b/packages/tokens/scripts/build.ts
@@ -7,8 +7,6 @@ import StyleDictionary from 'style-dictionary';
 import type { DesignToken, PlatformConfig } from 'style-dictionary/types';
 
 import tinycolor from 'tinycolor2';
-import chalk from 'chalk';
-import { isEqual } from 'lodash-es';
 
 import fs from 'fs-extra';
 import path from 'path';
@@ -16,6 +14,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 
 import { targets, modes, getStyleDictionaryConfig } from './build-parts/getStyleDictionaryConfig.ts';
+import { preprocessorReplaceValueForMode } from './build-parts/preprocessorReplaceValueForMode.ts';
 import { customFormatCssThemedTokensFunctionForTarget } from './build-parts/customFormatCssThemedTokens.ts';
 import { customFormatDocsJsonFunction } from './build-parts/customFormatDocsJson.ts';
 import { generateCssHelpers } from './build-parts/generateCssHelpers.ts';
@@ -39,57 +38,7 @@ const distFolder = path.resolve(__dirname, '../dist');
 for (const mode of modes) {
   StyleDictionary.registerPreprocessor({
     name: `replace-value-for-mode-${mode}`,
-    preprocessor: (dictionary, options) => {
-      // we get the `buildPath` from the `PlatformConfig` option
-      const buildPath = (options as any).buildPath;
-      // recursively traverse token objects and replace the `$value` with the corresponding colocated `$modes` theme value
-      // note: the `slice` is always an object (a token or a parent group)
-      function replaceModes(slice: DesignToken, tokenPath: string[]) {
-        if (slice.$modes) {
-          if (mode in slice.$modes) {
-            // extra validation to catch instances where the `default` mode value is different from the `$value`
-            // note: we use `isEqual` for a deep/structural comparison so that object values (eg. the new DTCG `dimension` format `{ value, unit }`)
-            // and array values (eg. the `cubicBezier` timing functions) don't trigger false positives when they are structurally equal
-            if (mode === 'default' && !isEqual(slice.$modes[mode], slice.$value)) {
-              console.warn(`⚠️ ${chalk.yellow.bold('WARNING')} - Found themed 'default' token '{${tokenPath.join('.')}}' with value different than '$value' (\`${JSON.stringify(slice.$modes[mode])}\` instead of the expected \`${JSON.stringify(slice.$value)}\`) - BuildPath: ${buildPath} - File: ${slice.filePath}`);
-            }
-            // note: a `$modes` entry resolves to one of two shapes, distinguished by whether it carries its own `$value`:
-            // 1) a "standard" value:
-            //      - a primitive value (eg. a number, a string, an alias, etc)
-            //      - an array (eg. the `cubicBezier` timing function like in `accordion.item.toggle.icon.transition.timing-function`)
-            //      - a DTCG object value (eg. the new `dimension` `{ value, unit }` shape) — which replaces `$value` directly.
-            // 2) a "property-override" object:
-            //      - by convention always an object that carries its own `$value`, optionally with sibling props (eg. `unit`/`alpha`, like in `color.palette.alpha-300`).
-            //        its keys override the token's own props, and a `null` value removes that prop from the token (eg. `{ "$value": "{…}", "alpha": null }` drops the alpha).
-            const modeValue = slice.$modes[mode];
-            const isPropertyOverrideObject = typeof modeValue === 'object' && modeValue !== null && !Array.isArray(modeValue) && '$value' in modeValue;
-            if (isPropertyOverrideObject) {
-              // we spread the override object's keys/values over the token's base keys/values
-              Object.keys(modeValue).forEach((key: string) => {
-                if (modeValue[key] === null) {
-                  delete slice[key];
-                } else {
-                  slice[key] = modeValue[key];
-                }
-              });
-            } else {
-              slice.$value = modeValue;
-            }
-          } else {
-            // we want to interrupt the execution of the script if one of the expected modes is missing
-            throw new Error(`❌ ${chalk.red.bold('ERROR')} - Found themed token '{${tokenPath.join('.')}}' without '${mode}' value - BuildPath: ${buildPath} - File: ${slice.filePath} - Path: ${tokenPath.join('.')} - ${JSON.stringify(slice, null, 2)}`);
-          }
-        } else {
-            Object.entries(slice).forEach(([key, value]) => {
-              if (typeof value === 'object') {
-                replaceModes(value, [...tokenPath, key]);
-              }
-            });
-        }
-        return slice;
-      }
-      return replaceModes(dictionary, []);
-    },
+    preprocessor: preprocessorReplaceValueForMode(mode),
   });
 }
 

--- a/packages/tokens/src/global/focus-ring.json
+++ b/packages/tokens/src/global/focus-ring.json
@@ -50,10 +50,10 @@
           "cds-g10": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
           "cds-g90": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}",
           "cds-g100": "inset 0 0 0 {focus-ring.width.external} {color.focus.critical.external}"
+        },
+        "comments": {
+          "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         }
-      },
-      "comments": {
-        "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       }
     }
   }

--- a/packages/tokens/src/products/shared/badge.json
+++ b/packages/tokens/src/products/shared/badge.json
@@ -489,7 +489,6 @@
           "filled": {
             "$type": "color",
             "$value": "{color.palette.amber-100}",
-            "comment": "we don't use `surface-warning` for accessibility (better contrast)",
             "$modes": {
               "default": "{color.palette.amber-100}",
               "cds-g0": "{carbon.color.orange.20}",
@@ -498,6 +497,7 @@
               "cds-g100": "{carbon.color.orange.70}"
             },
             "comments": {
+              "hds": "we don't use `surface-warning` for accessibility (better contrast)",
               "cds": "in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead"
             }
           },

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -228,7 +228,7 @@
   --hds-accordion-item-toggle-icon-size-medium: 20px;
   --hds-accordion-item-toggle-icon-size-large: 24px;
   --hds-accordion-item-toggle-icon-transform-rotate: -180deg;
-  --hds-accordion-item-toggle-icon-transition-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1);
+  --hds-accordion-item-toggle-icon-transition-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1); /** the values correspond to the `ease` timing function, the browser's default */
   --hds-accordion-item-toggle-icon-transition-duration: 0.3s;
   --hds-accordion-item-content-padding-top-small: 4px;
   --hds-accordion-item-content-padding-top-medium: 4px;
@@ -362,7 +362,7 @@
   --hds-badge-foreground-color-success-filled: #006619; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-inverted: #ffffff;
   --hds-badge-foreground-color-success-outlined: #008a22;
-  --hds-badge-foreground-color-warning-filled: #803d00;
+  --hds-badge-foreground-color-warning-filled: #803d00; /** we don't use `warning-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-warning-inverted: #ffffff;
   --hds-badge-foreground-color-warning-outlined: #bb5a00;
   --hds-badge-foreground-color-critical-filled: #940004; /** we don't use `critical-on-surface` for accessibility (better contrast) */
@@ -414,9 +414,9 @@
   --hds-button-typography-font-size-small: 0.8125rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-large: 1rem;
-  --hds-button-typography-line-height-small: 0.9286;
-  --hds-button-typography-line-height-medium: 1.1429;
-  --hds-button-typography-line-height-large: 1.5;
+  --hds-button-typography-line-height-small: 0.9286; /** 14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants) */
+  --hds-button-typography-line-height-medium: 1.1429; /** 16px/14px ~ 1.1429 */
+  --hds-button-typography-line-height-large: 1.5; /** 24px/16px = 1.5 */
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-hover: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -520,9 +520,9 @@
   --hds-dialog-primitive-padding-horizontal: 24px;
   --hds-dialog-primitive-padding-vertical: 16px;
   --hds-dialog-primitive-border-color: rgba(0, 0, 0, 0);
-  --hds-dialog-primitive-header-tagline-typography-font-size: 0.8125rem;
-  --hds-dialog-primitive-header-tagline-typography-line-height: 1.3846;
-  --hds-dialog-primitive-header-title-typography-font-weight: 600;
+  --hds-dialog-primitive-header-tagline-typography-font-size: 0.8125rem; /** we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline */
+  --hds-dialog-primitive-header-tagline-typography-line-height: 1.3846; /** we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline */
+  --hds-dialog-primitive-header-title-typography-font-weight: 600; /** we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title */
   --hds-dismiss-button-size: 24px;
   --hds-dismiss-button-foreground-color-default: #656a76;
   --hds-dismiss-button-foreground-color-active: #0c0c0e;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -80,7 +80,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     0.1,
     0.25,
     1
-  );
+  ); /** the values correspond to the `ease` timing function, the browser's default */
   --hds-accordion-item-toggle-padding-bottom-large: 16px;
   --hds-accordion-item-toggle-padding-bottom-medium: 12px;
   --hds-accordion-item-toggle-padding-bottom-small: 8px;
@@ -260,7 +260,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-badge-foreground-color-warning-filled: var(
     --hds-color-palette-amber-400
-  );
+  ); /** we don't use `warning-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-warning-outlined: var(
     --hds-color-foreground-warning
   );
@@ -476,9 +476,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 1rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.8125rem;
-  --hds-button-typography-line-height-large: 1.5;
-  --hds-button-typography-line-height-medium: 1.1429;
-  --hds-button-typography-line-height-small: 0.9286;
+  --hds-button-typography-line-height-large: 1.5; /** 24px/16px = 1.5 */
+  --hds-button-typography-line-height-medium: 1.1429; /** 16px/14px ~ 1.1429 */
+  --hds-button-typography-line-height-small: 0.9286; /** 14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants) */
   --hds-card-surface-color-primary: var(--hds-color-surface-primary);
   --hds-card-surface-color-secondary: var(--hds-color-surface-faint);
   --hds-code-block-border-color-primary: rgba(178, 182, 189, 0.2);
@@ -634,13 +634,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-dialog-primitive-border-color: rgba(0, 0, 0, 0);
   --hds-dialog-primitive-header-tagline-typography-font-size: var(
     --hds-typography-body-100-font-size
-  );
+  ); /** we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline */
   --hds-dialog-primitive-header-tagline-typography-line-height: var(
     --hds-typography-body-100-line-height
-  );
+  ); /** we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline */
   --hds-dialog-primitive-header-title-typography-font-weight: var(
     --hds-typography-font-weight-semibold
-  );
+  ); /** we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title */
   --hds-dialog-primitive-padding-horizontal: 24px;
   --hds-dialog-primitive-padding-vertical: 16px;
   --hds-dismiss-button-border-color-active: var(--hds-color-border-strong);
@@ -1140,8 +1140,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #161616;
     --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #0e6027;
-    --hds-badge-foreground-color-warning-filled: #8a3800;
-    --hds-badge-foreground-color-warning-outlined: #8a3800;
+    --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1160,8 +1160,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #0e6027;
-    --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #8a3800;
+    --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1186,7 +1186,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: #c6c6c6;
+    --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1195,13 +1195,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #0f62fe;
-    --hds-button-border-color-tertiary-disabled: #c6c6c6;
+    --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: #8d8d8d;
+    --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1235,7 +1235,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: #c6c6c6;
+    --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1254,9 +1254,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #f4f4f4;
     --hds-card-surface-color-secondary: #ffffff;
     --hds-code-block-border-color-primary: #c6c6c6;
@@ -1434,10 +1434,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #6f6f6f;
@@ -1757,8 +1757,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
     --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #a7f0ba;
-    --hds-badge-foreground-color-warning-filled: #ffd9be;
-    --hds-badge-foreground-color-warning-outlined: #ffd9be;
+    --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1777,8 +1777,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #a7f0ba;
-    --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #ffd9be;
+    --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1803,7 +1803,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1812,13 +1817,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #ffffff;
-    --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-tertiary-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+    --hds-button-foreground-color-disabled: rgba(
+      255,
+      255,
+      255,
+      0.25
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1852,7 +1867,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-surface-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1871,9 +1891,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #262626;
     --hds-card-surface-color-secondary: #393939;
     --hds-code-block-border-color-primary: #525252;
@@ -2051,10 +2071,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #a8a8a8;
@@ -2374,8 +2394,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2394,8 +2414,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -2420,7 +2440,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -2429,13 +2449,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -2469,7 +2489,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -2488,9 +2508,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #f4f4f4;
   --hds-card-surface-color-secondary: #ffffff;
   --hds-code-block-border-color-primary: #c6c6c6;
@@ -2667,10 +2687,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -2989,8 +3009,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -3009,8 +3029,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -3035,7 +3055,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -3044,13 +3069,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(
+    255,
+    255,
+    255,
+    0.25
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -3084,7 +3119,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -3103,9 +3143,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #262626;
   --hds-card-surface-color-secondary: #393939;
   --hds-code-block-border-color-primary: #525252;
@@ -3282,10 +3322,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #a8a8a8;
@@ -3603,8 +3643,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -3623,8 +3663,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -3649,7 +3689,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -3658,13 +3698,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -3698,7 +3738,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -3717,9 +3757,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #ffffff;
   --hds-card-surface-color-secondary: #f4f4f4;
   --hds-code-block-border-color-primary: #e0e0e0;
@@ -3896,10 +3936,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -4217,8 +4257,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -4237,8 +4277,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -4263,7 +4303,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -4272,13 +4317,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(
+    255,
+    255,
+    255,
+    0.25
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -4312,7 +4367,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -4331,9 +4391,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #393939;
   --hds-card-surface-color-secondary: #525252;
   --hds-code-block-border-color-primary: #6f6f6f;
@@ -4510,10 +4570,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #c6c6c6;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
@@ -68,7 +68,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     0.1,
     0.25,
     1
-  );
+  ); /** the values correspond to the `ease` timing function, the browser's default */
   --hds-accordion-item-toggle-padding-bottom-large: 16px;
   --hds-accordion-item-toggle-padding-bottom-medium: 12px;
   --hds-accordion-item-toggle-padding-bottom-small: 8px;
@@ -248,7 +248,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-badge-foreground-color-warning-filled: var(
     --hds-color-palette-amber-400
-  );
+  ); /** we don't use `warning-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-warning-outlined: var(
     --hds-color-foreground-warning
   );
@@ -464,9 +464,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 1rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.8125rem;
-  --hds-button-typography-line-height-large: 1.5;
-  --hds-button-typography-line-height-medium: 1.1429;
-  --hds-button-typography-line-height-small: 0.9286;
+  --hds-button-typography-line-height-large: 1.5; /** 24px/16px = 1.5 */
+  --hds-button-typography-line-height-medium: 1.1429; /** 16px/14px ~ 1.1429 */
+  --hds-button-typography-line-height-small: 0.9286; /** 14px/13px ~ 0.9286 - we need to make it even (so we set it slighly larger than the font-size; notice: in Figma is 12px but this would cut some ascendants/descendants) */
   --hds-card-surface-color-primary: var(--hds-color-surface-primary);
   --hds-card-surface-color-secondary: var(--hds-color-surface-faint);
   --hds-code-block-border-color-primary: rgba(178, 182, 189, 0.2);
@@ -622,13 +622,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-dialog-primitive-border-color: rgba(0, 0, 0, 0);
   --hds-dialog-primitive-header-tagline-typography-font-size: var(
     --hds-typography-body-100-font-size
-  );
+  ); /** we need a component-level token for this, to account for the difference in font-size between HDS and CDS for the tagline */
   --hds-dialog-primitive-header-tagline-typography-line-height: var(
     --hds-typography-body-100-line-height
-  );
+  ); /** we need a component-level token for this, to account for the difference in line-height between HDS and CDS for the tagline */
   --hds-dialog-primitive-header-title-typography-font-weight: var(
     --hds-typography-font-weight-semibold
-  );
+  ); /** we need a component-level token for this, to account for the difference in font-weight between HDS and CDS for the title */
   --hds-dialog-primitive-padding-horizontal: 24px;
   --hds-dialog-primitive-padding-vertical: 16px;
   --hds-dismiss-button-border-color-active: var(--hds-color-border-strong);
@@ -1128,8 +1128,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #161616;
     --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #0e6027;
-    --hds-badge-foreground-color-warning-filled: #8a3800;
-    --hds-badge-foreground-color-warning-outlined: #8a3800;
+    --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1148,8 +1148,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #0e6027;
-    --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #8a3800;
+    --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1174,7 +1174,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: #c6c6c6;
+    --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1183,13 +1183,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #0f62fe;
-    --hds-button-border-color-tertiary-disabled: #c6c6c6;
+    --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: #8d8d8d;
+    --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1223,7 +1223,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: #c6c6c6;
+    --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1242,9 +1242,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #f4f4f4;
     --hds-card-surface-color-secondary: #ffffff;
     --hds-code-block-border-color-primary: #c6c6c6;
@@ -1422,10 +1422,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #6f6f6f;
@@ -1745,8 +1745,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
     --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #a7f0ba;
-    --hds-badge-foreground-color-warning-filled: #ffd9be;
-    --hds-badge-foreground-color-warning-outlined: #ffd9be;
+    --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1765,8 +1765,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #a7f0ba;
-    --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #ffd9be;
+    --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1791,7 +1791,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1800,13 +1805,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #ffffff;
-    --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-tertiary-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+    --hds-button-foreground-color-disabled: rgba(
+      255,
+      255,
+      255,
+      0.25
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1840,7 +1855,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-surface-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1859,9 +1879,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #262626;
     --hds-card-surface-color-secondary: #393939;
     --hds-code-block-border-color-primary: #525252;
@@ -2039,10 +2059,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #a8a8a8;
@@ -2361,8 +2381,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2381,8 +2401,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -2407,7 +2427,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -2416,13 +2436,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -2456,7 +2476,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -2475,9 +2495,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #f4f4f4;
   --hds-card-surface-color-secondary: #ffffff;
   --hds-code-block-border-color-primary: #c6c6c6;
@@ -2654,10 +2674,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -2975,8 +2995,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2995,8 +3015,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -3021,7 +3041,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -3030,13 +3055,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(
+    255,
+    255,
+    255,
+    0.25
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -3070,7 +3105,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -3089,9 +3129,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #262626;
   --hds-card-surface-color-secondary: #393939;
   --hds-code-block-border-color-primary: #525252;
@@ -3268,10 +3308,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #a8a8a8;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
@@ -182,8 +182,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -202,8 +202,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -228,7 +228,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -237,13 +237,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -277,7 +277,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -296,9 +296,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #f4f4f4;
   --hds-card-surface-color-secondary: #ffffff;
   --hds-code-block-border-color-primary: #c6c6c6;
@@ -475,10 +475,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -797,8 +797,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #161616;
     --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #0e6027;
-    --hds-badge-foreground-color-warning-filled: #8a3800;
-    --hds-badge-foreground-color-warning-outlined: #8a3800;
+    --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -817,8 +817,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #0e6027;
-    --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #8a3800;
+    --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -843,7 +843,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: #c6c6c6;
+    --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -852,13 +852,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #0f62fe;
-    --hds-button-border-color-tertiary-disabled: #c6c6c6;
+    --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: #8d8d8d;
+    --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -892,7 +892,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: #c6c6c6;
+    --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -911,9 +911,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #f4f4f4;
     --hds-card-surface-color-secondary: #ffffff;
     --hds-code-block-border-color-primary: #c6c6c6;
@@ -1091,10 +1091,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #6f6f6f;
@@ -1414,8 +1414,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
     --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
     --hds-badge-foreground-color-success-outlined: #a7f0ba;
-    --hds-badge-foreground-color-warning-filled: #ffd9be;
-    --hds-badge-foreground-color-warning-outlined: #ffd9be;
+    --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-gap-large: 4px;
     --hds-badge-gap-medium: 4px;
     --hds-badge-gap-small: 4px;
@@ -1434,8 +1434,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
     --hds-badge-surface-color-success-inverted: #a7f0ba;
-    --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-    --hds-badge-surface-color-warning-inverted: #ffd9be;
+    --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+    --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
     --hds-badge-typography-font-size-large: 0.75rem;
     --hds-badge-typography-font-size-medium: 0.75rem;
     --hds-badge-typography-font-size-small: 0.75rem;
@@ -1460,7 +1460,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-    --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
     --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -1469,13 +1474,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
     --hds-button-border-color-tertiary-default: #ffffff;
-    --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-border-color-tertiary-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
     --hds-button-foreground-color-critical-active: #ffffff;
     --hds-button-foreground-color-critical-default: #ffffff;
     --hds-button-foreground-color-critical-focus: #ffffff;
     --hds-button-foreground-color-critical-hover: #ffffff;
-    --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+    --hds-button-foreground-color-disabled: rgba(
+      255,
+      255,
+      255,
+      0.25
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-foreground-color-primary-active: #ffffff;
     --hds-button-foreground-color-primary-default: #ffffff;
     --hds-button-foreground-color-primary-focus: #ffffff;
@@ -1509,7 +1524,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-surface-color-critical-default: #da1e28;
     --hds-button-surface-color-critical-focus: #da1e28;
     --hds-button-surface-color-critical-hover: #b81921;
-    --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+    --hds-button-surface-color-disabled: rgba(
+      141,
+      141,
+      141,
+      0.3
+    ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
     --hds-button-surface-color-primary-active: #002d9c;
     --hds-button-surface-color-primary-default: #0f62fe;
     --hds-button-surface-color-primary-focus: #0f62fe;
@@ -1528,9 +1548,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-button-typography-font-size-large: 0.875rem;
     --hds-button-typography-font-size-medium: 0.875rem;
     --hds-button-typography-font-size-small: 0.875rem;
-    --hds-button-typography-line-height-large: 1.2858;
-    --hds-button-typography-line-height-medium: 1.2858;
-    --hds-button-typography-line-height-small: 1.2858;
+    --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+    --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
     --hds-card-surface-color-primary: #262626;
     --hds-card-surface-color-secondary: #393939;
     --hds-code-block-border-color-primary: #525252;
@@ -1708,10 +1728,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-elevation-overlay-box-shadow: none;
     --hds-focus-ring-action-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-action-external);
+      var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-critical-box-shadow: inset 0 0 0
       var(--hds-focus-ring-width-external)
-      var(--hds-color-focus-critical-external);
+      var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
     --hds-focus-ring-width-internal: 0px;
     --hds-form-character-count-foreground-color: #a8a8a8;
@@ -2030,8 +2050,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #161616;
   --hds-badge-foreground-color-success-filled: #0e6027; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #0e6027;
-  --hds-badge-foreground-color-warning-filled: #8a3800;
-  --hds-badge-foreground-color-warning-outlined: #8a3800;
+  --hds-badge-foreground-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2050,8 +2070,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #393939; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #a7f0ba; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #0e6027;
-  --hds-badge-surface-color-warning-filled: #ffd9be; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #8a3800;
+  --hds-badge-surface-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -2076,7 +2096,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: #c6c6c6;
+  --hds-button-border-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -2085,13 +2105,13 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #0f62fe;
-  --hds-button-border-color-tertiary-disabled: #c6c6c6;
+  --hds-button-border-color-tertiary-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: #8d8d8d;
+  --hds-button-foreground-color-disabled: #8d8d8d; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -2125,7 +2145,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: #c6c6c6;
+  --hds-button-surface-color-disabled: #c6c6c6; /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -2144,9 +2164,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #f4f4f4;
   --hds-card-surface-color-secondary: #ffffff;
   --hds-code-block-border-color-primary: #c6c6c6;
@@ -2323,10 +2343,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #6f6f6f;
@@ -2644,8 +2664,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-foreground-color-neutral-outlined: #f4f4f4;
   --hds-badge-foreground-color-success-filled: #a7f0ba; /** we don't use `success-on-surface` for accessibility (better contrast) */
   --hds-badge-foreground-color-success-outlined: #a7f0ba;
-  --hds-badge-foreground-color-warning-filled: #ffd9be;
-  --hds-badge-foreground-color-warning-outlined: #ffd9be;
+  --hds-badge-foreground-color-warning-filled: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-foreground-color-warning-outlined: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-gap-large: 4px;
   --hds-badge-gap-medium: 4px;
   --hds-badge-gap-small: 4px;
@@ -2664,8 +2684,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-badge-surface-color-neutral-inverted: #f4f4f4; /** In Figma the `cds` value uses a token `Tag/HighContrast/TagBackground` that doesn't exist in code, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-surface-color-success-filled: #0e6027; /** we don't use `surface-success` for accessibility (better contrast) */
   --hds-badge-surface-color-success-inverted: #a7f0ba;
-  --hds-badge-surface-color-warning-filled: #8a3800; /** we don't use `surface-warning` for accessibility (better contrast) */
-  --hds-badge-surface-color-warning-inverted: #ffd9be;
+  --hds-badge-surface-color-warning-filled: #8a3800; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
+  --hds-badge-surface-color-warning-inverted: #ffd9be; /** in code there are no tokens for the `Tag/Orange` variant, so we need to use the corresponding values in Figma (aliases) instead */
   --hds-badge-typography-font-size-large: 0.75rem;
   --hds-badge-typography-font-size-medium: 0.75rem;
   --hds-badge-typography-font-size-small: 0.75rem;
@@ -2690,7 +2710,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-critical-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-critical-hover: rgba(0, 0, 0, 0);
-  --hds-button-border-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-primary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-default: rgba(0, 0, 0, 0);
   --hds-button-border-color-primary-hover: rgba(0, 0, 0, 0);
@@ -2699,13 +2724,23 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-border-color-secondary-hover: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-active: rgba(0, 0, 0, 0);
   --hds-button-border-color-tertiary-default: #ffffff;
-  --hds-button-border-color-tertiary-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-border-color-tertiary-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-border-color-tertiary-hover: rgba(0, 0, 0, 0);
   --hds-button-foreground-color-critical-active: #ffffff;
   --hds-button-foreground-color-critical-default: #ffffff;
   --hds-button-foreground-color-critical-focus: #ffffff;
   --hds-button-foreground-color-critical-hover: #ffffff;
-  --hds-button-foreground-color-disabled: rgba(255, 255, 255, 0.25);
+  --hds-button-foreground-color-disabled: rgba(
+    255,
+    255,
+    255,
+    0.25
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-foreground-color-primary-active: #ffffff;
   --hds-button-foreground-color-primary-default: #ffffff;
   --hds-button-foreground-color-primary-focus: #ffffff;
@@ -2739,7 +2774,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-surface-color-critical-default: #da1e28;
   --hds-button-surface-color-critical-focus: #da1e28;
   --hds-button-surface-color-critical-hover: #b81921;
-  --hds-button-surface-color-disabled: rgba(141, 141, 141, 0.3);
+  --hds-button-surface-color-disabled: rgba(
+    141,
+    141,
+    141,
+    0.3
+  ); /** This is different from Figma, but we prefer to align with the Carbon implementation in code for consistency across products */
   --hds-button-surface-color-primary-active: #002d9c;
   --hds-button-surface-color-primary-default: #0f62fe;
   --hds-button-surface-color-primary-focus: #0f62fe;
@@ -2758,9 +2798,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-button-typography-font-size-large: 0.875rem;
   --hds-button-typography-font-size-medium: 0.875rem;
   --hds-button-typography-font-size-small: 0.875rem;
-  --hds-button-typography-line-height-large: 1.2858;
-  --hds-button-typography-line-height-medium: 1.2858;
-  --hds-button-typography-line-height-small: 1.2858;
+  --hds-button-typography-line-height-large: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-medium: 1.2858; /** 18px/14px ~ 1.2858 */
+  --hds-button-typography-line-height-small: 1.2858; /** 18px/14px ~ 1.2858 */
   --hds-card-surface-color-primary: #262626;
   --hds-card-surface-color-secondary: #393939;
   --hds-code-block-border-color-primary: #525252;
@@ -2937,10 +2977,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-elevation-mid-box-shadow: none;
   --hds-elevation-overlay-box-shadow: none;
   --hds-focus-ring-action-box-shadow: inset 0 0 0
-    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external);
+    var(--hds-focus-ring-width-external) var(--hds-color-focus-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-critical-box-shadow: inset 0 0 0
     var(--hds-focus-ring-width-external)
-    var(--hds-color-focus-critical-external);
+    var(--hds-color-focus-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-form-character-count-foreground-color: #a8a8a8;


### PR DESCRIPTION
### :pushpin: Summary

We have started to add `comments: { hds: ***, cds: *** }` declarations in our source JSON token files, but we never actually handled/processed them properly in the tokens pipeline. This PR updates the pipeline logic to handle both `comment` and `comments` entries.

### :hammer_and_wrench: Detailed description

In this PR I have:
- extracted pre-processor for `$modes` replacement to its own
- added pre-processor to resolve `comments` declarations 
- dropped `comments` object from generated JSON for docs 

#### Notes:

- in the process I have also fixed a couple of tokens where `comment/comments` where not in the expected format
- re-generating the output files has updated comments in a few places/files (now that they're handled correctly) 

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-5670

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>