### PR TITLE
[Project Solar / Phase 1 / Migration] Set new icons for Alert and StepIndicator

### DIFF
--- a/packages/components/src/components/hds/alert/index.gts
+++ b/packages/components/src/components/hds/alert/index.gts
@@ -67,7 +67,7 @@ export const MAPPING_COLORS_TO_CARBON_THEME_ICONS = {
   [HdsAlertColorValues.Highlight]: 'info-fill',
   [HdsAlertColorValues.Success]: 'check-circle-fill',
   [HdsAlertColorValues.Warning]: 'alert-circle-fill',
-  [HdsAlertColorValues.Critical]: 'skip', // Note: The HDS "skip" icon is used because it maps to the Carbon icon used in their critical alerts
+  [HdsAlertColorValues.Critical]: 'error-filled',
 } as const;
 
 const CONTENT_ELEMENT_SELECTOR = '.hds-alert__content';

--- a/packages/components/src/components/hds/stepper/step/indicator.gts
+++ b/packages/components/src/components/hds/stepper/step/indicator.gts
@@ -22,8 +22,8 @@ export const STATUSES: HdsStepperStatuses[] = Object.values(
 );
 
 export const MAPPING_STATUSES_TO_CARBON_THEME_ICONS = {
-  [HdsStepperStatusesValues.Incomplete]: 'circle',
-  [HdsStepperStatusesValues.Progress]: 'circle-half',
+  [HdsStepperStatusesValues.Incomplete]: 'circle-dash',
+  [HdsStepperStatusesValues.Progress]: 'incomplete-normal',
   [HdsStepperStatusesValues.Processing]: 'loading',
   [HdsStepperStatusesValues.Complete]: 'check-circle',
 } as const;

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -2470,7 +2470,7 @@
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-badge {
@@ -2633,7 +2633,7 @@
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-badge-count {
@@ -5801,7 +5801,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-label {
@@ -5819,7 +5819,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-helper-text {
@@ -5836,7 +5836,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-character-count {
@@ -5851,7 +5851,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-error {
@@ -6037,7 +6037,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-legend {
@@ -6100,7 +6100,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-indicator--optional {
@@ -7415,7 +7415,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-icon-tile {
@@ -8032,7 +8032,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-link-standalone {
@@ -8835,7 +8835,7 @@ button.hds-button[href]::after {
 
 /* clean-css ignore:end */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-segmented-group {
@@ -10210,7 +10210,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-tag {

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -3333,7 +3333,7 @@
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-badge {
@@ -3496,7 +3496,7 @@
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-badge-count {
@@ -6664,7 +6664,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-label {
@@ -6682,7 +6682,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-helper-text {
@@ -6699,7 +6699,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-character-count {
@@ -6714,7 +6714,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-error {
@@ -6900,7 +6900,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-legend {
@@ -6963,7 +6963,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-form-indicator--optional {
@@ -8278,7 +8278,7 @@ button.hds-button[href]::after {
 }
 
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-icon-tile {
@@ -8895,7 +8895,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-link-standalone {
@@ -9698,7 +9698,7 @@ button.hds-button[href]::after {
 
 /* clean-css ignore:end */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-segmented-group {
@@ -11073,7 +11073,7 @@ button.hds-button[href]::after {
  * SPDX-License-Identifier: MPL-2.0
  */
 /**
- * Copyright IBM Corp. 2021, 2025
+ * Copyright IBM Corp. 2021, 2026
  * SPDX-License-Identifier: MPL-2.0
  */
 .hds-tag {


### PR DESCRIPTION
### :pushpin: Summary

This PR adds the new `error-filled`, `circle-dash`, and `incomplete-normal` icons to the critical `Alert` and `StepperStepIndicator`.

Preview pages
- [Alert](http://hds-showcase-git-project-solar-phase-1dchyunne-0be853-hashicorp.vercel.app/components/alert)
- [StepIndicator](https://hds-showcase-git-project-solar-phase-1dchyunne-0be853-hashicorp.vercel.app/components/stepper/indicator)

Note: Carbon icons can only be seen in the main showcase pages with the Carbon theme set. They can't be seen in the Carbonization pages for these components.

### :hammer_and_wrench: Detailed description

Previously in the Carbonization of the `Alert` and `StepperStepIndicator` icons were used which did not exactly match their Carbon equivalent components. This was done because the icons used in the Carbon components did not have an equivalent in the HDS library.

After #4002 these icons are now available in the library and have been implemented here inside the Carbon themes of these components.

### :camera_flash: Screenshots

**Critical Alert - Before**
<img width="370" height="107" alt="Screenshot 2026-07-28 at 10 54 16 AM" src="https://github.com/user-attachments/assets/00551a10-a01e-4525-a6ba-b5df98d1391d" />

**Critical Alert - After**
<img width="370" height="120" alt="Screenshot 2026-07-28 at 10 53 31 AM" src="https://github.com/user-attachments/assets/eb6b542d-8835-42ad-8e6e-833cafcb4d28" />

**StepIndicator - Before**
<img width="630" height="73" alt="Screenshot 2026-07-28 at 10 54 08 AM" src="https://github.com/user-attachments/assets/8be6fba5-5959-4d4f-b40f-5d7423b621ab" />

**StepIndicator - After**
<img width="641" height="70" alt="Screenshot 2026-07-28 at 10 53 46 AM" src="https://github.com/user-attachments/assets/90962738-74cc-4774-b9b4-7b0f8fbdb2c4" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6531](https://hashicorp.atlassian.net/browse/HDS-6531)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6531]: https://hashicorp.atlassian.net/browse/HDS-6531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ