### PR TITLE
MCP - add watch/inspect dev scripts and JSON type

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -24,7 +24,7 @@
     "build:watch": "pnpm tsc -p tsconfig.json --watch --preserveWatchOutput",
     "serve": "node ./dist/index.js",
     "serve:watch": "node --watch --watch-path=./dist --watch-preserve-output ./dist/index.js",
-    "start": "pnpm build && pnpm concurrently --kill-others-on-fail --names build,server \"pnpm build:watch\" \"pnpm serve:watch\"",
+    "start": "pnpm build && concurrently --kill-others-on-fail --names build,server \"pnpm build:watch\" \"pnpm serve:watch\"",
     "inspect": "npx -y @modelcontextprotocol/inspector node --watch --watch-path=./dist --watch-preserve-output ./dist/index.js",
     "start:dev": "pnpm build && pnpm concurrently --kill-others-on-fail --names build,inspector \"pnpm build:watch\" \"pnpm inspect\""
   },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,7 +26,7 @@
     "serve:watch": "node --watch --watch-path=./dist --watch-preserve-output ./dist/index.js",
     "start": "pnpm build && concurrently --kill-others-on-fail --names build,server \"pnpm build:watch\" \"pnpm serve:watch\"",
     "inspect": "npx -y @modelcontextprotocol/inspector node --watch --watch-path=./dist --watch-preserve-output ./dist/index.js",
-    "start:dev": "pnpm build && pnpm concurrently --kill-others-on-fail --names build,inspector \"pnpm build:watch\" \"pnpm inspect\""
+    "start:dev": "pnpm build && concurrently --kill-others-on-fail --names build,inspector \"pnpm build:watch\" \"pnpm inspect\""
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -24,9 +24,9 @@
     "build:watch": "pnpm tsc -p tsconfig.json --watch --preserveWatchOutput",
     "serve": "node ./dist/index.js",
     "serve:watch": "node --watch --watch-path=./dist --watch-preserve-output ./dist/index.js",
-    "start": "pnpm concurrently --kill-others-on-fail --names build,server \"pnpm build:watch\" \"pnpm serve:watch\"",
-    "inspect": "npx @modelcontextprotocol/inspector node --watch --watch-path=./dist ./dist/index.js",
-    "start:dev": "pnpm concurrently --kill-others-on-fail --names mcp,inspector \"pnpm start\" \"pnpm inspect\""
+    "start": "pnpm build && pnpm concurrently --kill-others-on-fail --names build,server \"pnpm build:watch\" \"pnpm serve:watch\"",
+    "inspect": "npx -y @modelcontextprotocol/inspector node --watch --watch-path=./dist --watch-preserve-output ./dist/index.js",
+    "start:dev": "pnpm build && pnpm concurrently --kill-others-on-fail --names build,inspector \"pnpm build:watch\" \"pnpm inspect\""
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@eslint/js": "^9.27.0",
     "@types/node": "^22.10.2",
+    "concurrently": "^9.2.1",
     "eslint": "^9.27.0",
     "globals": "^16.1.0",
     "typescript": "^5.8.3",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -21,7 +21,7 @@
     "typecheck": "pnpm tsc --noEmit",
     "lint": "pnpm eslint --quiet .",
     "build": "pnpm tsc -p tsconfig.json",
-    "build:watch": "pnpm build --watch --preserveWatchOutput",
+    "build:watch": "pnpm tsc -p tsconfig.json --watch --preserveWatchOutput",
     "serve": "node ./dist/index.js",
     "serve:watch": "node --watch --watch-path=./dist --watch-preserve-output ./dist/index.js",
     "start": "pnpm concurrently --kill-others-on-fail --names build,server \"pnpm build:watch\" \"pnpm serve:watch\"",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -21,10 +21,16 @@
     "typecheck": "pnpm tsc --noEmit",
     "lint": "pnpm eslint --quiet .",
     "build": "pnpm tsc -p tsconfig.json",
-    "start": "node ./dist/index.js"
+    "build:watch": "pnpm build --watch --preserveWatchOutput",
+    "serve": "node ./dist/index.js",
+    "serve:watch": "node --watch --watch-path=./dist --watch-preserve-output ./dist/index.js",
+    "start": "pnpm concurrently --kill-others-on-fail --names build,server \"pnpm build:watch\" \"pnpm serve:watch\"",
+    "inspect": "npx @modelcontextprotocol/inspector node --watch --watch-path=./dist ./dist/index.js",
+    "start:dev": "pnpm concurrently --kill-others-on-fail --names mcp,inspector \"pnpm start\" \"pnpm inspect\""
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,0 +1,9 @@
+export type JsonObject = { [key: string]: JsonValue };
+export type JsonArray = JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonObject
+  | JsonArray;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,6 +466,9 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.17.0
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.3
       eslint:
         specifier: ^9.27.0
         version: 9.32.0
@@ -5548,6 +5551,11 @@ packages:
 
   concurrently@9.2.0:
     resolution: {integrity: sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  concurrently@9.2.3:
+    resolution: {integrity: sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10713,6 +10721,9 @@ packages:
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -10872,6 +10883,10 @@ packages:
 
   shell-quote@1.8.2:
     resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
+    engines: {node: '>= 0.4'}
+
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shellwords@0.1.1:
@@ -18417,6 +18432,15 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  concurrently@9.2.3:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.4
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   configstore@5.0.1:
     dependencies:
       dot-prop: 5.3.0
@@ -25443,6 +25467,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -25665,6 +25693,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.2: {}
+
+  shell-quote@1.8.4: {}
 
   shellwords@0.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,7 +455,10 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0
+        version: 1.29.0(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.27.0
@@ -3160,6 +3163,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -15127,7 +15131,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@modelcontextprotocol/sdk@1.29.0':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.18.0


### PR DESCRIPTION
### :pushpin: Summary
If merged, this PR adds MCP developer workflow scripts and introduces shared JSON value types.

### :hammer_and_wrench: Detailed description
- Updates `packages/mcp/package.json` scripts to support watch-mode `build`/`serve`, inspector usage, and a combined dev start flow.
- Renames single-run server command into `serve` and makes start run concurrent watch processes.
- Adds `zod` to `packages/mcp/package.json` dependencies.
- Adds `packages/mcp/src/types.ts` with reusable `JsonValue`/`JsonObject`/`JsonArray` type definitions.

### :copilot: Copilot instructions
Review only:
- script intent and naming consistency in `packages/mcp/package.json`
- `watch`/`dev` workflow correctness (`build:watch`, `serve:watch`, `start`, `start:dev`, `inspect`)
- correctness and safety of recursive JSON type definitions in `packages/mcp/src/types.ts`

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>