### PR TITLE
`FilterBar` - Add docs for `searchAriaLabel` option (HDS-6513)

### DIFF
--- a/website/docs/components/filter-bar/partials/code/code-snippets/filter-bar-search-placeholder.classic.hbs
+++ b/website/docs/components/filter-bar/partials/code/code-snippets/filter-bar-search-placeholder.classic.hbs
@@ -3,6 +3,7 @@
   @onFilter={{this.demoUpdateEmptyFilters}}
   @hasSearch={{true}}
   @searchPlaceholder="Search projects"
+  @searchAriaLabel="Search by project name"
   as |F|
 >
   <F.FiltersDropdown as |D|>

--- a/website/docs/components/filter-bar/partials/code/code-snippets/filter-bar-search-placeholder.gts
+++ b/website/docs/components/filter-bar/partials/code/code-snippets/filter-bar-search-placeholder.gts
@@ -19,6 +19,7 @@ export default class LocalComponent extends Component {
       @onFilter={{this.demoUpdateEmptyFilters}}
       @hasSearch={{true}}
       @searchPlaceholder="Search projects"
+      @searchAriaLabel="Search by project name"
       as |F|
     >
       <F.FiltersDropdown as |D|>

--- a/website/docs/components/filter-bar/partials/code/component-api.md
+++ b/website/docs/components/filter-bar/partials/code/component-api.md
@@ -26,6 +26,9 @@
   <C.Property @name="searchPlaceholder" @type="string" @default="&quot;Search&quot;">
     Placeholder text for the search input when `@hasSearch` is `true`.
   </C.Property>
+  <C.Property @name="searchAriaLabel" @type="string" @default="&quot;Search&quot;">
+    Aria-label text for the search input.
+  </C.Property>
   <C.Property @name="onFilter" @type="function">
     Callback invoked when filters are applied, changed, or cleared. Receives a single argument: the updated `HdsFilterBarFilters` object.
   </C.Property>

--- a/website/docs/components/filter-bar/partials/code/component-api.md
+++ b/website/docs/components/filter-bar/partials/code/component-api.md
@@ -27,7 +27,7 @@
     Placeholder text for the search input when `@hasSearch` is `true`.
   </C.Property>
   <C.Property @name="searchAriaLabel" @type="string" @default="&quot;Search&quot;">
-    Aria-label text for the search input.
+    The `aria-label` text for the search input.
   </C.Property>
   <C.Property @name="onFilter" @type="function">
     Callback invoked when filters are applied, changed, or cleared. Receives a single argument: the updated `HdsFilterBarFilters` object.

--- a/website/docs/components/filter-bar/partials/code/how-to-use.md
+++ b/website/docs/components/filter-bar/partials/code/how-to-use.md
@@ -119,7 +119,7 @@ When the search input's `input` event is triggered, a filter of type `search` wi
 
 [[code-snippets/filter-bar-search-data execute=false]]
 
-The search input's placeholder text is "Search" by default, but can be customized with the `@searchPlaceholder` argument.
+The search input’s aria-label and placeholder text values are both “Search” by default, but they can be customized with the `@searchAriaLabel` and `@searchPlaceholder` arguments respectively.
 
 [[code-snippets/filter-bar-search-placeholder]]
 

--- a/website/docs/components/filter-bar/partials/code/how-to-use.md
+++ b/website/docs/components/filter-bar/partials/code/how-to-use.md
@@ -119,7 +119,7 @@ When the search input's `input` event is triggered, a filter of type `search` wi
 
 [[code-snippets/filter-bar-search-data execute=false]]
 
-The search input’s aria-label and placeholder text values are both “Search” by default, but they can be customized with the `@searchAriaLabel` and `@searchPlaceholder` arguments respectively.
+The search input’s `aria-label` and `placeholder` text values are both “Search” by default, but they can be customized with the `@searchAriaLabel` and `@searchPlaceholder` arguments respectively.
 
 [[code-snippets/filter-bar-search-placeholder]]
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR updates the web docs for the `FilterBar` component to document the newly added `searchAriaLabel` option.

**Preview**: https://hds-website-git-kristin-hds-6513-filter-bar-se-dcbb0c-hashicorp.vercel.app/components/filter-bar?tab=code#search

#### Related PR:
* Code update: https://github.com/hashicorp/design-system/pull/3980

<!-- 
### :hammer_and_wrench: Detailed description
If more details are appropriate, add them here. What code changed, and why?

### :copilot: Copilot instructions
Specific instructions for Copilot when reviewing the PR -->

### :camera_flash: Screenshots

**_HOW TO_**:
<img width="675" height="446" alt="image" src="https://github.com/user-attachments/assets/b10436aa-c764-410a-90e2-3f080c0dc57c" />

**_API_**:
<img width="669" height="218" alt="image" src="https://github.com/user-attachments/assets/7aae0d35-bc04-409b-b656-98d7837aa301" />

### :link: External links

* Jira ticket: [HDS-6513](https://hashicorp.atlassian.net/browse/HDS-6513)

***

### :eyes: Component checklist

- ~~[ ] Percy was checked for any visual regression~~
- ~~[ ] A changelog entry was added via [Changesets]~~(https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6513]: https://hashicorp.atlassian.net/browse/HDS-6513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ