### PR TITLE
[Project Solar / Phase 2 / Tokens renaming] 04 - Update `focus-ring` tokens

### DIFF
--- a/.changeset/eight-zoos-notice.md
+++ b/.changeset/eight-zoos-notice.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+Updated components' code to reflect change of focus-ring tokens naming from `focus-ring-[action|critical]-box-shadow` to `focus-ring-box-shadow-[action|critical]`.

--- a/.changeset/twelve-mirrors-grab.md
+++ b/.changeset/twelve-mirrors-grab.md
@@ -1,0 +1,19 @@
+---
+"@hashicorp/design-system-tokens": major
+---
+
+Changed the focus-ring box-shadow token names from `focus-ring-[variant]-box-shadow` to `focus-ring-box-shadow-[variant]`. Updated also the helper generation script and downstream token consumers.
+
+**Token**:
+
+| Before | After |
+| --- | --- |
+| `--hds-focus-ring-action-box-shadow` | `--hds-focus-ring-box-shadow-action` |
+| `--hds-focus-ring-critical-box-shadow` | `--hds-focus-ring-box-shadow-critical` |
+
+**Helper CSS Class**:
+
+| Before | After |
+| --- | --- |
+| `.hds-focus-ring-action-box-shadow` | `.hds-focus-ring-box-shadow-action` |
+| `.hds-focus-ring-critical-box-shadow` | `.hds-focus-ring-box-shadow-critical` |

--- a/packages/components/src/styles/components/app-side-nav/content.scss
+++ b/packages/components/src/styles/components/app-side-nav/content.scss
@@ -101,7 +101,7 @@
   &:focus-visible,
   &.mock-focus {
     outline: none;
-    box-shadow: var(--hds-focus-ring-action-box-shadow);
+    box-shadow: var(--hds-focus-ring-box-shadow-action);
   }
 
   &:hover,

--- a/packages/components/src/styles/components/breadcrumb.scss
+++ b/packages/components/src/styles/components/breadcrumb.scss
@@ -22,7 +22,7 @@
     inset: $pseudo-element-inset;
     z-index: -1;
     border-radius: inherit;
-    box-shadow: var(--hds-focus-ring-action-box-shadow);
+    box-shadow: var(--hds-focus-ring-box-shadow-action);
     content: "";
 
     @include hds-apply-only-if-carbon() {

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -520,7 +520,7 @@
     --current-color-active: var(--hds-dropdown-list-item-foreground-color-action-active);
 
     &::after {
-      --current-focus-ring-box-shadow: var(--hds-focus-ring-action-box-shadow);
+      --current-focus-ring-box-shadow: var(--hds-focus-ring-box-shadow-action);
     }
   }
 
@@ -543,7 +543,7 @@
 
     &::after {
       --current-background-color: var(--hds-surface-color-critical);
-      --current-focus-ring-box-shadow: var(--hds-focus-ring-critical-box-shadow);
+      --current-focus-ring-box-shadow: var(--hds-focus-ring-box-shadow-critical);
     }
   }
 

--- a/packages/components/src/styles/mixins/_button.scss
+++ b/packages/components/src/styles/mixins/_button.scss
@@ -246,7 +246,7 @@ $hds-button-sizes: ("small", "medium", "large");
       inset: -1px; // we have to take into account the border
       z-index: -1;
       border-radius: inherit;
-      box-shadow: var(--hds-focus-ring-critical-box-shadow);
+      box-shadow: var(--hds-focus-ring-box-shadow-critical);
       content: "";
 
       @include hds-apply-only-if-carbon() {

--- a/packages/tokens/dist/cloud-email/helpers/focus-ring.css
+++ b/packages/tokens/dist/cloud-email/helpers/focus-ring.css
@@ -2,5 +2,5 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.hds-focus-ring-action-box-shadow { box-shadow: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff; }
-.hds-focus-ring-critical-box-shadow { box-shadow: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578; }
+.hds-focus-ring-box-shadow-action { box-shadow: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff; }
+.hds-focus-ring-box-shadow-critical { box-shadow: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578; }

--- a/packages/tokens/dist/cloud-email/tokens.scss
+++ b/packages/tokens/dist/cloud-email/tokens.scss
@@ -111,8 +111,8 @@ $hds-elevation-higher-box-shadow: 0px 2px 3px 0px #656a761a, 0px 12px 28px 0px #
 $hds-elevation-overlay-box-shadow: 0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559;
 $hds-focus-ring-width-external: 3px;
 $hds-focus-ring-width-internal: 1px;
-$hds-focus-ring-action-box-shadow: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff;
-$hds-focus-ring-critical-box-shadow: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578;
+$hds-focus-ring-box-shadow-action: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff;
+$hds-focus-ring-box-shadow-critical: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578;
 $hds-product-hashicorp-brand-color: #000000;
 $hds-product-boundary-brand-color: #f24c53;
 $hds-product-boundary-foreground-color: #cf2d32;

--- a/packages/tokens/dist/docs/products/themed-tokens.json
+++ b/packages/tokens/dist/docs/products/themed-tokens.json
@@ -3942,8 +3942,8 @@
         "internal"
       ]
     },
-    "hds-focus-ring-action-box-shadow": {
-      "key": "{focus-ring.action.box-shadow}",
+    "hds-focus-ring-box-shadow-action": {
+      "key": "{focus-ring.box-shadow.action}",
       "$value": "inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff",
       "$modes": {
         "default": "inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff",
@@ -3964,20 +3964,20 @@
         "comments": {
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
-        "key": "{focus-ring.action.box-shadow}"
+        "key": "{focus-ring.box-shadow.action}"
       },
-      "name": "hds-focus-ring-action-box-shadow",
+      "name": "hds-focus-ring-box-shadow-action",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "action",
-        "box-shadow"
+        "box-shadow",
+        "action"
       ]
     },
-    "hds-focus-ring-critical-box-shadow": {
-      "key": "{focus-ring.critical.box-shadow}",
+    "hds-focus-ring-box-shadow-critical": {
+      "key": "{focus-ring.box-shadow.critical}",
       "$value": "inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578",
       "$modes": {
         "default": "inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578",
@@ -3998,16 +3998,16 @@
         "comments": {
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
-        "key": "{focus-ring.critical.box-shadow}"
+        "key": "{focus-ring.box-shadow.critical}"
       },
-      "name": "hds-focus-ring-critical-box-shadow",
+      "name": "hds-focus-ring-box-shadow-critical",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "critical",
-        "box-shadow"
+        "box-shadow",
+        "critical"
       ]
     },
     "hds-accordion-card-gap-small": {
@@ -29694,8 +29694,8 @@
         "internal"
       ]
     },
-    "hds-focus-ring-action-box-shadow": {
-      "key": "{focus-ring.action.box-shadow}",
+    "hds-focus-ring-box-shadow-action": {
+      "key": "{focus-ring.box-shadow.action}",
       "$value": "inset 0 0 0 2px #0f62fe",
       "$modes": {
         "default": "inset 0 0 0 0px #ffffff, 0 0 0 2px #0f62fe",
@@ -29718,20 +29718,20 @@
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
         "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-        "key": "{focus-ring.action.box-shadow}"
+        "key": "{focus-ring.box-shadow.action}"
       },
-      "name": "hds-focus-ring-action-box-shadow",
+      "name": "hds-focus-ring-box-shadow-action",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "action",
-        "box-shadow"
+        "box-shadow",
+        "action"
       ]
     },
-    "hds-focus-ring-critical-box-shadow": {
-      "key": "{focus-ring.critical.box-shadow}",
+    "hds-focus-ring-box-shadow-critical": {
+      "key": "{focus-ring.box-shadow.critical}",
       "$value": "inset 0 0 0 2px #0f62fe",
       "$modes": {
         "default": "inset 0 0 0 0px #ffffff, 0 0 0 2px #0f62fe",
@@ -29754,16 +29754,16 @@
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
         "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-        "key": "{focus-ring.critical.box-shadow}"
+        "key": "{focus-ring.box-shadow.critical}"
       },
-      "name": "hds-focus-ring-critical-box-shadow",
+      "name": "hds-focus-ring-box-shadow-critical",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "critical",
-        "box-shadow"
+        "box-shadow",
+        "critical"
       ]
     },
     "hds-accordion-card-gap-small": {
@@ -55466,8 +55466,8 @@
         "internal"
       ]
     },
-    "hds-focus-ring-action-box-shadow": {
-      "key": "{focus-ring.action.box-shadow}",
+    "hds-focus-ring-box-shadow-action": {
+      "key": "{focus-ring.box-shadow.action}",
       "$value": "inset 0 0 0 2px #0f62fe",
       "$modes": {
         "default": "inset 0 0 0 0px #ffffff, 0 0 0 2px #0f62fe",
@@ -55490,20 +55490,20 @@
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
         "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-        "key": "{focus-ring.action.box-shadow}"
+        "key": "{focus-ring.box-shadow.action}"
       },
-      "name": "hds-focus-ring-action-box-shadow",
+      "name": "hds-focus-ring-box-shadow-action",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "action",
-        "box-shadow"
+        "box-shadow",
+        "action"
       ]
     },
-    "hds-focus-ring-critical-box-shadow": {
-      "key": "{focus-ring.critical.box-shadow}",
+    "hds-focus-ring-box-shadow-critical": {
+      "key": "{focus-ring.box-shadow.critical}",
       "$value": "inset 0 0 0 2px #0f62fe",
       "$modes": {
         "default": "inset 0 0 0 0px #ffffff, 0 0 0 2px #0f62fe",
@@ -55526,16 +55526,16 @@
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
         "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-        "key": "{focus-ring.critical.box-shadow}"
+        "key": "{focus-ring.box-shadow.critical}"
       },
-      "name": "hds-focus-ring-critical-box-shadow",
+      "name": "hds-focus-ring-box-shadow-critical",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "critical",
-        "box-shadow"
+        "box-shadow",
+        "critical"
       ]
     },
     "hds-accordion-card-gap-small": {
@@ -81238,8 +81238,8 @@
         "internal"
       ]
     },
-    "hds-focus-ring-action-box-shadow": {
-      "key": "{focus-ring.action.box-shadow}",
+    "hds-focus-ring-box-shadow-action": {
+      "key": "{focus-ring.box-shadow.action}",
       "$value": "inset 0 0 0 2px #ffffff",
       "$modes": {
         "default": "inset 0 0 0 0px #161616, 0 0 0 2px #ffffff",
@@ -81262,20 +81262,20 @@
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
         "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-        "key": "{focus-ring.action.box-shadow}"
+        "key": "{focus-ring.box-shadow.action}"
       },
-      "name": "hds-focus-ring-action-box-shadow",
+      "name": "hds-focus-ring-box-shadow-action",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "action",
-        "box-shadow"
+        "box-shadow",
+        "action"
       ]
     },
-    "hds-focus-ring-critical-box-shadow": {
-      "key": "{focus-ring.critical.box-shadow}",
+    "hds-focus-ring-box-shadow-critical": {
+      "key": "{focus-ring.box-shadow.critical}",
       "$value": "inset 0 0 0 2px #ffffff",
       "$modes": {
         "default": "inset 0 0 0 0px #161616, 0 0 0 2px #ffffff",
@@ -81298,16 +81298,16 @@
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
         "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-        "key": "{focus-ring.critical.box-shadow}"
+        "key": "{focus-ring.box-shadow.critical}"
       },
-      "name": "hds-focus-ring-critical-box-shadow",
+      "name": "hds-focus-ring-box-shadow-critical",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "critical",
-        "box-shadow"
+        "box-shadow",
+        "critical"
       ]
     },
     "hds-accordion-card-gap-small": {
@@ -107010,8 +107010,8 @@
         "internal"
       ]
     },
-    "hds-focus-ring-action-box-shadow": {
-      "key": "{focus-ring.action.box-shadow}",
+    "hds-focus-ring-box-shadow-action": {
+      "key": "{focus-ring.box-shadow.action}",
       "$value": "inset 0 0 0 2px #ffffff",
       "$modes": {
         "default": "inset 0 0 0 0px #161616, 0 0 0 2px #ffffff",
@@ -107034,20 +107034,20 @@
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
         "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-        "key": "{focus-ring.action.box-shadow}"
+        "key": "{focus-ring.box-shadow.action}"
       },
-      "name": "hds-focus-ring-action-box-shadow",
+      "name": "hds-focus-ring-box-shadow-action",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "action",
-        "box-shadow"
+        "box-shadow",
+        "action"
       ]
     },
-    "hds-focus-ring-critical-box-shadow": {
-      "key": "{focus-ring.critical.box-shadow}",
+    "hds-focus-ring-box-shadow-critical": {
+      "key": "{focus-ring.box-shadow.critical}",
       "$value": "inset 0 0 0 2px #ffffff",
       "$modes": {
         "default": "inset 0 0 0 0px #161616, 0 0 0 2px #ffffff",
@@ -107070,16 +107070,16 @@
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         },
         "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-        "key": "{focus-ring.critical.box-shadow}"
+        "key": "{focus-ring.box-shadow.critical}"
       },
-      "name": "hds-focus-ring-critical-box-shadow",
+      "name": "hds-focus-ring-box-shadow-critical",
       "attributes": {
         "category": "focus-ring"
       },
       "path": [
         "focus-ring",
-        "critical",
-        "box-shadow"
+        "box-shadow",
+        "critical"
       ]
     },
     "hds-accordion-card-gap-small": {

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
@@ -3936,7 +3936,7 @@
     ]
   },
   {
-    "key": "{focus-ring.action.box-shadow}",
+    "key": "{focus-ring.box-shadow.action}",
     "$value": "inset 0 0 0 2px #0f62fe",
     "$modes": {
       "default": "inset 0 0 0 0px #ffffff, 0 0 0 2px #0f62fe",
@@ -3959,20 +3959,20 @@
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-      "key": "{focus-ring.action.box-shadow}"
+      "key": "{focus-ring.box-shadow.action}"
     },
-    "name": "hds-focus-ring-action-box-shadow",
+    "name": "hds-focus-ring-box-shadow-action",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "action",
-      "box-shadow"
+      "box-shadow",
+      "action"
     ]
   },
   {
-    "key": "{focus-ring.critical.box-shadow}",
+    "key": "{focus-ring.box-shadow.critical}",
     "$value": "inset 0 0 0 2px #0f62fe",
     "$modes": {
       "default": "inset 0 0 0 0px #ffffff, 0 0 0 2px #0f62fe",
@@ -3995,16 +3995,16 @@
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-      "key": "{focus-ring.critical.box-shadow}"
+      "key": "{focus-ring.box-shadow.critical}"
     },
-    "name": "hds-focus-ring-critical-box-shadow",
+    "name": "hds-focus-ring-box-shadow-critical",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "critical",
-      "box-shadow"
+      "box-shadow",
+      "critical"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
@@ -3936,7 +3936,7 @@
     ]
   },
   {
-    "key": "{focus-ring.action.box-shadow}",
+    "key": "{focus-ring.box-shadow.action}",
     "$value": "inset 0 0 0 2px #0f62fe",
     "$modes": {
       "default": "inset 0 0 0 0px #ffffff, 0 0 0 2px #0f62fe",
@@ -3959,20 +3959,20 @@
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-      "key": "{focus-ring.action.box-shadow}"
+      "key": "{focus-ring.box-shadow.action}"
     },
-    "name": "hds-focus-ring-action-box-shadow",
+    "name": "hds-focus-ring-box-shadow-action",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "action",
-      "box-shadow"
+      "box-shadow",
+      "action"
     ]
   },
   {
-    "key": "{focus-ring.critical.box-shadow}",
+    "key": "{focus-ring.box-shadow.critical}",
     "$value": "inset 0 0 0 2px #0f62fe",
     "$modes": {
       "default": "inset 0 0 0 0px #ffffff, 0 0 0 2px #0f62fe",
@@ -3995,16 +3995,16 @@
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-      "key": "{focus-ring.critical.box-shadow}"
+      "key": "{focus-ring.box-shadow.critical}"
     },
-    "name": "hds-focus-ring-critical-box-shadow",
+    "name": "hds-focus-ring-box-shadow-critical",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "critical",
-      "box-shadow"
+      "box-shadow",
+      "critical"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
@@ -3936,7 +3936,7 @@
     ]
   },
   {
-    "key": "{focus-ring.action.box-shadow}",
+    "key": "{focus-ring.box-shadow.action}",
     "$value": "inset 0 0 0 2px #ffffff",
     "$modes": {
       "default": "inset 0 0 0 0px #161616, 0 0 0 2px #ffffff",
@@ -3959,20 +3959,20 @@
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-      "key": "{focus-ring.action.box-shadow}"
+      "key": "{focus-ring.box-shadow.action}"
     },
-    "name": "hds-focus-ring-action-box-shadow",
+    "name": "hds-focus-ring-box-shadow-action",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "action",
-      "box-shadow"
+      "box-shadow",
+      "action"
     ]
   },
   {
-    "key": "{focus-ring.critical.box-shadow}",
+    "key": "{focus-ring.box-shadow.critical}",
     "$value": "inset 0 0 0 2px #ffffff",
     "$modes": {
       "default": "inset 0 0 0 0px #161616, 0 0 0 2px #ffffff",
@@ -3995,16 +3995,16 @@
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-      "key": "{focus-ring.critical.box-shadow}"
+      "key": "{focus-ring.box-shadow.critical}"
     },
-    "name": "hds-focus-ring-critical-box-shadow",
+    "name": "hds-focus-ring-box-shadow-critical",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "critical",
-      "box-shadow"
+      "box-shadow",
+      "critical"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
@@ -3936,7 +3936,7 @@
     ]
   },
   {
-    "key": "{focus-ring.action.box-shadow}",
+    "key": "{focus-ring.box-shadow.action}",
     "$value": "inset 0 0 0 2px #ffffff",
     "$modes": {
       "default": "inset 0 0 0 0px #161616, 0 0 0 2px #ffffff",
@@ -3959,20 +3959,20 @@
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-      "key": "{focus-ring.action.box-shadow}"
+      "key": "{focus-ring.box-shadow.action}"
     },
-    "name": "hds-focus-ring-action-box-shadow",
+    "name": "hds-focus-ring-box-shadow-action",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "action",
-      "box-shadow"
+      "box-shadow",
+      "action"
     ]
   },
   {
-    "key": "{focus-ring.critical.box-shadow}",
+    "key": "{focus-ring.box-shadow.critical}",
     "$value": "inset 0 0 0 2px #ffffff",
     "$modes": {
       "default": "inset 0 0 0 0px #161616, 0 0 0 2px #ffffff",
@@ -3995,16 +3995,16 @@
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
       "comment": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation",
-      "key": "{focus-ring.critical.box-shadow}"
+      "key": "{focus-ring.box-shadow.critical}"
     },
-    "name": "hds-focus-ring-critical-box-shadow",
+    "name": "hds-focus-ring-box-shadow-critical",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "critical",
-      "box-shadow"
+      "box-shadow",
+      "critical"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/themed-tokens/default.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/default.json
@@ -3942,7 +3942,7 @@
     ]
   },
   {
-    "key": "{focus-ring.action.box-shadow}",
+    "key": "{focus-ring.box-shadow.action}",
     "$value": "inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff",
     "$modes": {
       "default": "inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff",
@@ -3963,20 +3963,20 @@
       "comments": {
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
-      "key": "{focus-ring.action.box-shadow}"
+      "key": "{focus-ring.box-shadow.action}"
     },
-    "name": "hds-focus-ring-action-box-shadow",
+    "name": "hds-focus-ring-box-shadow-action",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "action",
-      "box-shadow"
+      "box-shadow",
+      "action"
     ]
   },
   {
-    "key": "{focus-ring.critical.box-shadow}",
+    "key": "{focus-ring.box-shadow.critical}",
     "$value": "inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578",
     "$modes": {
       "default": "inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578",
@@ -3997,16 +3997,16 @@
       "comments": {
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
-      "key": "{focus-ring.critical.box-shadow}"
+      "key": "{focus-ring.box-shadow.critical}"
     },
-    "name": "hds-focus-ring-critical-box-shadow",
+    "name": "hds-focus-ring-box-shadow-critical",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "critical",
-      "box-shadow"
+      "box-shadow",
+      "critical"
     ]
   },
   {

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -3942,7 +3942,7 @@
     ]
   },
   {
-    "key": "{focus-ring.action.box-shadow}",
+    "key": "{focus-ring.box-shadow.action}",
     "$value": "inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff",
     "$modes": {
       "default": "inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff",
@@ -3963,20 +3963,20 @@
       "comments": {
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
-      "key": "{focus-ring.action.box-shadow}"
+      "key": "{focus-ring.box-shadow.action}"
     },
-    "name": "hds-focus-ring-action-box-shadow",
+    "name": "hds-focus-ring-box-shadow-action",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "action",
-      "box-shadow"
+      "box-shadow",
+      "action"
     ]
   },
   {
-    "key": "{focus-ring.critical.box-shadow}",
+    "key": "{focus-ring.box-shadow.critical}",
     "$value": "inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578",
     "$modes": {
       "default": "inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578",
@@ -3997,16 +3997,16 @@
       "comments": {
         "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
       },
-      "key": "{focus-ring.critical.box-shadow}"
+      "key": "{focus-ring.box-shadow.critical}"
     },
-    "name": "hds-focus-ring-critical-box-shadow",
+    "name": "hds-focus-ring-box-shadow-critical",
     "attributes": {
       "category": "focus-ring"
     },
     "path": [
       "focus-ring",
-      "critical",
-      "box-shadow"
+      "box-shadow",
+      "critical"
     ]
   },
   {

--- a/packages/tokens/dist/products/css/helpers/focus-ring.css
+++ b/packages/tokens/dist/products/css/helpers/focus-ring.css
@@ -2,5 +2,5 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-.hds-focus-ring-action-box-shadow { box-shadow: var(--hds-focus-ring-action-box-shadow); }
-.hds-focus-ring-critical-box-shadow { box-shadow: var(--hds-focus-ring-critical-box-shadow); }
+.hds-focus-ring-box-shadow-action { box-shadow: var(--hds-focus-ring-box-shadow-action); }
+.hds-focus-ring-box-shadow-critical { box-shadow: var(--hds-focus-ring-box-shadow-critical); }

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -647,12 +647,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: var(--hds-core-color-blue-300);
   --hds-focus-color-critical-external: #dd7578; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: var(--hds-core-color-red-300);
-  --hds-focus-ring-action-box-shadow:
+  --hds-focus-ring-box-shadow-action:
     inset 0 0 0 var(--hds-focus-ring-width-internal)
       var(--hds-focus-color-action-internal),
     0 0 0 var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external);
-  --hds-focus-ring-critical-box-shadow:
+  --hds-focus-ring-box-shadow-critical:
     inset 0 0 0 var(--hds-focus-ring-width-internal)
       var(--hds-focus-color-critical-internal),
     0 0 0 var(--hds-focus-ring-width-external)
@@ -1378,10 +1378,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #ffffff;
     --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #ffffff;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2015,10 +2015,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #161616;
     --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #161616;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2632,9 +2632,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -3267,9 +3267,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -3881,9 +3881,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -4515,9 +4515,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
@@ -635,12 +635,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: var(--hds-core-color-blue-300);
   --hds-focus-color-critical-external: #dd7578; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: var(--hds-core-color-red-300);
-  --hds-focus-ring-action-box-shadow:
+  --hds-focus-ring-box-shadow-action:
     inset 0 0 0 var(--hds-focus-ring-width-internal)
       var(--hds-focus-color-action-internal),
     0 0 0 var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external);
-  --hds-focus-ring-critical-box-shadow:
+  --hds-focus-ring-box-shadow-critical:
     inset 0 0 0 var(--hds-focus-ring-width-internal)
       var(--hds-focus-color-critical-internal),
     0 0 0 var(--hds-focus-ring-width-external)
@@ -1366,10 +1366,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #ffffff;
     --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #ffffff;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2003,10 +2003,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #161616;
     --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #161616;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2619,9 +2619,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -3253,9 +3253,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
@@ -434,9 +434,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -1049,10 +1049,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #ffffff;
     --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #ffffff;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -1686,10 +1686,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #161616;
     --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #161616;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2302,9 +2302,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -2936,9 +2936,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
@@ -369,8 +369,8 @@
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-box-shadow-action: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-foreground-color-action-active: #0f62fe;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
@@ -369,8 +369,8 @@
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-box-shadow-action: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-foreground-color-action-active: #0f62fe;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
@@ -369,8 +369,8 @@
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-box-shadow-action: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-foreground-color-action-active: #78a9ff;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
@@ -369,8 +369,8 @@
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-box-shadow-action: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
   --hds-focus-ring-width-internal: 0px;
   --hds-foreground-color-action-active: #78a9ff;

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
@@ -369,8 +369,8 @@
   --hds-focus-color-action-internal: var(--hds-core-color-blue-300);
   --hds-focus-color-critical-external: #dd7578; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: var(--hds-core-color-red-300);
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-internal) var(--hds-focus-color-action-internal), 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external);
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 var(--hds-focus-ring-width-internal) var(--hds-focus-color-critical-internal), 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external);
+  --hds-focus-ring-box-shadow-action: inset 0 0 0 var(--hds-focus-ring-width-internal) var(--hds-focus-color-action-internal), 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external);
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0 var(--hds-focus-ring-width-internal) var(--hds-focus-color-critical-internal), 0 0 0 var(--hds-focus-ring-width-external) var(--hds-focus-color-critical-external);
   --hds-focus-ring-width-external: 3px;
   --hds-focus-ring-width-internal: 1px;
   --hds-foreground-color-action-active: var(--hds-core-color-blue-400);

--- a/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
@@ -618,12 +618,12 @@
     --hds-focus-color-action-internal: var(--hds-core-color-blue-300);
     --hds-focus-color-critical-external: #dd7578; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: var(--hds-core-color-red-300);
-    --hds-focus-ring-action-box-shadow:
+    --hds-focus-ring-box-shadow-action:
       inset 0 0 0 var(--hds-focus-ring-width-internal)
         var(--hds-focus-color-action-internal),
       0 0 0 var(--hds-focus-ring-width-external)
         var(--hds-focus-color-action-external);
-    --hds-focus-ring-critical-box-shadow:
+    --hds-focus-ring-box-shadow-critical:
       inset 0 0 0 var(--hds-focus-ring-width-internal)
         var(--hds-focus-color-critical-internal),
       0 0 0 var(--hds-focus-ring-width-external)
@@ -1369,10 +1369,10 @@
     --hds-focus-color-action-internal: #ffffff;
     --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #ffffff;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2008,10 +2008,10 @@
     --hds-focus-color-action-internal: #161616;
     --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #161616;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2627,10 +2627,10 @@
     --hds-focus-color-action-internal: #ffffff;
     --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #ffffff;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -3246,10 +3246,10 @@
     --hds-focus-color-action-internal: #ffffff;
     --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #ffffff;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -3885,10 +3885,10 @@
     --hds-focus-color-action-internal: #161616;
     --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #161616;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -4524,10 +4524,10 @@
     --hds-focus-color-action-internal: #161616;
     --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #161616;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -113,8 +113,8 @@
   --hds-elevation-overlay-box-shadow: 0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559;
   --hds-focus-ring-width-external: 3px;
   --hds-focus-ring-width-internal: 1px;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff;
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578;
+  --hds-focus-ring-box-shadow-action: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff;
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578;
   --hds-accordion-card-gap-small: 4px;
   --hds-accordion-card-gap-medium: 8px;
   --hds-accordion-card-gap-large: 12px;

--- a/packages/tokens/scripts/build-parts/generateFocusRingHelpers.ts
+++ b/packages/tokens/scripts/build-parts/generateFocusRingHelpers.ts
@@ -9,18 +9,17 @@ import { PREFIX } from './generateCssHelpers.ts';
 
 type Helpers = string[];
 
-export function generateFocusRingHelpers(tokens: TransformedTokens, outputCssVars: boolean): Helpers {
+export function generateFocusRingHelpers(tokensFocusRing: TransformedTokens, outputCssVars: boolean): Helpers {
 
   const helpersFocusRing: Helpers = [];
 
-  Object.keys(tokens).forEach((key: string) => {
-    const color = key;
-    if (tokens && tokens[color] && Object.prototype.hasOwnProperty.call(tokens[color], 'box-shadow')) {
-      const selector = `.${PREFIX}-focus-ring-${color}-box-shadow`;
-      const value = outputCssVars ? `var(--hds-focus-ring-${color}-box-shadow)` : tokens[color]['box-shadow'].$value;
+  if (tokensFocusRing && tokensFocusRing['box-shadow']) {
+    Object.keys(tokensFocusRing['box-shadow']).forEach((variant: string) => {
+      const selector = `.${PREFIX}-focus-ring-box-shadow-${variant}`;
+      const value = outputCssVars ? `var(--hds-focus-ring-box-shadow-${variant})` : tokensFocusRing['box-shadow'][variant].$value;
       helpersFocusRing.push(`${selector} { box-shadow: ${value}; }`);
-    }
-  });
+    });
+  }
 
   return [...helpersFocusRing];
 }

--- a/packages/tokens/src/global/focus-ring.json
+++ b/packages/tokens/src/global/focus-ring.json
@@ -26,8 +26,8 @@
         }
       }
     },
-    "action": {
-      "box-shadow": {
+    "box-shadow": {
+      "action": {
         "$value": "inset 0 0 0 {focus-ring.width.internal} {focus.color.action.internal}, 0 0 0 {focus-ring.width.external} {focus.color.action.external}",
         "$modes": {
           "default": "inset 0 0 0 {focus-ring.width.internal} {focus.color.action.internal}, 0 0 0 {focus-ring.width.external} {focus.color.action.external}",
@@ -39,10 +39,8 @@
         "comments": {
           "cds": "this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation"
         }
-      }
-    },
-    "critical": {
-      "box-shadow": {
+      },
+      "critical": {
         "$value": "inset 0 0 0 {focus-ring.width.internal} {focus.color.critical.internal}, 0 0 0 {focus-ring.width.external} {focus.color.critical.external}",
         "$modes": {
           "default": "inset 0 0 0 {focus-ring.width.internal} {focus.color.critical.internal}, 0 0 0 {focus-ring.width.external} {focus.color.critical.external}",

--- a/showcase/app/components/page-carbonization/foundations/focus-ring/index.gts
+++ b/showcase/app/components/page-carbonization/foundations/focus-ring/index.gts
@@ -143,7 +143,7 @@ const FocusRingCarbonizationIndex: TemplateOnlyComponent = <template>
         <ShwFlex @direction="column" as |SF|>
           <SF.Item>
             <div
-              class="hds-focus-ring-action-box-shadow shw-component-focus-ring-box-corners"
+              class="hds-focus-ring-box-shadow-action shw-component-focus-ring-box-corners"
             >
               <ShwPlaceholder
                 @width="100"
@@ -154,7 +154,7 @@ const FocusRingCarbonizationIndex: TemplateOnlyComponent = <template>
           </SF.Item>
           <SF.Item>
             <div
-              class="hds-focus-ring-action-box-shadow"
+              class="hds-focus-ring-box-shadow-action"
               {{style width="fit-content" border-radius="5px"}}
             >
               <ShwPlaceholder
@@ -166,7 +166,7 @@ const FocusRingCarbonizationIndex: TemplateOnlyComponent = <template>
           </SF.Item>
           <SF.Item>
             <div
-              class="hds-focus-ring-critical-box-shadow"
+              class="hds-focus-ring-box-shadow-critical"
               {{style width="fit-content" border-radius="5px"}}
             >
               <ShwPlaceholder

--- a/showcase/app/components/page-foundations/focus-ring/sub-sections/base.gts
+++ b/showcase/app/components/page-foundations/focus-ring/sub-sections/base.gts
@@ -15,7 +15,7 @@ const SubSectionBase: TemplateOnlyComponent = <template>
 
   <ShwFlex as |SF|>
     <SF.Item>
-      <div class="hds-focus-ring-action-box-shadow">
+      <div class="hds-focus-ring-box-shadow-action">
         <ShwPlaceholder
           @text="no radius"
           @width="100"
@@ -26,7 +26,7 @@ const SubSectionBase: TemplateOnlyComponent = <template>
     </SF.Item>
     <SF.Item>
       <div
-        class="hds-focus-ring-action-box-shadow"
+        class="hds-focus-ring-box-shadow-action"
         {{style border-radius="5px"}}
       >
         <ShwPlaceholder

--- a/showcase/app/components/page-foundations/focus-ring/sub-sections/variants.gts
+++ b/showcase/app/components/page-foundations/focus-ring/sub-sections/variants.gts
@@ -13,7 +13,7 @@ const SubSectionVariants: TemplateOnlyComponent = <template>
 
   <ShwFlex as |SF|>
     <SF.Item @label="action">
-      <div class="hds-focus-ring-action-box-shadow">
+      <div class="hds-focus-ring-box-shadow-action">
         <ShwPlaceholder
           @text="with border radius"
           @width="100"
@@ -23,7 +23,7 @@ const SubSectionVariants: TemplateOnlyComponent = <template>
       </div>
     </SF.Item>
     <SF.Item @label="critical">
-      <div class="hds-focus-ring-critical-box-shadow">
+      <div class="hds-focus-ring-box-shadow-critical">
         <ShwPlaceholder
           @text="with border radius"
           @width="100"

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -236,12 +236,12 @@
 /**
  * Do not edit directly, this file was auto-generated.
  */
-.hds-focus-ring-action-box-shadow {
-  box-shadow: var(--hds-focus-ring-action-box-shadow);
+.hds-focus-ring-box-shadow-action {
+  box-shadow: var(--hds-focus-ring-box-shadow-action);
 }
 
-.hds-focus-ring-critical-box-shadow {
-  box-shadow: var(--hds-focus-ring-critical-box-shadow);
+.hds-focus-ring-box-shadow-critical {
+  box-shadow: var(--hds-focus-ring-box-shadow-critical);
 }
 
 /**
@@ -2219,7 +2219,7 @@
 }
 .hds-app-side-nav__list-item-link:focus-visible, .hds-app-side-nav__list-item-link.mock-focus {
   outline: none;
-  box-shadow: var(--hds-focus-ring-action-box-shadow);
+  box-shadow: var(--hds-focus-ring-box-shadow-action);
 }
 .hds-app-side-nav__list-item-link:hover, .hds-app-side-nav__list-item-link.mock-hover {
   background: var(--hds-app-side-nav-body-list-item-surface-color-hover);
@@ -2795,7 +2795,7 @@
   inset: 0;
   z-index: -1;
   border-radius: inherit;
-  box-shadow: var(--hds-focus-ring-action-box-shadow);
+  box-shadow: var(--hds-focus-ring-box-shadow-action);
   content: "";
 }
 .hds-theme-light .hds-breadcrumb__link:focus-visible::before, .hds-theme-light .hds-breadcrumb__link.mock-focus::before,
@@ -2887,7 +2887,7 @@
   inset: -1px;
   z-index: -1;
   border-radius: inherit;
-  box-shadow: var(--hds-focus-ring-action-box-shadow);
+  box-shadow: var(--hds-focus-ring-box-shadow-action);
   content: "";
 }
 .hds-theme-light .hds-breadcrumb__truncation-toggle:focus-visible::before, .hds-theme-light .hds-breadcrumb__truncation-toggle.mock-focus::before,
@@ -3278,7 +3278,7 @@ a.hds-button:hover, a.hds-button:focus, a.hds-button:active, a.hds-button.mock-h
   inset: -1px;
   z-index: -1;
   border-radius: inherit;
-  box-shadow: var(--hds-focus-ring-critical-box-shadow);
+  box-shadow: var(--hds-focus-ring-box-shadow-critical);
   content: "";
 }
 .hds-theme-light .hds-button--color-critical:focus-visible::before, .hds-theme-light .hds-button--color-critical.mock-focus::before,
@@ -5331,7 +5331,7 @@ button.hds-button[href]::after {
 .hds-dropdown-list-item--color-action a::after,
 .hds-dropdown-list-item--color-action button::after,
 .hds-dropdown-list-item--color-action .hds-dropdown-list-item__label::after {
-  --current-focus-ring-box-shadow: var(--hds-focus-ring-action-box-shadow);
+  --current-focus-ring-box-shadow: var(--hds-focus-ring-box-shadow-action);
 }
 .hds-dropdown-list-item--color-action:has(button:hover, button.mock-hover, a:hover, a.mock-hover, input:hover, input.mock-hover) {
   background-color: var(--hds-dropdown-list-item-surface-color-action-hover);
@@ -5347,7 +5347,7 @@ button.hds-button[href]::after {
 .hds-dropdown-list-item--color-critical a::after,
 .hds-dropdown-list-item--color-critical button::after {
   --current-background-color: var(--hds-surface-color-critical);
-  --current-focus-ring-box-shadow: var(--hds-focus-ring-critical-box-shadow);
+  --current-focus-ring-box-shadow: var(--hds-focus-ring-box-shadow-critical);
 }
 .hds-dropdown-list-item--color-critical:has(button:hover, button.mock-hover, a:hover, a.mock-hover, input:hover, input.mock-hover), .hds-dropdown-list-item--color-critical:has(button:focus, button.mock-focus, a:focus, a.mock-focus, input:focus, input.mock-focus), .hds-dropdown-list-item--color-critical:has(button:active, button.mock-active, a:active, a.mock-active, input:active, input.mock-active) {
   background-color: var(--hds-dropdown-list-item-surface-color-critical-hover);

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -117,8 +117,8 @@
   --hds-elevation-overlay-box-shadow: 0px 2px 3px 0px #3b3d4540, 0px 12px 24px 0px #3b3d4559;
   --hds-focus-ring-width-external: 3px;
   --hds-focus-ring-width-internal: 1px;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff;
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578;
+  --hds-focus-ring-box-shadow-action: inset 0 0 0 1px #0c56e9, 0 0 0 3px #5990ff;
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0 1px #c00005, 0 0 0 3px #dd7578;
   --hds-accordion-card-gap-small: 4px;
   --hds-accordion-card-gap-medium: 8px;
   --hds-accordion-card-gap-large: 12px;
@@ -1046,12 +1046,12 @@
 /**
  * Do not edit directly, this file was auto-generated.
  */
-.hds-focus-ring-action-box-shadow {
-  box-shadow: var(--hds-focus-ring-action-box-shadow);
+.hds-focus-ring-box-shadow-action {
+  box-shadow: var(--hds-focus-ring-box-shadow-action);
 }
 
-.hds-focus-ring-critical-box-shadow {
-  box-shadow: var(--hds-focus-ring-critical-box-shadow);
+.hds-focus-ring-box-shadow-critical {
+  box-shadow: var(--hds-focus-ring-box-shadow-critical);
 }
 
 /**
@@ -3029,7 +3029,7 @@
 }
 .hds-app-side-nav__list-item-link:focus-visible, .hds-app-side-nav__list-item-link.mock-focus {
   outline: none;
-  box-shadow: var(--hds-focus-ring-action-box-shadow);
+  box-shadow: var(--hds-focus-ring-box-shadow-action);
 }
 .hds-app-side-nav__list-item-link:hover, .hds-app-side-nav__list-item-link.mock-hover {
   background: var(--hds-app-side-nav-body-list-item-surface-color-hover);
@@ -3605,7 +3605,7 @@
   inset: 0;
   z-index: -1;
   border-radius: inherit;
-  box-shadow: var(--hds-focus-ring-action-box-shadow);
+  box-shadow: var(--hds-focus-ring-box-shadow-action);
   content: "";
 }
 .hds-theme-light .hds-breadcrumb__link:focus-visible::before, .hds-theme-light .hds-breadcrumb__link.mock-focus::before,
@@ -3697,7 +3697,7 @@
   inset: -1px;
   z-index: -1;
   border-radius: inherit;
-  box-shadow: var(--hds-focus-ring-action-box-shadow);
+  box-shadow: var(--hds-focus-ring-box-shadow-action);
   content: "";
 }
 .hds-theme-light .hds-breadcrumb__truncation-toggle:focus-visible::before, .hds-theme-light .hds-breadcrumb__truncation-toggle.mock-focus::before,
@@ -4088,7 +4088,7 @@ a.hds-button:hover, a.hds-button:focus, a.hds-button:active, a.hds-button.mock-h
   inset: -1px;
   z-index: -1;
   border-radius: inherit;
-  box-shadow: var(--hds-focus-ring-critical-box-shadow);
+  box-shadow: var(--hds-focus-ring-box-shadow-critical);
   content: "";
 }
 .hds-theme-light .hds-button--color-critical:focus-visible::before, .hds-theme-light .hds-button--color-critical.mock-focus::before,
@@ -6141,7 +6141,7 @@ button.hds-button[href]::after {
 .hds-dropdown-list-item--color-action a::after,
 .hds-dropdown-list-item--color-action button::after,
 .hds-dropdown-list-item--color-action .hds-dropdown-list-item__label::after {
-  --current-focus-ring-box-shadow: var(--hds-focus-ring-action-box-shadow);
+  --current-focus-ring-box-shadow: var(--hds-focus-ring-box-shadow-action);
 }
 .hds-dropdown-list-item--color-action:has(button:hover, button.mock-hover, a:hover, a.mock-hover, input:hover, input.mock-hover) {
   background-color: var(--hds-dropdown-list-item-surface-color-action-hover);
@@ -6157,7 +6157,7 @@ button.hds-button[href]::after {
 .hds-dropdown-list-item--color-critical a::after,
 .hds-dropdown-list-item--color-critical button::after {
   --current-background-color: var(--hds-surface-color-critical);
-  --current-focus-ring-box-shadow: var(--hds-focus-ring-critical-box-shadow);
+  --current-focus-ring-box-shadow: var(--hds-focus-ring-box-shadow-critical);
 }
 .hds-dropdown-list-item--color-critical:has(button:hover, button.mock-hover, a:hover, a.mock-hover, input:hover, input.mock-hover), .hds-dropdown-list-item--color-critical:has(button:focus, button.mock-focus, a:focus, a.mock-focus, input:focus, input.mock-focus), .hds-dropdown-list-item--color-critical:has(button:active, button.mock-active, a:active, a.mock-active, input:active, input.mock-active) {
   background-color: var(--hds-dropdown-list-item-surface-color-critical-hover);

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -647,12 +647,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: var(--hds-core-color-blue-300);
   --hds-focus-color-critical-external: #dd7578; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: var(--hds-core-color-red-300);
-  --hds-focus-ring-action-box-shadow:
+  --hds-focus-ring-box-shadow-action:
     inset 0 0 0 var(--hds-focus-ring-width-internal)
       var(--hds-focus-color-action-internal),
     0 0 0 var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external);
-  --hds-focus-ring-critical-box-shadow:
+  --hds-focus-ring-box-shadow-critical:
     inset 0 0 0 var(--hds-focus-ring-width-internal)
       var(--hds-focus-color-critical-internal),
     0 0 0 var(--hds-focus-ring-width-external)
@@ -1378,10 +1378,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #ffffff;
     --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #ffffff;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2015,10 +2015,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #161616;
     --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #161616;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2632,9 +2632,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -3267,9 +3267,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -3881,9 +3881,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -4515,9 +4515,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
@@ -635,12 +635,12 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: var(--hds-core-color-blue-300);
   --hds-focus-color-critical-external: #dd7578; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: var(--hds-core-color-red-300);
-  --hds-focus-ring-action-box-shadow:
+  --hds-focus-ring-box-shadow-action:
     inset 0 0 0 var(--hds-focus-ring-width-internal)
       var(--hds-focus-color-action-internal),
     0 0 0 var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external);
-  --hds-focus-ring-critical-box-shadow:
+  --hds-focus-ring-box-shadow-critical:
     inset 0 0 0 var(--hds-focus-ring-width-internal)
       var(--hds-focus-color-critical-internal),
     0 0 0 var(--hds-focus-ring-width-external)
@@ -1366,10 +1366,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #ffffff;
     --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #ffffff;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2003,10 +2003,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #161616;
     --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #161616;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2619,9 +2619,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -3253,9 +3253,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
@@ -434,9 +434,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -1049,10 +1049,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #ffffff;
     --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #ffffff;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -1686,10 +1686,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-focus-color-action-internal: #161616;
     --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
     --hds-focus-color-critical-internal: #161616;
-    --hds-focus-ring-action-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-action: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-    --hds-focus-ring-critical-box-shadow: inset 0 0 0
+    --hds-focus-ring-box-shadow-critical: inset 0 0 0
       var(--hds-focus-ring-width-external)
       var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
     --hds-focus-ring-width-external: 2px;
@@ -2302,9 +2302,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #ffffff;
   --hds-focus-color-critical-external: #0f62fe; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #ffffff;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;
@@ -2936,9 +2936,9 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-focus-color-action-internal: #161616;
   --hds-focus-color-critical-external: #ffffff; /** this is a special color used only for the focus style, to pass color contrast for a11y purpose */
   --hds-focus-color-critical-internal: #161616;
-  --hds-focus-ring-action-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-action: inset 0 0 0
     var(--hds-focus-ring-width-external) var(--hds-focus-color-action-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
-  --hds-focus-ring-critical-box-shadow: inset 0 0 0
+  --hds-focus-ring-box-shadow-critical: inset 0 0 0
     var(--hds-focus-ring-width-external)
     var(--hds-focus-color-critical-external); /** this box shadow covers the most simple/common use cases, for more complex ones you have to use the `advanced` Sass mixin or a custom/local implementation */
   --hds-focus-ring-width-external: 2px;

--- a/website/app/styles/pages/components/card.scss
+++ b/website/app/styles/pages/components/card.scss
@@ -31,7 +31,7 @@
 
         &:focus {
           outline: none;
-          box-shadow: var(--hds-focus-ring-action-box-shadow);
+          box-shadow: var(--hds-focus-ring-box-shadow-action);
         }
       }
     }

--- a/website/docs/components/card/partials/code/code-snippets/card-container-interactive-styles.scss
+++ b/website/docs/components/card/partials/code/code-snippets/card-container-interactive-styles.scss
@@ -12,7 +12,7 @@
 
       &:focus {
         outline: none;
-        box-shadow: var(--hds-focus-ring-action-box-shadow);
+        box-shadow: var(--hds-focus-ring-box-shadow-action);
       }
     }
   }

--- a/website/docs/foundations/focus-ring/partials/code/code-snippets/focus-ring-token-usage.scss
+++ b/website/docs/foundations/focus-ring/partials/code/code-snippets/focus-ring-token-usage.scss
@@ -8,6 +8,6 @@
   &:focus,
   &:focus-visible {
     border-radius: inherit;
-    box-shadow: var(--hds-focus-ring-action-box-shadow);
+    box-shadow: var(--hds-focus-ring-box-shadow-action);
   }
 }

--- a/website/docs/foundations/focus-ring/partials/code/how-to-use.md
+++ b/website/docs/foundations/focus-ring/partials/code/how-to-use.md
@@ -12,7 +12,7 @@ Note that `border-radius` is not included with this token and needs to be set ac
 
 ### Design tokens (recommended)
 
-Use the `--hds-focus-ring-action-box-shadow` [design token](./tokens) directly in your CSS definitions. Note that it can only be used with the `box-shadow` property.
+Use the `--hds-focus-ring-box-shadow-action` [design token](./tokens) directly in your CSS definitions. Note that it can only be used with the `box-shadow` property.
 
 [[code-snippets/focus-ring-token-usage]]
 
@@ -28,20 +28,20 @@ To use this class, ensure you’ve imported the relevant CSS file:
 
 ### Border radius
 
-<div class="hds-focus-ring-action-box-shadow" style="margin-bottom: 16px;">
+<div class="hds-focus-ring-box-shadow-action" style="margin-bottom: 16px;">
   <Doc::Placeholder @text="no radius" @width="100" @height="100" @background="transparent" />
 </div>
 
-<div class="hds-focus-ring-action-box-shadow" style="margin-bottom: 16px; border-radius: 5px;">
+<div class="hds-focus-ring-box-shadow-action" style="margin-bottom: 16px; border-radius: 5px;">
   <Doc::Placeholder @text="with border radius" @width="100" @height="100" @background="transparent" />
 </div>
 
 ### Colors
 
-<div class="hds-focus-ring-action-box-shadow" style="margin-bottom: 16px;">
+<div class="hds-focus-ring-box-shadow-action" style="margin-bottom: 16px;">
   <Doc::Placeholder @text="action" @width="100" @height="100" @background="transparent" />
 </div>
 
-<div class="hds-focus-ring-critical-box-shadow" style="margin-bottom: 16px;">
+<div class="hds-focus-ring-box-shadow-critical" style="margin-bottom: 16px;">
   <Doc::Placeholder @text="critical" @width="100" @height="100" @background="transparent" />
 </div>


### PR DESCRIPTION
> [!NOTE]
> Note: this PR is built on top of https://github.com/hashicorp/design-system/pull/3979

### :pushpin: Summary

This is the fourth in a set of PRs that will rename some of the HDS tokens to follow the [approved naming convention](https://ibm.sharepoint.com/:w:/r/sites/hermes/_layouts/15/doc2.aspx?sourcedoc=%7B36A06FC9-1B5E-46B0-841A-AFBF8875ED7D%7D&file=DS-HDS%20Token%20Nomenclature.docx&action=default&mobileredirect=true). 

### :hammer_and_wrench: Detailed description

In this PR I have:
- `packages/tokens/src`
    - renamed `focus-ring-[action|critical]-box-shadow` to `focus-ring-box-shadow-[action|critical]`
- `packages/tokens/scripts`
    - updated pipeline script that generates the `.hds-focus-ring-***` CSS helpers
- `packages/components` folder
    - updated “focus-ring-box-shadow” token names
- `showcase` folder
    - updated “focus-ring-box-shadow” token names
- `website` folder
    - updated “focus-ring-box-shadow” token names
        - ⚠️ excluded documentation updates, they will be done in a separate, single PR for all the changes
- re-generated files in output

### ♻️ Renamed tokens and CSS helper classes

**Token**:

| Before | After |
| --- | --- |
| `--hds-focus-ring-action-box-shadow` | `--hds-focus-ring-box-shadow-action` |
| `--hds-focus-ring-critical-box-shadow` | `--hds-focus-ring-box-shadow-critical` |

**Helper CSS Class**:

| Before | After |
| --- | --- |
| `.hds-focus-ring-action-box-shadow` | `.hds-focus-ring-box-shadow-action` |
| `.hds-focus-ring-critical-box-shadow` | `.hds-focus-ring-box-shadow-critical` |

### :copilot: Copilot instructions

Ignore changes that should be made to files under the `website/docs folder`: they will be fixed in a separate PR.

### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-6270

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>