### PR TITLE
Website: AdvancedTable: fix incorrect reference to isExpanded

### DIFF
--- a/website/docs/components/table/advanced-table/partials/code/component-api.md
+++ b/website/docs/components/table/advanced-table/partials/code/component-api.md
@@ -42,8 +42,8 @@ The Advanced Table component itself is where most of the options will be applied
       <C.Property @name="children" @type="array">
         If there are nested rows, the Advanced Table will use the `children` key in the model to render the child content. The key can be changed by setting `childrenKey` argument on the `Hds::AdvancedTable`.
       </C.Property>
-      <C.Property @name="isExpanded" @type="boolean">
-        If there are nested rows, the default state of the toggle can be set by adding `isExpanded` to the row in the model.
+      <C.Property @name="isOpen" @type="boolean">
+        If there are nested rows, the default state of the toggle can be set by adding `isOpen` to the row in the model.
       </C.Property>
     </Doc::ComponentApi>
   </C.Property>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix an incorrect mention of isExpanded on the AdvancedTable docs page. isExpanded is the internal variable name, isOpen is what consumers use.

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>