### PR TITLE
`FilterBar` -  Add feature to expose the search input aria-label (HDS-6513)

### DIFF
--- a/.changeset/silent-coats-say.md
+++ b/.changeset/silent-coats-say.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+`FilterBar` - Add a `searchAriaLabel` feature to expose the value of the search input aria-label, allowing the value to be customized

--- a/.changeset/silent-coats-say.md
+++ b/.changeset/silent-coats-say.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": minor
 ---
 
-`FilterBar` - Add a `searchAriaLabel` feature to expose the value of the search input aria-label, allowing the value to be customized
+<!-- START components/filter-bar -->
+`FilterBar` - Added a `searchAriaLabel` feature to expose the value of the search input aria-label, allowing the value to be customized
+<!-- END -->

--- a/packages/components/src/components/hds/filter-bar/index.gts
+++ b/packages/components/src/components/hds/filter-bar/index.gts
@@ -42,6 +42,7 @@ export interface HdsFilterBarSignature {
     isLiveFilter?: boolean;
     hasSearch?: boolean;
     searchPlaceholder?: string;
+    searchAriaLabel?: string;
     onFilter?: (filters: HdsFilterBarFilters) => void;
   };
   Blocks: {
@@ -92,6 +93,15 @@ export default class HdsFilterBar extends Component<HdsFilterBarSignature> {
     return (
       this.args.searchPlaceholder ||
       this.hdsIntl.t('hds.components.filter-bar.search.placeholder', {
+        default: 'Search',
+      })
+    );
+  }
+
+  get searchAriaLabel(): string {
+    return (
+      this.args.searchAriaLabel ||
+      this.hdsIntl.t('hds.components.filter-bar.search.aria-label', {
         default: 'Search',
       })
     );
@@ -380,10 +390,7 @@ export default class HdsFilterBar extends Component<HdsFilterBarSignature> {
             @value={{this.searchValue}}
             class="hds-filter-bar__search"
             placeholder={{this.searchPlaceholder}}
-            aria-label={{hdsT
-              "hds.components.filter-bar.search.aria-label"
-              default="Search"
-            }}
+            aria-label={{this.searchAriaLabel}}
             name="search"
             {{on "change" this.onSearch}}
           />

--- a/showcase/app/components/page-components/filter-bar/code-fragments/with-generic-content.gts
+++ b/showcase/app/components/page-components/filter-bar/code-fragments/with-generic-content.gts
@@ -44,6 +44,7 @@ export interface CodeFragmentWithGenericContentSignature {
   Args: {
     hasSearch?: boolean;
     searchPlaceholder?: string;
+    searchAriaLabel?: string;
     hasActionsDropdown?: boolean;
     hasActionsGeneric?: boolean;
     hasFilters?: boolean;
@@ -68,6 +69,7 @@ export default class CodeFragmentWithGenericContent extends Component<CodeFragme
       @filters={{this.filters}}
       @hasSearch={{@hasSearch}}
       @searchPlaceholder={{@searchPlaceholder}}
+      @searchAriaLabel={{@searchAriaLabel}}
       as |F|
     >
       {{#if @hasActionsGeneric}}

--- a/showcase/app/components/page-components/filter-bar/sub-sections/content.gts
+++ b/showcase/app/components/page-components/filter-bar/sub-sections/content.gts
@@ -31,6 +31,13 @@ const SubSectionContent: TemplateOnlyComponent = <template>
       />
     </SF.Item>
     <SF.Item as |SFI|>
+      <SFI.Label>With search, custom aria-label</SFI.Label>
+      <CodeFragmentWithGenericContent
+        @hasSearch={{true}}
+        @searchAriaLabel="Search by deployment name"
+      />
+    </SF.Item>
+    <SF.Item as |SFI|>
       <SFI.Label>With ActionsDropdown</SFI.Label>
       <CodeFragmentWithGenericContent @hasActionsDropdown={{true}} />
     </SF.Item>

--- a/showcase/tests/integration/components/hds/filter-bar/index-test.gts
+++ b/showcase/tests/integration/components/hds/filter-bar/index-test.gts
@@ -235,6 +235,7 @@ const FILTERS: Record<string, HdsFilterBarFilters> = {
 const createBasicFilterBar = async (options: {
   hasSearch?: boolean;
   searchPlaceholder?: string;
+  searchAriaLabel?: string;
   isLiveFilter?: boolean;
   appliedFiltersType?: string;
   onFilter?: (filters: HdsFilterBarFilters) => void;
@@ -250,6 +251,7 @@ const createBasicFilterBar = async (options: {
         @filters={{filters}}
         @hasSearch={{options.hasSearch}}
         @searchPlaceholder={{options.searchPlaceholder}}
+        @searchAriaLabel={{options.searchAriaLabel}}
         @isLiveFilter={{options.isLiveFilter}}
         @onFilter={{options.onFilter}}
         as |F|
@@ -334,6 +336,23 @@ module('Integration | Component | hds/filter-bar/index', function (hooks) {
     assert
       .dom('.hds-filter-bar__search')
       .hasAttribute('placeholder', 'Search custom placeholder');
+  });
+
+  // SEARCH ARIA-LABEL
+
+  test('it should render the default search input aria-label text if no @searchAriaLabel argument is provided', async function (assert) {
+    await createBasicFilterBar({ hasSearch: true });
+    assert.dom('.hds-filter-bar__search').hasAttribute('aria-label', 'Search');
+  });
+
+  test('it should render the search input aria-label text from the @searchAriaLabel argument', async function (assert) {
+    await createBasicFilterBar({
+      hasSearch: true,
+      searchAriaLabel: 'Search by deployment name',
+    });
+    assert
+      .dom('.hds-filter-bar__search')
+      .hasAttribute('aria-label', 'Search by deployment name');
   });
 
   // CALLBACK - ONFILTER


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR adds a `searchAriaLabel` feature to the Search input of the `FilterBar` allowing consumers to pass in a custom value.

**Preview**: https://hds-showcase-git-kristin-hds-6513-filter-bar-s-bc0a05-hashicorp.vercel.app/components/filter-bar#content
(Note: There is no visible change, inspect the DOM or use a11y tools to see the custom value in the example.)

#### Related PR:
* Docs update: https://github.com/hashicorp/design-system/pull/3983

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :copilot: Copilot instructions
Specific instructions for Copilot when reviewing the PR
-->

### :camera_flash: Screenshots

<img width="1115" height="507" alt="image" src="https://github.com/user-attachments/assets/b411ff88-0062-4e9b-a191-82a07f25f535" />

### :link: External links

* Jira ticket: [HDS-6513](https://hashicorp.atlassian.net/browse/HDS-6513)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6513]: https://hashicorp.atlassian.net/browse/HDS-6513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ