### PR TITLE
Stepper - Add sr text for step number

### DIFF
--- a/.changeset/tall-dancers-crash.md
+++ b/.changeset/tall-dancers-crash.md
@@ -1,0 +1,11 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/stepper/nav -->
+`StepperNav` - Added scren reader text for step number
+<!-- END -->
+
+<!-- START components/stepper/list -->
+`StepperList` - Added scren reader text for step number
+<!-- END -->

--- a/packages/components/src/components/hds/stepper/list/step.gts
+++ b/packages/components/src/components/hds/stepper/list/step.gts
@@ -8,6 +8,7 @@ import { assert } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 import { modifier } from 'ember-modifier';
 import { service } from '@ember/service';
+import { concat } from '@ember/helper';
 import type HdsIntlService from '../../../../services/hds-intl';
 import type Owner from '@ember/owner';
 
@@ -18,6 +19,7 @@ import {
 } from '../types.ts';
 import HdsTextBody from '../../text/body.gts';
 import HdsStepperStepIndicator from '../step/indicator.gts';
+import hdsT from '../../../../helpers/hds-t.ts';
 
 import type {
   HdsStepperListStepIds,
@@ -124,6 +126,7 @@ export default class HdsStepperListStep extends Component<HdsStepperListStepSign
           @text="{{this.stepNumber}}"
           @status={{this.status}}
           @isInteractive={{false}}
+          aria-hidden="true"
           class="hds-stepper-list__step-indicator"
         />
       </div>
@@ -135,6 +138,13 @@ export default class HdsStepperListStep extends Component<HdsStepperListStepSign
           @weight="semibold"
           @color="strong"
         >
+          <span class="sr-only">
+            {{hdsT
+              "hds.components.stepper.step-number"
+              default=(concat "Step " this.stepNumber)
+              stepNumber=this.stepNumber
+            }}
+          </span>
           {{yield to="title"}}
           <span class="sr-only">{{this.statusSrOnlyText}}</span>
         </HdsTextBody>

--- a/packages/components/src/components/hds/stepper/nav/step.gts
+++ b/packages/components/src/components/hds/stepper/nav/step.gts
@@ -8,6 +8,7 @@ import { guidFor } from '@ember/object/internals';
 import { modifier } from 'ember-modifier';
 import { eq } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
+import { concat } from '@ember/helper';
 
 import { service } from '@ember/service';
 import type HdsIntlService from '../../../../services/hds-intl';
@@ -21,6 +22,7 @@ import {
 } from '../types.ts';
 import HdsStepperStepIndicator from '../step/indicator.gts';
 import HdsTextBody from '../../text/body.gts';
+import hdsT from '../../../../helpers/hds-t.ts';
 
 import type {
   HdsStepperNavPanelIds,
@@ -217,6 +219,7 @@ export default class HdsStepperNavStep extends Component<HdsStepperNavStepSignat
               @text="{{this.stepNumber}}"
               @status={{this.stepIndicatorStatus}}
               @isInteractive={{true}}
+              aria-hidden="true"
               class="hds-stepper-nav__step-indicator"
             />
           </div>
@@ -227,6 +230,13 @@ export default class HdsStepperNavStep extends Component<HdsStepperNavStepSignat
               @size="200"
               @weight="semibold"
             >
+              <span class="sr-only">
+                {{hdsT
+                  "hds.components.stepper.step-number"
+                  default=(concat "Step " this.stepNumber)
+                  stepNumber=this.stepNumber
+                }}
+              </span>
               {{yield to="title"}}
               <span class="sr-only">{{this.statusSrOnlyText}}</span>
             </HdsTextBody>

--- a/packages/components/translations/hds/components/stepper/en-us.yaml
+++ b/packages/components/translations/hds/components/stepper/en-us.yaml
@@ -1,3 +1,4 @@
 progress: "(current)"
 processing: "(in progress)"
 complete: "(complete)"
+step-number: "Step {stepNumber}"

--- a/showcase/tests/integration/components/hds/stepper/list-step-test.gts
+++ b/showcase/tests/integration/components/hds/stepper/list-step-test.gts
@@ -41,7 +41,7 @@ module('Integration | Component | hds/stepper/list/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-incomplete');
-    assert.dom('.sr-only').hasNoText();
+    assert.dom('.sr-only:last-child').hasNoText();
   });
 
   test('it sets the status to complete when the @status argument is provided', async function (assert) {
@@ -58,7 +58,7 @@ module('Integration | Component | hds/stepper/list/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-complete');
-    assert.dom('.sr-only').hasText('(complete)');
+    assert.dom('.sr-only:last-child').hasText('(complete)');
   });
 
   test('it sets the status to progress when the @status argument is provided', async function (assert) {
@@ -75,7 +75,7 @@ module('Integration | Component | hds/stepper/list/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-progress');
-    assert.dom('.sr-only').hasText('(current)');
+    assert.dom('.sr-only:last-child').hasText('(current)');
   });
 
   test('it sets the status to processing when the @status argument is provided', async function (assert) {
@@ -92,7 +92,7 @@ module('Integration | Component | hds/stepper/list/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-processing');
-    assert.dom('.sr-only').hasText('(in progress)');
+    assert.dom('.sr-only:last-child').hasText('(in progress)');
   });
 
   // TITLE TAG
@@ -131,6 +131,9 @@ module('Integration | Component | hds/stepper/list/step', function (hooks) {
       </template>,
     );
     assert.dom('.hds-stepper-indicator-step__text').hasText('1');
+    assert
+      .dom('.hds-stepper-list__step-title .sr-only:first-child')
+      .hasText('Step 1');
   });
 
   // TITLE

--- a/showcase/tests/integration/components/hds/stepper/nav-step-test.gts
+++ b/showcase/tests/integration/components/hds/stepper/nav-step-test.gts
@@ -111,6 +111,9 @@ module('Integration | Component | hds/stepper/nav/step', function (hooks) {
   test('it sets the step number automatically based on the step ids provided', async function (assert) {
     await createNavStep({});
     assert.dom('.hds-stepper-indicator-step__text').hasText('1');
+    assert
+      .dom('.hds-stepper-nav__step-title .sr-only:first-child')
+      .hasText('Step 1');
   });
 
   // navInteractive
@@ -170,7 +173,7 @@ module('Integration | Component | hds/stepper/nav/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-incomplete');
-    assert.dom('.sr-only').hasNoText();
+    assert.dom('.sr-only:last-child').hasNoText();
   });
 
   test('it sets the step to complete when the @currentStep is greater than the nodeIndex and @isNavInteractive is true', async function (assert) {
@@ -185,7 +188,7 @@ module('Integration | Component | hds/stepper/nav/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-complete');
-    assert.dom('.sr-only').hasText('(complete)');
+    assert.dom('.sr-only:last-child').hasText('(complete)');
   });
 
   test('it sets the step to active when the @currentStep is equal to the nodeIndex and @isNavInteractive is true', async function (assert) {
@@ -200,7 +203,7 @@ module('Integration | Component | hds/stepper/nav/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-progress');
-    assert.dom('.sr-only').hasText('(current)');
+    assert.dom('.sr-only:last-child').hasText('(current)');
   });
 
   // STATUS - NOT INTERACTIVE
@@ -221,7 +224,7 @@ module('Integration | Component | hds/stepper/nav/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-incomplete');
-    assert.dom('.sr-only').hasNoText();
+    assert.dom('.sr-only:last-child').hasNoText();
   });
 
   test('it sets the step to complete when the @currentStep is greater than the nodeIndex and @isNavInteractive is false', async function (assert) {
@@ -233,7 +236,7 @@ module('Integration | Component | hds/stepper/nav/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-complete');
-    assert.dom('.sr-only').hasText('(complete)');
+    assert.dom('.sr-only:last-child').hasText('(complete)');
   });
 
   test('it sets the step to active when the @currentStep is equal to the nodeIndex and @isNavInteractive is false', async function (assert) {
@@ -245,7 +248,7 @@ module('Integration | Component | hds/stepper/nav/step', function (hooks) {
     assert
       .dom('.hds-stepper-indicator-step')
       .hasClass('hds-stepper-indicator-step--status-progress');
-    assert.dom('.sr-only').hasText('(current)');
+    assert.dom('.sr-only:last-child').hasText('(current)');
   });
 
   // NAMED BLOCKS


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would add sr-only text to the `StepperNav` and `StepperList` step titles which indicates the step number of a given step. 

### :hammer_and_wrench: Detailed description

Currently in both the `StepperNav` and `StepperList` there is a disjointed SR experience for how step numbers are announced. Neither component has any explicit sr text announcing the step number. For the active and incomplete steps the step number is visible inside the `StepperIndicator` used in both components and is announced. However for completed steps the step number is not shown in the `StepperIndicator` and thus no number is announced to screen readers.

To provide more consistency to this experience for screen readers, and to ensure the step number is always announced the following changes have been made

- New `sr-only` text of the format `Step {number}` has been added in each step title
- The `StepperIndicator` has been set to `aria-hidden="true"` so the textual numbers inside it are not announced for the active and incomplete steps

### :camera_flash: Screenshots

All screen reader testing is from Voiceover on MacOS

**SR - before**

<img width="1258" height="351" alt="Screenshot 2026-07-10 at 9 11 20 AM" src="https://github.com/user-attachments/assets/461f49b8-dbc7-4efd-9276-498f0a3d8853" />
<img width="1178" height="375" alt="Screenshot 2026-07-10 at 9 11 38 AM" src="https://github.com/user-attachments/assets/e80e4e52-2c27-4a01-8347-c76fe23bd154" />


**SR - after**
<img width="869" height="342" alt="Screenshot 2026-07-10 at 9 36 49 AM" src="https://github.com/user-attachments/assets/4a7a30d1-3114-43da-bde9-474d2f6bde83" />
<img width="814" height="331" alt="Screenshot 2026-07-10 at 10 27 04 AM" src="https://github.com/user-attachments/assets/d37a0d31-6c65-4421-bbf7-ba8064a3a658" />


**DOM - before**

<img width="247" height="142" alt="Screenshot 2026-07-10 at 9 51 08 AM" src="https://github.com/user-attachments/assets/000faaa6-9841-4985-ac6d-c5e30a0fa8b9" />

**DOM - after**
<img width="249" height="170" alt="Screenshot 2026-07-10 at 9 50 55 AM" src="https://github.com/user-attachments/assets/f7b70803-9163-4cc3-9083-8356eccea1fe" />


### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-XXX](https://hashicorp.atlassian.net/browse/HDS-XXX)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>