### PR TITLE
Bump `concurrently` to `9.2.3`

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -92,7 +92,7 @@
     "@types/luxon": "^3.4.2",
     "@types/prismjs": "^1.26.5",
     "babel-plugin-ember-template-compilation": "^2.4.1",
-    "concurrently": "^9.1.2",
+    "concurrently": "^9.2.3",
     "ember-basic-dropdown": "^8.8.0",
     "ember-intl": "^8.0.0",
     "ember-source": "^6.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,8 +271,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       concurrently:
-        specifier: ^9.1.2
-        version: 9.2.0
+        specifier: ^9.2.3
+        version: 9.2.3
       ember-basic-dropdown:
         specifier: ^8.8.0
         version: 8.8.0(@babel/core@7.28.0)(@ember/string@4.0.1)(@ember/test-helpers@4.0.5(@babel/core@7.28.0)(@glint/template@1.7.7)(ember-source@6.5.0(@glimmer/component@2.0.0)(rsvp@4.8.5)))(@glimmer/component@2.0.0)(@glint/template@1.7.7)(ember-source@6.5.0(@glimmer/component@2.0.0)(rsvp@4.8.5))
@@ -650,8 +650,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       concurrently:
-        specifier: ^9.1.2
-        version: 9.2.0
+        specifier: ^9.2.3
+        version: 9.2.3
       ember-a11y-testing:
         specifier: ^7.1.2
         version: 7.1.2(@ember/test-helpers@5.4.0(@babel/core@7.28.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.24.1)(webpack@5.107.2(postcss@8.5.15))
@@ -941,8 +941,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.1
       concurrently:
-        specifier: ^9.1.2
-        version: 9.2.0
+        specifier: ^9.2.3
+        version: 9.2.3
       cspell:
         specifier: ^8.17.1
         version: 8.19.4
@@ -5542,8 +5542,8 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  concurrently@9.2.0:
-    resolution: {integrity: sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==}
+  concurrently@9.2.3:
+    resolution: {integrity: sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10709,6 +10709,9 @@ packages:
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -10866,8 +10869,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.2:
-    resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shellwords@0.1.1:
@@ -18403,12 +18406,11 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  concurrently@9.2.0:
+  concurrently@9.2.3:
     dependencies:
       chalk: 4.1.2
-      lodash: 4.18.1
-      rxjs: 7.8.1
-      shell-quote: 1.8.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -25439,6 +25441,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -25660,7 +25666,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.2: {}
+  shell-quote@1.8.4: {}
 
   shellwords@0.1.1: {}
 

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -66,7 +66,7 @@
     "@types/rsvp": "^4.0.9",
     "@types/sinon": "^17.0.4",
     "broccoli-asset-rev": "^3.0.0",
-    "concurrently": "^9.1.2",
+    "concurrently": "^9.2.3",
     "ember-a11y-testing": "^7.1.2",
     "ember-auto-import": "^2.10.0",
     "ember-basic-dropdown": "^8.8.0",

--- a/website/package.json
+++ b/website/package.json
@@ -74,7 +74,7 @@
     "broccoli-plugin": "^4.0.7",
     "broccoli-stew": "^3.0.0",
     "chalk": "^5.4.0",
-    "concurrently": "^9.1.2",
+    "concurrently": "^9.2.3",
     "cspell": "^8.17.1",
     "dotenv": "^16.4.7",
     "ember-a11y-refocus": "^5.1.0",


### PR DESCRIPTION
### :pushpin: Summary

Bump `concurrently` from `9.1.2` to `9.2.3` across the monorepo to get `shell-quote` from `1.8.2` to `1.8.4`.

- [9.2.3 addressed precisely this vulnerability](https://github.com/open-cli-tools/concurrently/releases/tag/v9.2.3)
- `shell-quote` is only used via `concurrently` in our repo
- addressing https://github.com/hashicorp/design-system/security/code-scanning/234 due July 10

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5912](https://hashicorp.atlassian.net/browse/HDS-5912)>[SECVULN-46275](https://hashicorp.atlassian.net/browse/SECVULN-46275)

***

### :eyes: Component checklist

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5912]: https://hashicorp.atlassian.net/browse/HDS-5912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SECVULN-46275]: https://hashicorp.atlassian.net/browse/SECVULN-46275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ