### PR TITLE
[Project Solar / Phase 1 / Migration] DropdownToggleIcon color argument

### DIFF
--- a/packages/components/src/components/hds/dropdown/toggle/icon.gts
+++ b/packages/components/src/components/hds/dropdown/toggle/icon.gts
@@ -19,15 +19,23 @@ import HdsDropdownToggleChevron from './chevron.gts';
 import {
   HdsDropdownToggleIconSizeValues,
   HdsDropdownToggleIconAllowedIconValues,
+  HdsDropdownToggleIconColorValues,
 } from './types.ts';
 
 import type { HdsIconSignature } from '../../icon/index.gts';
-import type { HdsDropdownToggleIconSizes } from './types.ts';
+import type {
+  HdsDropdownToggleIconSizes,
+  HdsDropdownToggleIconColors,
+} from './types.ts';
 import type { SetupPrimitiveToggleModifier } from '../../popover-primitive/index.gts';
 
 export const DEFAULT_SIZE = HdsDropdownToggleIconSizeValues.Medium;
+export const DEFAULT_COLOR = HdsDropdownToggleIconColorValues.Secondary;
 export const SIZES: HdsDropdownToggleIconSizes[] = Object.values(
   HdsDropdownToggleIconSizeValues
+);
+export const COLORS: HdsDropdownToggleIconColors[] = Object.values(
+  HdsDropdownToggleIconColorValues
 );
 
 export const ALLOWED_ICON_LIST: HdsIconSignature['Args']['name'][] =
@@ -39,6 +47,7 @@ export interface HdsDropdownToggleIconSignature {
     icon?: HdsIconSignature['Args']['name'];
     imageSrc?: string;
     isOpen?: boolean;
+    color?: HdsDropdownToggleIconColors;
     size?: HdsDropdownToggleIconSizes;
     text: string;
     setupPrimitiveToggle?: ModifierLike<SetupPrimitiveToggleModifier>;
@@ -77,6 +86,19 @@ export default class HdsDropdownToggleIcon extends Component<HdsDropdownToggleIc
     );
 
     return text;
+  }
+
+  get color(): HdsDropdownToggleIconColors {
+    const { color = DEFAULT_COLOR } = this.args;
+
+    assert(
+      `@color for "Hds::Dropdown::Toggle::Icon" must be one of the following: ${COLORS.join(
+        ', '
+      )}; received: ${color}`,
+      COLORS.includes(color)
+    );
+
+    return color;
   }
 
   get size(): HdsDropdownToggleIconSizes {
@@ -123,6 +145,9 @@ export default class HdsDropdownToggleIcon extends Component<HdsDropdownToggleIc
 
     // add a class based on the @size argument
     classes.push(`hds-dropdown-toggle-icon--size-${this.size}`);
+
+    // add a class based on the @color argument
+    classes.push(`hds-dropdown-toggle-icon--color-${this.color}`);
 
     // add a class based on the @isOpen argument
     if (this.args.isOpen) {

--- a/packages/components/src/components/hds/dropdown/toggle/types.ts
+++ b/packages/components/src/components/hds/dropdown/toggle/types.ts
@@ -24,6 +24,12 @@ export enum HdsDropdownToggleButtonColorValues {
 export type HdsDropdownToggleButtonColors =
   `${HdsDropdownToggleButtonColorValues}`;
 
+export enum HdsDropdownToggleIconColorValues {
+  Secondary = 'secondary',
+  SecondaryMuted = 'secondary-muted',
+}
+export type HdsDropdownToggleIconColors = `${HdsDropdownToggleIconColorValues}`;
+
 export enum HdsDropdownToggleIconAllowedIconValues {
   MoreHorizontal = 'more-horizontal',
   MoreVertical = 'more-vertical',

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -58,53 +58,50 @@
   border-radius: var(--hds-button-border-radius);
   isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
 
-  &:hover,
-  &.mock-hover {
-    color: var(--hds-button-foreground-color-secondary-hover);
-    background-color: var(--hds-button-surface-color-secondary-hover);
-    border-color: var(--hds-button-border-color-secondary-hover);
-    cursor: pointer;
-  }
-
-  &:focus-visible,
-  &.mock-focus {
-    @include hds-focus-ring-advanced(
-      // the element has already a `position: relative` with `isolation: isolate`
-      $element-position: false,
-      // needs to overlay the avatar image
-      $pseudo-element-z-index: 1,
-      // we want to see the white/black inner border for cds
-      $internal-border-width-cds: 1px
-    );
-    color: var(--hds-button-foreground-color-secondary-focus);
-    background-color: var(--hds-button-surface-color-secondary-focus);
-  }
-
-  &:active,
-  &.mock-active {
-    color: var(--hds-button-foreground-color-secondary-active);
-    background-color: var(--hds-button-surface-color-secondary-active);
-    border-color: var(--hds-button-border-color-secondary-active);
-  }
-
   &:disabled,
   &.mock-disabled {
     @include hds-button-state-disabled();
   }
+}
 
-  // this variant mimics the secondary and secondary-muted button, but not entirely (eg. it doesn't have an elevation shadow)
-  // so we need to provide the same color values but without using the `hds-button-color-{color}()` mixin
+// this variant mimics the secondary and secondary-muted button, but not entirely (eg. it doesn't have an elevation shadow)
+// so we need to provide the same color values but without using the `hds-button-color-{color}()` mixin
+$hds-dropdown-toggle-icon-colors: ("secondary", "secondary-muted");
 
-  &.hds-dropdown-toggle-icon--color-secondary {
-    color: var(--hds-button-foreground-color-secondary-default);
-    background-color: var(--hds-button-surface-color-secondary-default);
-    border: 1px solid var(--hds-button-border-color-secondary-default);
-  }
+@each $color in $hds-dropdown-toggle-icon-colors {
+  .hds-dropdown-toggle-icon--color-#{$color} {
+    color: var(--hds-button-foreground-color-#{$color}-default);
+    background-color: var(--hds-button-surface-color-#{$color}-default);
+    border: 1px solid var(--hds-button-border-color-#{$color}-default);
 
-  &.hds-dropdown-toggle-icon--color-secondary-muted {
-    color: var(--hds-button-foreground-color-secondary-muted-default);
-    background-color: var(--hds-button-surface-color-secondary-muted-default);
-    border: 1px solid var(--hds-button-border-color-secondary-muted-default);
+    &:hover,
+    &.mock-hover {
+      color: var(--hds-button-foreground-color-#{$color}-hover);
+      background-color: var(--hds-button-surface-color-#{$color}-hover);
+      border-color: var(--hds-button-border-color-#{$color}-hover);
+      cursor: pointer;
+    }
+
+    &:focus-visible,
+    &.mock-focus {
+      @include hds-focus-ring-advanced(
+        // the element has already a `position: relative` with `isolation: isolate`
+        $element-position: false,
+        // needs to overlay the avatar image
+        $pseudo-element-z-index: 1,
+        // we want to see the white/black inner border for cds
+        $internal-border-width-cds: 1px
+      );
+      color: var(--hds-button-foreground-color-#{$color}-focus);
+      background-color: var(--hds-button-surface-color-#{$color}-focus);
+    }
+
+    &:active,
+    &.mock-active {
+      color: var(--hds-button-foreground-color-#{$color}-active);
+      background-color: var(--hds-button-surface-color-#{$color}-active);
+      border-color: var(--hds-button-border-color-#{$color}-active);
+    }
   }
 }
 

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -59,7 +59,11 @@
   isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
 
   &:disabled,
-  &.mock-disabled {
+  &.mock-disabled,
+  &:disabled:hover,
+  &.mock-disabled:hover,
+  &:disabled:focus,
+  &.mock-disabled:focus {
     @include hds-button-state-disabled();
   }
 }

--- a/packages/components/src/styles/components/dropdown.scss
+++ b/packages/components/src/styles/components/dropdown.scss
@@ -55,11 +55,6 @@
   align-items: center;
   justify-content: center;
   padding: var(--hds-dropdown-toggle-icon-padding);
-  // this variant mimics the secondary button, but not entirely (eg. it doesn't have an elevation shadow)
-  // so we need to provide the same color values but without using the `hds-button-color-secondary()` mixin
-  color: var(--hds-button-foreground-color-secondary-default);
-  background-color: var(--hds-button-surface-color-secondary-default);
-  border: 1px solid var(--hds-button-border-color-secondary-default);
   border-radius: var(--hds-button-border-radius);
   isolation: isolate; // used to create a new stacking context (needed to have the pseudo element below text/icon but not the parent container)
 
@@ -95,6 +90,21 @@
   &:disabled,
   &.mock-disabled {
     @include hds-button-state-disabled();
+  }
+
+  // this variant mimics the secondary and secondary-muted button, but not entirely (eg. it doesn't have an elevation shadow)
+  // so we need to provide the same color values but without using the `hds-button-color-{color}()` mixin
+
+  &.hds-dropdown-toggle-icon--color-secondary {
+    color: var(--hds-button-foreground-color-secondary-default);
+    background-color: var(--hds-button-surface-color-secondary-default);
+    border: 1px solid var(--hds-button-border-color-secondary-default);
+  }
+
+  &.hds-dropdown-toggle-icon--color-secondary-muted {
+    color: var(--hds-button-foreground-color-secondary-muted-default);
+    background-color: var(--hds-button-surface-color-secondary-muted-default);
+    border: 1px solid var(--hds-button-border-color-secondary-muted-default);
   }
 }
 

--- a/showcase/app/components/page-carbonization/components/dropdown/index.gts
+++ b/showcase/app/components/page-carbonization/components/dropdown/index.gts
@@ -42,7 +42,14 @@ import {
   HdsFormTextInputBase,
 } from '@hashicorp/design-system-components/components';
 
-const TOGGLE_STATES = ['default', 'hover', 'active', 'focus', 'disabled'];
+const TOGGLE_STATES = [
+  'default',
+  'hover',
+  'active',
+  'focus',
+  'disabled',
+  'open',
+];
 const ITEM_STATES = ['default', 'hover', 'focus', 'active'];
 const GENERIC_ITEMS = ['1', '2', '3'];
 const ORGANIZATIONS = ['Organization A', 'Organization B', 'Organization C'];
@@ -50,13 +57,13 @@ const ORGANIZATIONS = ['Organization A', 'Organization B', 'Organization C'];
 import { COLORS as ITEM_INTERACTIVE_COLORS } from '@hashicorp/design-system-components/components/hds/dropdown/list-item/interactive';
 
 import {
-  COLORS as BUTTON_COLORS,
-  SIZES as BUTTON_SIZES,
+  COLORS as TOGGLE_BUTTION_COLORS,
+  SIZES as TOGGLE_BUTTION_SIZES,
 } from '@hashicorp/design-system-components/components/hds/dropdown/toggle/button';
 
 import {
-  COLORS as ICON_COLORS,
-  SIZES as ICON_SIZES,
+  COLORS as TOGGLE_ICON_COLORS,
+  SIZES as TOGGLE_ICON_SIZES,
 } from '@hashicorp/design-system-components/components/hds/dropdown/toggle/icon';
 
 const CARBON_SIZES = ['xs', 'sm', 'md'] as const;
@@ -203,9 +210,9 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid @layout="side-by-side">
       <:theming>
-        {{#each BUTTON_COLORS as |color|}}
+        {{#each TOGGLE_BUTTION_COLORS as |color|}}
           <ShwFlex @direction="column" as |SF|>
-            {{#each BUTTON_SIZES as |size|}}
+            {{#each TOGGLE_BUTTION_SIZES as |size|}}
               <SF.Item>
                 <HdsDropdownToggleButton
                   @color={{color}}
@@ -238,9 +245,9 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid @layout="side-by-side">
       <:theming>
-        {{#each BUTTON_COLORS as |color|}}
+        {{#each TOGGLE_BUTTION_COLORS as |color|}}
           <ShwFlex @direction="column" as |SF|>
-            {{#each BUTTON_SIZES as |size|}}
+            {{#each TOGGLE_BUTTION_SIZES as |size|}}
               <SF.Item>
                 <ShwFlex @direction="column" as |SF|>
                   <SF.Item>
@@ -278,7 +285,7 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid @layout="side-by-side">
       <:theming>
-        {{#each BUTTON_COLORS as |color|}}
+        {{#each TOGGLE_BUTTION_COLORS as |color|}}
           <ShwFlex @direction="column" as |SF|>
             <SF.Item>
               <ShwOutliner {{style width="300px"}}>
@@ -325,9 +332,9 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid @layout="side-by-side">
       <:theming>
-        {{#each ICON_COLORS as |color|}}
+        {{#each TOGGLE_ICON_COLORS as |color|}}
           <ShwFlex as |SF|>
-            {{#each ICON_SIZES as |size|}}
+            {{#each TOGGLE_ICON_SIZES as |size|}}
               <SF.Item>
                 <HdsDropdownToggleIcon
                   @icon="user"
@@ -340,9 +347,9 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
           </ShwFlex>
         {{/each}}
 
-        {{#each ICON_COLORS as |color|}}
+        {{#each TOGGLE_ICON_COLORS as |color|}}
           <ShwFlex as |SF|>
-            {{#each ICON_SIZES as |size|}}
+            {{#each TOGGLE_ICON_SIZES as |size|}}
               <SF.Item>
                 <HdsDropdownToggleIcon
                   @imageSrc="/assets/images/avatar.png"
@@ -372,7 +379,7 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
     <ShwTextH3>Toggle states</ShwTextH3>
 
     <ShwTextH4>Text Toggle states</ShwTextH4>
-    {{#each BUTTON_COLORS as |color|}}
+    {{#each TOGGLE_BUTTION_COLORS as |color|}}
       <ShwTextBody>{{capitalize color}}</ShwTextBody>
       {{#each TOGGLE_STATES as |state|}}
         <ShwCarbonizationComparisonGrid
@@ -392,6 +399,16 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
                     @badgeIcon="hexagon"
                     @color={{color}}
                     disabled
+                  />
+                {{else if (eq state "open")}}
+                  <HdsDropdownToggleButton
+                    @text="Tgl"
+                    @icon="hexagon"
+                    @count="1"
+                    @badge="Bdg"
+                    @badgeIcon="hexagon"
+                    @color={{color}}
+                    @isOpen={{true}}
                   />
                 {{else}}
                   <HdsDropdownToggleButton
@@ -416,7 +433,7 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwTextH4>Icon/Image Toggle states</ShwTextH4>
 
-    {{#each ICON_COLORS as |color|}}
+    {{#each TOGGLE_ICON_COLORS as |color|}}
       <ShwTextBody>{{capitalize color}}</ShwTextBody>
 
       {{#each TOGGLE_STATES as |state|}}
@@ -451,6 +468,32 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
                     @imageSrc="/assets/images/avatar.png"
                     @color={{color}}
                     disabled
+                  />
+                </SF.Item>
+              {{else if (eq state "open")}}
+                <SF.Item>
+                  <HdsDropdownToggleIcon
+                    @icon="more-horizontal"
+                    @text="overflow menu"
+                    @hasChevron={{false}}
+                    @color={{color}}
+                    @isOpen={{true}}
+                  />
+                </SF.Item>
+                <SF.Item>
+                  <HdsDropdownToggleIcon
+                    @icon="user"
+                    @text="user menu"
+                    @color={{color}}
+                    @isOpen={{true}}
+                  />
+                </SF.Item>
+                <SF.Item>
+                  <HdsDropdownToggleIcon
+                    @text={{state}}
+                    @imageSrc="/assets/images/avatar.png"
+                    @color={{color}}
+                    @isOpen={{true}}
                   />
                 </SF.Item>
               {{else}}

--- a/showcase/app/components/page-carbonization/components/dropdown/index.gts
+++ b/showcase/app/components/page-carbonization/components/dropdown/index.gts
@@ -50,9 +50,14 @@ const ORGANIZATIONS = ['Organization A', 'Organization B', 'Organization C'];
 import { COLORS as ITEM_INTERACTIVE_COLORS } from '@hashicorp/design-system-components/components/hds/dropdown/list-item/interactive';
 
 import {
-  COLORS,
-  SIZES,
+  COLORS as BUTTON_COLORS,
+  SIZES as BUTTON_SIZES,
 } from '@hashicorp/design-system-components/components/hds/dropdown/toggle/button';
+
+import {
+  COLORS as ICON_COLORS,
+  SIZES as ICON_SIZES,
+} from '@hashicorp/design-system-components/components/hds/dropdown/toggle/icon';
 
 const CARBON_SIZES = ['xs', 'sm', 'md'] as const;
 
@@ -198,9 +203,9 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid @layout="side-by-side">
       <:theming>
-        {{#each COLORS as |color|}}
+        {{#each BUTTON_COLORS as |color|}}
           <ShwFlex @direction="column" as |SF|>
-            {{#each SIZES as |size|}}
+            {{#each BUTTON_SIZES as |size|}}
               <SF.Item>
                 <HdsDropdownToggleButton
                   @color={{color}}
@@ -233,9 +238,9 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid @layout="side-by-side">
       <:theming>
-        {{#each COLORS as |color|}}
+        {{#each BUTTON_COLORS as |color|}}
           <ShwFlex @direction="column" as |SF|>
-            {{#each SIZES as |size|}}
+            {{#each BUTTON_SIZES as |size|}}
               <SF.Item>
                 <ShwFlex @direction="column" as |SF|>
                   <SF.Item>
@@ -273,7 +278,7 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid @layout="side-by-side">
       <:theming>
-        {{#each COLORS as |color|}}
+        {{#each BUTTON_COLORS as |color|}}
           <ShwFlex @direction="column" as |SF|>
             <SF.Item>
               <ShwOutliner {{style width="300px"}}>
@@ -320,36 +325,42 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwCarbonizationComparisonGrid @layout="side-by-side">
       <:theming>
-        <ShwFlex as |SF|>
-          {{#each SIZES as |size|}}
-            <SF.Item>
-              <HdsDropdownToggleIcon
-                @icon="user"
-                @text="user menu"
-                @size={{size}}
-              />
-            </SF.Item>
-          {{/each}}
-        </ShwFlex>
+        {{#each ICON_COLORS as |color|}}
+          <ShwFlex as |SF|>
+            {{#each ICON_SIZES as |size|}}
+              <SF.Item>
+                <HdsDropdownToggleIcon
+                  @icon="user"
+                  @text="user menu"
+                  @size={{size}}
+                  @color={{color}}
+                />
+              </SF.Item>
+            {{/each}}
+          </ShwFlex>
+        {{/each}}
 
-        <ShwFlex as |SF|>
-          {{#each SIZES as |size|}}
-            <SF.Item>
-              <HdsDropdownToggleIcon
-                @imageSrc="/assets/images/avatar.png"
-                @text="user menu"
-                @size={{size}}
-              />
-            </SF.Item>
-          {{/each}}
-
-          <SF.Item>
-            <HdsDropdownToggleIcon
-              @imageSrc="/assets/images/avatar-broken.png"
-              @text="user menu"
-            />
-          </SF.Item>
-        </ShwFlex>
+        {{#each ICON_COLORS as |color|}}
+          <ShwFlex as |SF|>
+            {{#each ICON_SIZES as |size|}}
+              <SF.Item>
+                <HdsDropdownToggleIcon
+                  @imageSrc="/assets/images/avatar.png"
+                  @text="user menu"
+                  @size={{size}}
+                  @color={{color}}
+                />
+              </SF.Item>
+              <SF.Item>
+                <HdsDropdownToggleIcon
+                  @imageSrc="/assets/images/avatar-broken.png"
+                  @text="user menu"
+                  @color={{color}}
+                />
+              </SF.Item>
+            {{/each}}
+          </ShwFlex>
+        {{/each}}
       </:theming>
       <:reference as |R|>
         <R.NoEquivalent @isCompact={{true}} />
@@ -361,7 +372,7 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
     <ShwTextH3>Toggle states</ShwTextH3>
 
     <ShwTextH4>Text Toggle states</ShwTextH4>
-    {{#each COLORS as |color|}}
+    {{#each BUTTON_COLORS as |color|}}
       <ShwTextBody>{{capitalize color}}</ShwTextBody>
       {{#each TOGGLE_STATES as |state|}}
         <ShwCarbonizationComparisonGrid
@@ -405,67 +416,77 @@ const DropdownCarbonizationIndex: TemplateOnlyComponent = <template>
 
     <ShwTextH4>Icon/Image Toggle states</ShwTextH4>
 
-    {{#each TOGGLE_STATES as |state|}}
-      <ShwCarbonizationComparisonGrid
-        @label="{{capitalize state}}"
-        @hideThemeLabels={{true}}
-        @hideCarbonLabels={{true}}
-      >
-        <:theming>
-          <ShwFlex @gap="0.75rem" as |SF|>
-            {{#if (eq state "disabled")}}
-              <SF.Item>
-                <HdsDropdownToggleIcon
-                  @icon="more-horizontal"
-                  @text="overflow menu"
-                  @hasChevron={{false}}
-                  disabled
-                />
-              </SF.Item>
-              <SF.Item>
-                <HdsDropdownToggleIcon
-                  @icon="user"
-                  @text="user menu"
-                  disabled
-                />
-              </SF.Item>
-              <SF.Item>
-                <HdsDropdownToggleIcon
-                  @text={{state}}
-                  @imageSrc="/assets/images/avatar.png"
-                  disabled
-                />
-              </SF.Item>
-            {{else}}
-              <SF.Item>
-                <HdsDropdownToggleIcon
-                  @icon="more-horizontal"
-                  @text="overflow menu"
-                  @hasChevron={{false}}
-                  mock-state-value={{state}}
-                />
-              </SF.Item>
-              <SF.Item>
-                <HdsDropdownToggleIcon
-                  @icon="user"
-                  @text="user menu"
-                  mock-state-value={{state}}
-                />
-              </SF.Item>
-              <SF.Item>
-                <HdsDropdownToggleIcon
-                  @text={{state}}
-                  @imageSrc="/assets/images/avatar.png"
-                  mock-state-value={{state}}
-                />
-              </SF.Item>
-            {{/if}}
-          </ShwFlex>
-        </:theming>
-        <:reference>
-          <pre>TODO: static image here</pre>
-        </:reference>
-      </ShwCarbonizationComparisonGrid>
+    {{#each ICON_COLORS as |color|}}
+      <ShwTextBody>{{capitalize color}}</ShwTextBody>
+
+      {{#each TOGGLE_STATES as |state|}}
+        <ShwCarbonizationComparisonGrid
+          @label="{{capitalize state}}"
+          @hideThemeLabels={{true}}
+          @hideCarbonLabels={{true}}
+        >
+          <:theming>
+            <ShwFlex @gap="0.75rem" as |SF|>
+              {{#if (eq state "disabled")}}
+                <SF.Item>
+                  <HdsDropdownToggleIcon
+                    @icon="more-horizontal"
+                    @text="overflow menu"
+                    @hasChevron={{false}}
+                    @color={{color}}
+                    disabled
+                  />
+                </SF.Item>
+                <SF.Item>
+                  <HdsDropdownToggleIcon
+                    @icon="user"
+                    @text="user menu"
+                    @color={{color}}
+                    disabled
+                  />
+                </SF.Item>
+                <SF.Item>
+                  <HdsDropdownToggleIcon
+                    @text={{state}}
+                    @imageSrc="/assets/images/avatar.png"
+                    @color={{color}}
+                    disabled
+                  />
+                </SF.Item>
+              {{else}}
+                <SF.Item>
+                  <HdsDropdownToggleIcon
+                    @icon="more-horizontal"
+                    @text="overflow menu"
+                    @hasChevron={{false}}
+                    @color={{color}}
+                    mock-state-value={{state}}
+                  />
+                </SF.Item>
+                <SF.Item>
+                  <HdsDropdownToggleIcon
+                    @icon="user"
+                    @text="user menu"
+                    @color={{color}}
+                    mock-state-value={{state}}
+                  />
+                </SF.Item>
+                <SF.Item>
+                  <HdsDropdownToggleIcon
+                    @text={{state}}
+                    @imageSrc="/assets/images/avatar.png"
+                    @color={{color}}
+                    mock-state-value={{state}}
+                  />
+                </SF.Item>
+              {{/if}}
+            </ShwFlex>
+          </:theming>
+          <:reference>
+            <pre>TODO: static image here</pre>
+          </:reference>
+        </ShwCarbonizationComparisonGrid>
+      {{/each}}
     {{/each}}
 
     <ShwDivider @level={{2}} />

--- a/showcase/app/components/page-components/dropdown/sub-sections/toggles.gts
+++ b/showcase/app/components/page-components/dropdown/sub-sections/toggles.gts
@@ -14,15 +14,21 @@ import ShwGrid from 'showcase/components/shw/grid';
 import ShwOutliner from 'showcase/components/shw/outliner';
 import ShwTextH2 from 'showcase/components/shw/text/h2';
 import ShwTextH3 from 'showcase/components/shw/text/h3';
+import ShwTextH4 from 'showcase/components/shw/text/h4';
 
 import {
   HdsDropdownToggleButton,
   HdsDropdownToggleIcon,
 } from '@hashicorp/design-system-components/components';
 import {
-  COLORS,
-  SIZES,
+  COLORS as BUTTON_COLORS,
+  SIZES as BUTTON_SIZES,
 } from '@hashicorp/design-system-components/components/hds/dropdown/toggle/button';
+
+import {
+  COLORS as ICON_COLORS,
+  SIZES as ICON_SIZES,
+} from '@hashicorp/design-system-components/components/hds/dropdown/toggle/icon';
 
 // these are used only for presentation purpose in the showcase
 const STATES = ['default', 'hover', 'active', 'focus', 'disabled'];
@@ -30,9 +36,9 @@ const STATES = ['default', 'hover', 'active', 'focus', 'disabled'];
 const SubSectionToggles: TemplateOnlyComponent = <template>
   <ShwTextH2>Toggles</ShwTextH2>
 
-  {{#each COLORS as |color|}}
+  {{#each BUTTON_COLORS as |color|}}
     <ShwFlex as |SF|>
-      {{#each SIZES as |size|}}
+      {{#each BUTTON_SIZES as |size|}}
         <SF.Item @label="{{capitalize color}} {{size}}">
           <HdsDropdownToggleButton
             @color={{color}}
@@ -55,9 +61,9 @@ const SubSectionToggles: TemplateOnlyComponent = <template>
 
   <ShwTextH3>With icon</ShwTextH3>
 
-  {{#each COLORS as |color|}}
+  {{#each BUTTON_COLORS as |color|}}
     <ShwFlex as |SF|>
-      {{#each SIZES as |size|}}
+      {{#each BUTTON_SIZES as |size|}}
         <SF.Item @label="{{capitalize color}} {{size}}">
           <HdsDropdownToggleButton
             @icon="hexagon"
@@ -82,9 +88,9 @@ const SubSectionToggles: TemplateOnlyComponent = <template>
 
   <ShwTextH3>With count</ShwTextH3>
 
-  {{#each COLORS as |color|}}
+  {{#each BUTTON_COLORS as |color|}}
     <ShwFlex as |SF|>
-      {{#each SIZES as |size|}}
+      {{#each BUTTON_SIZES as |size|}}
         <SF.Item @label="{{capitalize color}} {{size}}">
           <HdsDropdownToggleButton
             @color={{color}}
@@ -109,9 +115,9 @@ const SubSectionToggles: TemplateOnlyComponent = <template>
 
   <ShwTextH3>With badge</ShwTextH3>
 
-  {{#each COLORS as |color|}}
+  {{#each BUTTON_COLORS as |color|}}
     <ShwFlex as |SF|>
-      {{#each SIZES as |size|}}
+      {{#each BUTTON_SIZES as |size|}}
         <SF.Item @label="{{capitalize color}} {{size}}">
           <HdsDropdownToggleButton
             @color={{color}}
@@ -140,48 +146,84 @@ const SubSectionToggles: TemplateOnlyComponent = <template>
 
   <ShwTextH3>Icon</ShwTextH3>
 
-  <ShwFlex as |SF|>
-    {{#each SIZES as |size|}}
-      <SF.Item @label="With icon + chevron, {{size}}">
-        <HdsDropdownToggleIcon @icon="user" @text="user menu" @size={{size}} />
-      </SF.Item>
-    {{/each}}
-  </ShwFlex>
+  <ShwTextH4>With icon + chevron</ShwTextH4>
 
-  <ShwFlex as |SF|>
-    {{#each SIZES as |size|}}
-      <SF.Item @label="With image (avatar), {{size}}">
-        <HdsDropdownToggleIcon
-          @imageSrc="/assets/images/avatar.png"
-          @text="user menu"
-          @size={{size}}
-        />
-      </SF.Item>
-    {{/each}}
-    <SF.Item @label="With broken image (fallback to icon)">
-      <HdsDropdownToggleIcon
-        @imageSrc="/assets/images/avatar-broken.png"
-        @text="user menu"
-      />
-    </SF.Item>
-  </ShwFlex>
+  {{#each ICON_COLORS as |color|}}
+    <ShwFlex as |SF|>
+      {{#each ICON_SIZES as |size|}}
+        <SF.Item @label="{{capitalize color}}, {{size}}">
+          <HdsDropdownToggleIcon
+            @icon="user"
+            @text="user menu"
+            @color={{color}}
+            @size={{size}}
+          />
+        </SF.Item>
+      {{/each}}
+    </ShwFlex>
+  {{/each}}
 
-  <ShwFlex as |SF|>
-    {{#each SIZES as |size|}}
-      <SF.Item @label="Icon only, {{size}}">
-        <HdsDropdownToggleIcon
-          @icon="more-horizontal"
-          @hasChevron={{false}}
-          @text="overflow menu"
-          @size={{size}}
-        />
-      </SF.Item>
-    {{/each}}
-  </ShwFlex>
+  <ShwTextH4>With image (avatar)</ShwTextH4>
+
+  {{#each ICON_COLORS as |color|}}
+    <ShwFlex as |SF|>
+      {{#each ICON_SIZES as |size|}}
+        <SF.Item @label="{{capitalize color}}, {{size}}">
+          <HdsDropdownToggleIcon
+            @imageSrc="/assets/images/avatar.png"
+            @text="user menu"
+            @color={{color}}
+            @size={{size}}
+          />
+        </SF.Item>
+      {{/each}}
+    </ShwFlex>
+  {{/each}}
+
+  <ShwTextH4>With broken image (fallback to icon)</ShwTextH4>
+
+  {{#each ICON_COLORS as |color|}}
+    <ShwFlex as |SF|>
+      {{#each ICON_SIZES as |size|}}
+        <SF.Item
+          @label="{{capitalize
+            color
+          }}, {{size}}, With broken image (fallback to icon)"
+        >
+          <HdsDropdownToggleIcon
+            @imageSrc="/assets/images/avatar-broken.png"
+            @text="user menu"
+            @color={{color}}
+            @size={{size}}
+          />
+        </SF.Item>
+      {{/each}}
+    </ShwFlex>
+  {{/each}}
+
+  <ShwTextH4>Icon only</ShwTextH4>
+
+  {{#each ICON_COLORS as |color|}}
+    <ShwFlex as |SF|>
+      {{#each ICON_SIZES as |size|}}
+        <SF.Item @label="{{capitalize color}}, {{size}}">
+          <HdsDropdownToggleIcon
+            @icon="more-horizontal"
+            @hasChevron={{false}}
+            @text="overflow menu"
+            @color={{color}}
+            @size={{size}}
+          />
+        </SF.Item>
+      {{/each}}
+    </ShwFlex>
+  {{/each}}
 
   <ShwDivider @level={{2}} />
 
   <ShwTextH3>States</ShwTextH3>
+
+  <ShwTextH4>ToggleButton</ShwTextH4>
 
   <ShwGrid @columns={{6}} class="shw-component-dropdown-states-matrix" as |SG|>
 
@@ -196,7 +238,7 @@ const SubSectionToggles: TemplateOnlyComponent = <template>
       <span class="shw-label">Open</span>
     </SG.Item>
 
-    {{#each COLORS as |color|}}
+    {{#each BUTTON_COLORS as |color|}}
       {{#each STATES as |state|}}
         <SG.Item @label="{{capitalize color}}">
           {{#if (eq state "disabled")}}
@@ -306,55 +348,78 @@ const SubSectionToggles: TemplateOnlyComponent = <template>
         />
       </SG.Item>
     {{/each}}
+  </ShwGrid>
+
+  <ShwTextH4>ToggleIcon</ShwTextH4>
+
+  <ShwGrid @columns={{6}} class="shw-component-dropdown-states-matrix" as |SG|>
+
+    {{! Notice: we use a non-standard way to showcase the states to reduce the (visual) complexity of this matrix }}
 
     {{#each STATES as |state|}}
+      <SG.Item>
+        <span class="shw-label">{{capitalize state}}</span>
+      </SG.Item>
+    {{/each}}
+    <SG.Item>
+      <span class="shw-label">Open</span>
+    </SG.Item>
+
+    {{#each ICON_COLORS as |color|}}
+      {{#each STATES as |state|}}
+        <SG.Item @label="Icon">
+          <HdsDropdownToggleIcon
+            @icon="more-horizontal"
+            @text="overflow menu"
+            @hasChevron={{false}}
+            @color={{color}}
+            mock-state-value={{state}}
+          />
+        </SG.Item>
+      {{/each}}
       <SG.Item @label="Icon">
         <HdsDropdownToggleIcon
           @icon="more-horizontal"
           @text="overflow menu"
           @hasChevron={{false}}
-          mock-state-value={{state}}
+          @isOpen={{true}}
+          @color={{color}}
         />
       </SG.Item>
-    {{/each}}
-    <SG.Item @label="Icon">
-      <HdsDropdownToggleIcon
-        @icon="more-horizontal"
-        @text="overflow menu"
-        @hasChevron={{false}}
-        @isOpen={{true}}
-      />
-    </SG.Item>
 
-    {{#each STATES as |state|}}
+      {{#each STATES as |state|}}
+        <SG.Item @label="Icon+chevron">
+          <HdsDropdownToggleIcon
+            @icon="user"
+            @text={{state}}
+            @color={{color}}
+            mock-state-value={{state}}
+          />
+        </SG.Item>
+      {{/each}}
       <SG.Item @label="Icon+chevron">
-        <HdsDropdownToggleIcon
-          @icon="user"
-          @text={{state}}
-          mock-state-value={{state}}
-        />
+        <HdsDropdownToggleIcon @icon="user" @text="open" @isOpen={{true}} />
       </SG.Item>
-    {{/each}}
-    <SG.Item @label="Icon+chevron">
-      <HdsDropdownToggleIcon @icon="user" @text="open" @isOpen={{true}} />
-    </SG.Item>
 
-    {{#each STATES as |state|}}
+      {{#each STATES as |state|}}
+        <SG.Item @label="Avatar+chevron">
+          <HdsDropdownToggleIcon
+            @text={{state}}
+            @imageSrc="/assets/images/avatar.png"
+            @color={{color}}
+            mock-state-value={{state}}
+          />
+        </SG.Item>
+      {{/each}}
       <SG.Item @label="Avatar+chevron">
         <HdsDropdownToggleIcon
-          @text={{state}}
+          @text="open"
+          @isOpen={{true}}
           @imageSrc="/assets/images/avatar.png"
-          mock-state-value={{state}}
+          @color={{color}}
         />
       </SG.Item>
     {{/each}}
-    <SG.Item @label="Avatar+chevron">
-      <HdsDropdownToggleIcon
-        @text="open"
-        @isOpen={{true}}
-        @imageSrc="/assets/images/avatar.png"
-      />
-    </SG.Item>
   </ShwGrid>
 
   <ShwDivider />

--- a/showcase/app/components/page-components/dropdown/sub-sections/toggles.gts
+++ b/showcase/app/components/page-components/dropdown/sub-sections/toggles.gts
@@ -398,7 +398,12 @@ const SubSectionToggles: TemplateOnlyComponent = <template>
         </SG.Item>
       {{/each}}
       <SG.Item @label="Icon+chevron">
-        <HdsDropdownToggleIcon @icon="user" @text="open" @isOpen={{true}} />
+        <HdsDropdownToggleIcon
+          @icon="user"
+          @text="open"
+          @color={{color}}
+          @isOpen={{true}}
+        />
       </SG.Item>
 
       {{#each STATES as |state|}}

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -2470,7 +2470,7 @@
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-badge {
@@ -2633,7 +2633,7 @@
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-badge-count {
@@ -4581,9 +4581,6 @@ button.hds-button[href]::after {
   align-items: center;
   justify-content: center;
   padding: var(--hds-dropdown-toggle-icon-padding);
-  color: var(--hds-button-foreground-color-secondary-default);
-  background-color: var(--hds-button-surface-color-secondary-default);
-  border: 1px solid var(--hds-button-border-color-secondary-default);
   border-radius: var(--hds-button-border-radius);
   isolation: isolate;
 }
@@ -4629,6 +4626,16 @@ button.hds-button[href]::after {
   border-color: var(--hds-button-border-color-disabled);
   box-shadow: none;
   cursor: not-allowed;
+}
+.hds-dropdown-toggle-icon.hds-dropdown-toggle-icon--color-secondary {
+  color: var(--hds-button-foreground-color-secondary-default);
+  background-color: var(--hds-button-surface-color-secondary-default);
+  border: 1px solid var(--hds-button-border-color-secondary-default);
+}
+.hds-dropdown-toggle-icon.hds-dropdown-toggle-icon--color-secondary-muted {
+  color: var(--hds-button-foreground-color-secondary-muted-default);
+  background-color: var(--hds-button-surface-color-secondary-muted-default);
+  border: 1px solid var(--hds-button-border-color-secondary-muted-default);
 }
 
 .hds-dropdown-toggle-icon__wrapper {
@@ -5801,7 +5808,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-label {
@@ -5819,7 +5826,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-helper-text {
@@ -5836,7 +5843,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-character-count {
@@ -5851,7 +5858,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-error {
@@ -6037,7 +6044,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-legend {
@@ -6100,7 +6107,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-indicator--optional {
@@ -7415,7 +7422,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-icon-tile {
@@ -8032,7 +8039,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-link-standalone {
@@ -8835,7 +8842,7 @@ button.hds-button[href]::after {
 
 /* clean-css ignore:end */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-segmented-group {
@@ -10210,7 +10217,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-tag {

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -4584,16 +4584,29 @@ button.hds-button[href]::after {
   border-radius: var(--hds-button-border-radius);
   isolation: isolate;
 }
-.hds-dropdown-toggle-icon:hover, .hds-dropdown-toggle-icon.mock-hover {
+.hds-dropdown-toggle-icon:disabled, .hds-dropdown-toggle-icon.mock-disabled {
+  color: var(--hds-button-foreground-color-disabled);
+  background-color: var(--hds-button-surface-color-disabled);
+  border-color: var(--hds-button-border-color-disabled);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.hds-dropdown-toggle-icon--color-secondary {
+  color: var(--hds-button-foreground-color-secondary-default);
+  background-color: var(--hds-button-surface-color-secondary-default);
+  border: 1px solid var(--hds-button-border-color-secondary-default);
+}
+.hds-dropdown-toggle-icon--color-secondary:hover, .hds-dropdown-toggle-icon--color-secondary.mock-hover {
   color: var(--hds-button-foreground-color-secondary-hover);
   background-color: var(--hds-button-surface-color-secondary-hover);
   border-color: var(--hds-button-border-color-secondary-hover);
   cursor: pointer;
 }
-.hds-dropdown-toggle-icon:focus-visible, .hds-dropdown-toggle-icon.mock-focus {
+.hds-dropdown-toggle-icon--color-secondary:focus-visible, .hds-dropdown-toggle-icon--color-secondary.mock-focus {
   outline: none;
 }
-.hds-dropdown-toggle-icon:focus-visible::before, .hds-dropdown-toggle-icon.mock-focus::before {
+.hds-dropdown-toggle-icon--color-secondary:focus-visible::before, .hds-dropdown-toggle-icon--color-secondary.mock-focus::before {
   position: absolute;
   inset: -1px;
   z-index: 1;
@@ -4604,38 +4617,63 @@ button.hds-button[href]::after {
   content: "";
   pointer-events: auto;
 }
-.hds-theme-light .hds-dropdown-toggle-icon:focus-visible::before, .hds-theme-light .hds-dropdown-toggle-icon.mock-focus::before,
-.hds-theme-dark .hds-dropdown-toggle-icon:focus-visible::before, .hds-theme-dark .hds-dropdown-toggle-icon.mock-focus::before,
-.hds-theme-system .hds-dropdown-toggle-icon:focus-visible::before, .hds-theme-system .hds-dropdown-toggle-icon.mock-focus::before {
+.hds-theme-light .hds-dropdown-toggle-icon--color-secondary:focus-visible::before, .hds-theme-light .hds-dropdown-toggle-icon--color-secondary.mock-focus::before,
+.hds-theme-dark .hds-dropdown-toggle-icon--color-secondary:focus-visible::before, .hds-theme-dark .hds-dropdown-toggle-icon--color-secondary.mock-focus::before,
+.hds-theme-system .hds-dropdown-toggle-icon--color-secondary:focus-visible::before, .hds-theme-system .hds-dropdown-toggle-icon--color-secondary.mock-focus::before {
   inset: 1px;
   border-width: 1px;
 }
 
-.hds-dropdown-toggle-icon:focus-visible, .hds-dropdown-toggle-icon.mock-focus {
+.hds-dropdown-toggle-icon--color-secondary:focus-visible, .hds-dropdown-toggle-icon--color-secondary.mock-focus {
   color: var(--hds-button-foreground-color-secondary-focus);
   background-color: var(--hds-button-surface-color-secondary-focus);
 }
-.hds-dropdown-toggle-icon:active, .hds-dropdown-toggle-icon.mock-active {
+.hds-dropdown-toggle-icon--color-secondary:active, .hds-dropdown-toggle-icon--color-secondary.mock-active {
   color: var(--hds-button-foreground-color-secondary-active);
   background-color: var(--hds-button-surface-color-secondary-active);
   border-color: var(--hds-button-border-color-secondary-active);
 }
-.hds-dropdown-toggle-icon:disabled, .hds-dropdown-toggle-icon.mock-disabled {
-  color: var(--hds-button-foreground-color-disabled);
-  background-color: var(--hds-button-surface-color-disabled);
-  border-color: var(--hds-button-border-color-disabled);
-  box-shadow: none;
-  cursor: not-allowed;
-}
-.hds-dropdown-toggle-icon.hds-dropdown-toggle-icon--color-secondary {
-  color: var(--hds-button-foreground-color-secondary-default);
-  background-color: var(--hds-button-surface-color-secondary-default);
-  border: 1px solid var(--hds-button-border-color-secondary-default);
-}
-.hds-dropdown-toggle-icon.hds-dropdown-toggle-icon--color-secondary-muted {
+
+.hds-dropdown-toggle-icon--color-secondary-muted {
   color: var(--hds-button-foreground-color-secondary-muted-default);
   background-color: var(--hds-button-surface-color-secondary-muted-default);
   border: 1px solid var(--hds-button-border-color-secondary-muted-default);
+}
+.hds-dropdown-toggle-icon--color-secondary-muted:hover, .hds-dropdown-toggle-icon--color-secondary-muted.mock-hover {
+  color: var(--hds-button-foreground-color-secondary-muted-hover);
+  background-color: var(--hds-button-surface-color-secondary-muted-hover);
+  border-color: var(--hds-button-border-color-secondary-muted-hover);
+  cursor: pointer;
+}
+.hds-dropdown-toggle-icon--color-secondary-muted:focus-visible, .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus {
+  outline: none;
+}
+.hds-dropdown-toggle-icon--color-secondary-muted:focus-visible::before, .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus::before {
+  position: absolute;
+  inset: -1px;
+  z-index: 1;
+  border: var(--hds-focus-ring-width-internal) solid var(--hds-focus-color-action-internal);
+  border-radius: inherit;
+  outline: var(--hds-focus-ring-width-external) solid var(--hds-focus-color-action-external);
+  outline-offset: 0;
+  content: "";
+  pointer-events: auto;
+}
+.hds-theme-light .hds-dropdown-toggle-icon--color-secondary-muted:focus-visible::before, .hds-theme-light .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus::before,
+.hds-theme-dark .hds-dropdown-toggle-icon--color-secondary-muted:focus-visible::before, .hds-theme-dark .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus::before,
+.hds-theme-system .hds-dropdown-toggle-icon--color-secondary-muted:focus-visible::before, .hds-theme-system .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus::before {
+  inset: 1px;
+  border-width: 1px;
+}
+
+.hds-dropdown-toggle-icon--color-secondary-muted:focus-visible, .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus {
+  color: var(--hds-button-foreground-color-secondary-muted-focus);
+  background-color: var(--hds-button-surface-color-secondary-muted-focus);
+}
+.hds-dropdown-toggle-icon--color-secondary-muted:active, .hds-dropdown-toggle-icon--color-secondary-muted.mock-active {
+  color: var(--hds-button-foreground-color-secondary-muted-active);
+  background-color: var(--hds-button-surface-color-secondary-muted-active);
+  border-color: var(--hds-button-border-color-secondary-muted-active);
 }
 
 .hds-dropdown-toggle-icon__wrapper {

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -4584,7 +4584,7 @@ button.hds-button[href]::after {
   border-radius: var(--hds-button-border-radius);
   isolation: isolate;
 }
-.hds-dropdown-toggle-icon:disabled, .hds-dropdown-toggle-icon.mock-disabled {
+.hds-dropdown-toggle-icon:disabled, .hds-dropdown-toggle-icon.mock-disabled, .hds-dropdown-toggle-icon:disabled:hover, .hds-dropdown-toggle-icon.mock-disabled:hover, .hds-dropdown-toggle-icon:disabled:focus, .hds-dropdown-toggle-icon.mock-disabled:focus {
   color: var(--hds-button-foreground-color-disabled);
   background-color: var(--hds-button-surface-color-disabled);
   border-color: var(--hds-button-border-color-disabled);

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -3333,7 +3333,7 @@
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-badge {
@@ -3496,7 +3496,7 @@
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-badge-count {
@@ -5444,9 +5444,6 @@ button.hds-button[href]::after {
   align-items: center;
   justify-content: center;
   padding: var(--hds-dropdown-toggle-icon-padding);
-  color: var(--hds-button-foreground-color-secondary-default);
-  background-color: var(--hds-button-surface-color-secondary-default);
-  border: 1px solid var(--hds-button-border-color-secondary-default);
   border-radius: var(--hds-button-border-radius);
   isolation: isolate;
 }
@@ -5492,6 +5489,16 @@ button.hds-button[href]::after {
   border-color: var(--hds-button-border-color-disabled);
   box-shadow: none;
   cursor: not-allowed;
+}
+.hds-dropdown-toggle-icon.hds-dropdown-toggle-icon--color-secondary {
+  color: var(--hds-button-foreground-color-secondary-default);
+  background-color: var(--hds-button-surface-color-secondary-default);
+  border: 1px solid var(--hds-button-border-color-secondary-default);
+}
+.hds-dropdown-toggle-icon.hds-dropdown-toggle-icon--color-secondary-muted {
+  color: var(--hds-button-foreground-color-secondary-muted-default);
+  background-color: var(--hds-button-surface-color-secondary-muted-default);
+  border: 1px solid var(--hds-button-border-color-secondary-muted-default);
 }
 
 .hds-dropdown-toggle-icon__wrapper {
@@ -6664,7 +6671,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-label {
@@ -6682,7 +6689,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-helper-text {
@@ -6699,7 +6706,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-character-count {
@@ -6714,7 +6721,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-error {
@@ -6900,7 +6907,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-legend {
@@ -6963,7 +6970,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-indicator--optional {
@@ -8278,7 +8285,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-icon-tile {
@@ -8895,7 +8902,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-link-standalone {
@@ -9698,7 +9705,7 @@ button.hds-button[href]::after {
 
 /* clean-css ignore:end */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-segmented-group {
@@ -11073,7 +11080,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-tag {

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -5447,16 +5447,29 @@ button.hds-button[href]::after {
   border-radius: var(--hds-button-border-radius);
   isolation: isolate;
 }
-.hds-dropdown-toggle-icon:hover, .hds-dropdown-toggle-icon.mock-hover {
+.hds-dropdown-toggle-icon:disabled, .hds-dropdown-toggle-icon.mock-disabled {
+  color: var(--hds-button-foreground-color-disabled);
+  background-color: var(--hds-button-surface-color-disabled);
+  border-color: var(--hds-button-border-color-disabled);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.hds-dropdown-toggle-icon--color-secondary {
+  color: var(--hds-button-foreground-color-secondary-default);
+  background-color: var(--hds-button-surface-color-secondary-default);
+  border: 1px solid var(--hds-button-border-color-secondary-default);
+}
+.hds-dropdown-toggle-icon--color-secondary:hover, .hds-dropdown-toggle-icon--color-secondary.mock-hover {
   color: var(--hds-button-foreground-color-secondary-hover);
   background-color: var(--hds-button-surface-color-secondary-hover);
   border-color: var(--hds-button-border-color-secondary-hover);
   cursor: pointer;
 }
-.hds-dropdown-toggle-icon:focus-visible, .hds-dropdown-toggle-icon.mock-focus {
+.hds-dropdown-toggle-icon--color-secondary:focus-visible, .hds-dropdown-toggle-icon--color-secondary.mock-focus {
   outline: none;
 }
-.hds-dropdown-toggle-icon:focus-visible::before, .hds-dropdown-toggle-icon.mock-focus::before {
+.hds-dropdown-toggle-icon--color-secondary:focus-visible::before, .hds-dropdown-toggle-icon--color-secondary.mock-focus::before {
   position: absolute;
   inset: -1px;
   z-index: 1;
@@ -5467,38 +5480,63 @@ button.hds-button[href]::after {
   content: "";
   pointer-events: auto;
 }
-.hds-theme-light .hds-dropdown-toggle-icon:focus-visible::before, .hds-theme-light .hds-dropdown-toggle-icon.mock-focus::before,
-.hds-theme-dark .hds-dropdown-toggle-icon:focus-visible::before, .hds-theme-dark .hds-dropdown-toggle-icon.mock-focus::before,
-.hds-theme-system .hds-dropdown-toggle-icon:focus-visible::before, .hds-theme-system .hds-dropdown-toggle-icon.mock-focus::before {
+.hds-theme-light .hds-dropdown-toggle-icon--color-secondary:focus-visible::before, .hds-theme-light .hds-dropdown-toggle-icon--color-secondary.mock-focus::before,
+.hds-theme-dark .hds-dropdown-toggle-icon--color-secondary:focus-visible::before, .hds-theme-dark .hds-dropdown-toggle-icon--color-secondary.mock-focus::before,
+.hds-theme-system .hds-dropdown-toggle-icon--color-secondary:focus-visible::before, .hds-theme-system .hds-dropdown-toggle-icon--color-secondary.mock-focus::before {
   inset: 1px;
   border-width: 1px;
 }
 
-.hds-dropdown-toggle-icon:focus-visible, .hds-dropdown-toggle-icon.mock-focus {
+.hds-dropdown-toggle-icon--color-secondary:focus-visible, .hds-dropdown-toggle-icon--color-secondary.mock-focus {
   color: var(--hds-button-foreground-color-secondary-focus);
   background-color: var(--hds-button-surface-color-secondary-focus);
 }
-.hds-dropdown-toggle-icon:active, .hds-dropdown-toggle-icon.mock-active {
+.hds-dropdown-toggle-icon--color-secondary:active, .hds-dropdown-toggle-icon--color-secondary.mock-active {
   color: var(--hds-button-foreground-color-secondary-active);
   background-color: var(--hds-button-surface-color-secondary-active);
   border-color: var(--hds-button-border-color-secondary-active);
 }
-.hds-dropdown-toggle-icon:disabled, .hds-dropdown-toggle-icon.mock-disabled {
-  color: var(--hds-button-foreground-color-disabled);
-  background-color: var(--hds-button-surface-color-disabled);
-  border-color: var(--hds-button-border-color-disabled);
-  box-shadow: none;
-  cursor: not-allowed;
-}
-.hds-dropdown-toggle-icon.hds-dropdown-toggle-icon--color-secondary {
-  color: var(--hds-button-foreground-color-secondary-default);
-  background-color: var(--hds-button-surface-color-secondary-default);
-  border: 1px solid var(--hds-button-border-color-secondary-default);
-}
-.hds-dropdown-toggle-icon.hds-dropdown-toggle-icon--color-secondary-muted {
+
+.hds-dropdown-toggle-icon--color-secondary-muted {
   color: var(--hds-button-foreground-color-secondary-muted-default);
   background-color: var(--hds-button-surface-color-secondary-muted-default);
   border: 1px solid var(--hds-button-border-color-secondary-muted-default);
+}
+.hds-dropdown-toggle-icon--color-secondary-muted:hover, .hds-dropdown-toggle-icon--color-secondary-muted.mock-hover {
+  color: var(--hds-button-foreground-color-secondary-muted-hover);
+  background-color: var(--hds-button-surface-color-secondary-muted-hover);
+  border-color: var(--hds-button-border-color-secondary-muted-hover);
+  cursor: pointer;
+}
+.hds-dropdown-toggle-icon--color-secondary-muted:focus-visible, .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus {
+  outline: none;
+}
+.hds-dropdown-toggle-icon--color-secondary-muted:focus-visible::before, .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus::before {
+  position: absolute;
+  inset: -1px;
+  z-index: 1;
+  border: var(--hds-focus-ring-width-internal) solid var(--hds-focus-color-action-internal);
+  border-radius: inherit;
+  outline: var(--hds-focus-ring-width-external) solid var(--hds-focus-color-action-external);
+  outline-offset: 0;
+  content: "";
+  pointer-events: auto;
+}
+.hds-theme-light .hds-dropdown-toggle-icon--color-secondary-muted:focus-visible::before, .hds-theme-light .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus::before,
+.hds-theme-dark .hds-dropdown-toggle-icon--color-secondary-muted:focus-visible::before, .hds-theme-dark .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus::before,
+.hds-theme-system .hds-dropdown-toggle-icon--color-secondary-muted:focus-visible::before, .hds-theme-system .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus::before {
+  inset: 1px;
+  border-width: 1px;
+}
+
+.hds-dropdown-toggle-icon--color-secondary-muted:focus-visible, .hds-dropdown-toggle-icon--color-secondary-muted.mock-focus {
+  color: var(--hds-button-foreground-color-secondary-muted-focus);
+  background-color: var(--hds-button-surface-color-secondary-muted-focus);
+}
+.hds-dropdown-toggle-icon--color-secondary-muted:active, .hds-dropdown-toggle-icon--color-secondary-muted.mock-active {
+  color: var(--hds-button-foreground-color-secondary-muted-active);
+  background-color: var(--hds-button-surface-color-secondary-muted-active);
+  border-color: var(--hds-button-border-color-secondary-muted-active);
 }
 
 .hds-dropdown-toggle-icon__wrapper {

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -5447,7 +5447,7 @@ button.hds-button[href]::after {
   border-radius: var(--hds-button-border-radius);
   isolation: isolate;
 }
-.hds-dropdown-toggle-icon:disabled, .hds-dropdown-toggle-icon.mock-disabled {
+.hds-dropdown-toggle-icon:disabled, .hds-dropdown-toggle-icon.mock-disabled, .hds-dropdown-toggle-icon:disabled:hover, .hds-dropdown-toggle-icon.mock-disabled:hover, .hds-dropdown-toggle-icon:disabled:focus, .hds-dropdown-toggle-icon.mock-disabled:focus {
   color: var(--hds-button-foreground-color-disabled);
   background-color: var(--hds-button-surface-color-disabled);
   border-color: var(--hds-button-border-color-disabled);

--- a/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.gts
+++ b/showcase/tests/integration/components/hds/dropdown/toggle/icon-test.gts
@@ -115,6 +115,38 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
     assert.dom('.hds-icon.hds-icon-chevron-down').doesNotExist();
   });
 
+  // COLOR
+
+  test('it should render the secondary-color as the default if no color is declared', async function (assert) {
+    await render(
+      <template>
+        <HdsDropdownToggleIcon
+          @icon="user"
+          @text="user menu"
+          id="test-toggle-icon"
+        />
+      </template>,
+    );
+    assert
+      .dom('#test-toggle-icon')
+      .hasClass('hds-dropdown-toggle-icon--color-secondary');
+  });
+  test('it should render the correct CSS color class if the @color prop is declared', async function (assert) {
+    await render(
+      <template>
+        <HdsDropdownToggleIcon
+          @icon="user"
+          @text="user menu"
+          @color="secondary-muted"
+          id="test-toggle-icon"
+        />
+      </template>,
+    );
+    assert
+      .dom('#test-toggle-icon')
+      .hasClass('hds-dropdown-toggle-icon--color-secondary-muted');
+  });
+
   // SIZE
 
   test('it should render the medium size as the default if no size is declared', async function (assert) {
@@ -206,6 +238,7 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
       throw new Error(errorMessage);
     });
   });
+
   test('it should throw an assertion if both @icon and @imageSrc are not defined', async function (assert) {
     const errorMessage =
       '@icon or @imageSrc must be defined for "Hds::Dropdown::Toggle::Icon"';
@@ -220,6 +253,25 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
       throw new Error(errorMessage);
     });
   });
+
+  test('it should throw an assertion if an incorrect value for @color is provided', async function (assert) {
+    const errorMessage =
+      '@color for "Hds::Dropdown::Toggle::Icon" must be one of the following: secondary, secondary-muted; received: foo';
+    assert.expect(2);
+    setupOnerror(function (error) {
+      assert.strictEqual(error.message, `Assertion Failed: ${errorMessage}`);
+    });
+    await render(
+      <template>
+        {{! @glint-expect-error - assertion testing invalid value }}
+        <HdsDropdownToggleIcon @icon="user" @text="user menu" @color="foo" />
+      </template>,
+    );
+    assert.throws(function () {
+      throw new Error(errorMessage);
+    });
+  });
+
   test('it should throw an assertion if an incorrect value for @size is provided', async function (assert) {
     const errorMessage =
       '@size for "Hds::Dropdown::Toggle::Icon" must be one of the following: small, medium; received: foo';
@@ -237,6 +289,7 @@ module('Integration | Component | hds/dropdown/toggle/icon', function (hooks) {
       throw new Error(errorMessage);
     });
   });
+
   test('it should throw an assertion if an incorrect value for @icon is provided while @hasChevron is false', async function (assert) {
     const errorMessage =
       '@hasChevron for "Hds::Dropdown::Toggle::Icon" must be true unless the icon is one of the following: more-horizontal, more-vertical; received: apple';


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a new argument `@color` to the `DropdownToggleIcon` with values `secondary` and `secondary-muted`. These color variants are only for the Carbon themes. The HDS treatment is unchanged.

[Preview](https://hds-showcase-git-project-solar-phase-1toggle-i-dd85c6-hashicorp.vercel.app/carbonization/components/dropdown#toggle-with-icon-image)

### :camera_flash: Screenshots

<img width="374" height="222" alt="Screenshot 2026-07-24 at 9 32 51 AM" src="https://github.com/user-attachments/assets/99485d23-0a8a-42ae-bac0-c4cd2c285b2d" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6546](https://hashicorp.atlassian.net/browse/HDS-6546)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6546]: https://hashicorp.atlassian.net/browse/HDS-6546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ