### PR TITLE
`AdvancedTable` - Improve column resize behavior

### DIFF
--- a/.changeset/mighty-pandas-repeat.md
+++ b/.changeset/mighty-pandas-repeat.md
@@ -1,0 +1,9 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+<!-- START components/table/advanced-table -->
+
+`AdvancedTable` - Updates the resize column behavior to support cascading resizes while guaranteeing that columns will never inadvertently shrink below the size of their container.
+
+<!-- END -->

--- a/.changeset/mighty-pandas-repeat.md
+++ b/.changeset/mighty-pandas-repeat.md
@@ -4,6 +4,6 @@
 
 <!-- START components/table/advanced-table -->
 
-`AdvancedTable` - Updates the resize column behavior to support cascading resizes while guaranteeing that columns will never inadvertently shrink below the size of their container.
+`AdvancedTable` - Updated the resize column behavior to support cascading resizes while guaranteeing that columns will never inadvertently shrink below the size of their container.
 
 <!-- END -->

--- a/packages/components/src/components/hds/advanced-table/column-manager/index.gts
+++ b/packages/components/src/components/hds/advanced-table/column-manager/index.gts
@@ -20,6 +20,7 @@ import type {
   HdsAdvancedTableColumn,
   HdsAdvancedTableColumnReorderSide,
   HdsAdvancedTableNormalizedColumn,
+  HdsAdvancedTablePixelString,
 } from '../types.ts';
 import type { HdsAdvancedTableSignature } from '../index.gts';
 
@@ -56,15 +57,17 @@ export interface HdsAdvancedTableColumnManagerSignature {
         syncColumnOrder: ModifierLike<HdsAdvancedTableSyncColumnOrderSignature>;
         syncThElements: ModifierLike<HdsAdvancedTableSyncThElementsSignature>;
         syncWidthValues: ModifierLike<HdsAdvancedTableSyncWidthValuesSignature>;
-        applyTransientWidth: (
-          columnKey: HdsAdvancedTableNormalizedColumn['key']
-        ) => void;
+        beginColumnResize: () => void;
+        commitColumnWidths: () => void;
         getAppliedWidth: (
           columnKey: HdsAdvancedTableNormalizedColumn['key']
         ) => HdsAdvancedTableNormalizedColumn['width'];
         getColumnByKey: (
           columnKey: HdsAdvancedTableNormalizedColumn['key']
         ) => HdsAdvancedTableNormalizedColumn | undefined;
+        getRenderedWidth: (
+          columnKey: HdsAdvancedTableNormalizedColumn['key']
+        ) => HdsAdvancedTablePixelString | undefined;
         getSiblingColumnKeys: (
           columnKey: HdsAdvancedTableNormalizedColumn['key']
         ) => {
@@ -84,6 +87,10 @@ export interface HdsAdvancedTableColumnManagerSignature {
           columnKey: HdsAdvancedTableNormalizedColumn['key'],
           position: 'start' | 'end'
         ) => void;
+        resizeColumnByDelta: (
+          columnKey: HdsAdvancedTableNormalizedColumn['key'],
+          deltaPx: number
+        ) => number;
         restoreColumnWidth: (
           columnKey: HdsAdvancedTableNormalizedColumn['key']
         ) => void;
@@ -93,20 +100,10 @@ export interface HdsAdvancedTableColumnManagerSignature {
         setReorderHoveredColumnKey: (
           key: HdsAdvancedTableNormalizedColumn['key'] | null
         ) => void;
-        setTransientColumnWidths: (options: { roundValues?: boolean }) => void;
-        setTransientColumnWidth: (
-          columnKey: HdsAdvancedTableNormalizedColumn['key'],
-          width: `${number}px`,
-          clamped?: boolean
-        ) => void;
         resetTransientColumnWidths: () => void;
         stepColumn: (
           columnKey: HdsAdvancedTableNormalizedColumn['key'],
           step: number
-        ) => void;
-        updateResizeDebt: (
-          columnKey: HdsAdvancedTableNormalizedColumn['key'],
-          delta: number
         ) => void;
       },
     ];
@@ -176,22 +173,22 @@ export default class HdsAdvancedTableColumnManager extends Component<HdsAdvanced
             syncColumnOrder=Order.syncColumnOrder
             syncThElements=this.syncThElements
             syncWidthValues=Width.syncWidthValues
-            applyTransientWidth=Width.applyTransientWidth
+            beginColumnResize=Width.beginColumnResize
+            resizeColumnByDelta=Width.resizeColumnByDelta
+            commitColumnWidths=Width.commitColumnWidths
             getAppliedWidth=Width.getAppliedWidth
             getColumnByKey=this.getColumnByKey
             getSiblingColumnKeys=Width.getSiblingColumnKeys
+            getRenderedWidth=Width.getRenderedWidth
             reorderHoveredColumnKey=Order.reorderHoveredColumnKey
             restoreColumnWidth=Width.restoreColumnWidth
             moveColumnToDropTarget=Order.moveColumnToDropTarget
             moveColumnToTarget=Order.moveColumnToTarget
             moveColumnToTerminalPosition=Order.moveColumnToTerminalPosition
-            setTransientColumnWidths=Width.setTransientColumnWidths
-            setTransientColumnWidth=Width.setTransientColumnWidth
             resetTransientColumnWidths=Width.resetTransientColumnWidths
             stepColumn=Order.stepColumn
             setDraggedColumnKey=Order.setDraggedColumnKey
             setReorderHoveredColumnKey=Order.setReorderHoveredColumnKey
-            updateResizeDebt=Width.updateResizeDebt
           )
         }}
       </HdsAdvancedTableColumnManagerWidth>

--- a/packages/components/src/components/hds/advanced-table/column-manager/order.gts
+++ b/packages/components/src/components/hds/advanced-table/column-manager/order.gts
@@ -12,6 +12,7 @@ import { tracked } from '@glimmer/tracking';
 import { modifier } from 'ember-modifier';
 import { TrackedMap } from 'tracked-built-ins';
 import { HdsAdvancedTableColumnReorderSideValues } from '../types.ts';
+import { requestAnimationFrameWaiter } from '../utils.ts';
 
 import type {
   HdsAdvancedTableColumnReorderCallback,
@@ -298,7 +299,7 @@ export default class HdsAdvancedTableColumnManagerOrder extends Component<HdsAdv
       this.columnOrder = updated;
 
       // we need to wait until the reposition has finished
-      requestAnimationFrame(() => {
+      requestAnimationFrameWaiter(() => {
         const thElement = this.args.thElements.get(sourceColumnKey);
 
         if (thElement === undefined) {

--- a/packages/components/src/components/hds/advanced-table/column-manager/width.gts
+++ b/packages/components/src/components/hds/advanced-table/column-manager/width.gts
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { modifier } from 'ember-modifier';
 import { TrackedMap } from 'tracked-built-ins';
 import { hash } from '@ember/helper';
-import { isPixelSize, pixelToNumber } from '../utils.ts';
+import { isPixelSize, measureColumnWidth, pixelToNumber } from '../utils.ts';
 
 import type {
   HdsAdvancedTableNormalizedColumn,
@@ -17,7 +17,7 @@ import type { ModifierLike } from '@glint/template';
 
 export const DEFAULT_WIDTH = '1fr'; // default to '1fr' to allow flexible width
 export const DEFAULT_MIN_WIDTH = '150px';
-export const DEFAULT_MAX_WIDTH = '800px';
+export const SUBPIXEL_TOLERANCE = 0.5;
 
 type HdsAdvancedTableColumnWidth = HdsAdvancedTableNormalizedColumn['width'];
 
@@ -41,12 +41,18 @@ interface HdsAdvancedTableColumnManagerWidthSignature {
       {
         gridTemplateColumns: string;
         syncWidthValues: ModifierLike<HdsAdvancedTableSyncWidthValuesSignature>;
-        applyTransientWidth: (
-          columnKey: HdsAdvancedTableNormalizedColumn['key']
-        ) => void;
+        beginColumnResize: () => void;
+        resizeColumnByDelta: (
+          columnKey: HdsAdvancedTableNormalizedColumn['key'],
+          deltaPx: number
+        ) => number;
+        commitColumnWidths: () => void;
         getAppliedWidth: (
           columnKey: HdsAdvancedTableNormalizedColumn['key']
         ) => HdsAdvancedTableNormalizedColumn['width'];
+        getRenderedWidth: (
+          columnKey: HdsAdvancedTableNormalizedColumn['key']
+        ) => HdsAdvancedTablePixelString | undefined;
         getSiblingColumnKeys: (
           columnKey: HdsAdvancedTableNormalizedColumn['key'] | null
         ) => {
@@ -56,16 +62,6 @@ interface HdsAdvancedTableColumnManagerWidthSignature {
         resetTransientColumnWidths: () => void;
         restoreColumnWidth: (
           columnKey: HdsAdvancedTableNormalizedColumn['key']
-        ) => void;
-        setTransientColumnWidth: (
-          columnKey: HdsAdvancedTableNormalizedColumn['key'],
-          width: `${number}px`,
-          clamped?: boolean
-        ) => void;
-        setTransientColumnWidths: (options: { roundValues?: boolean }) => void;
-        updateResizeDebt: (
-          columnKey: HdsAdvancedTableNormalizedColumn['key'],
-          delta: number
         ) => void;
       },
     ];
@@ -82,7 +78,7 @@ export default class HdsAdvancedTableColumnManagerWidth extends Component<HdsAdv
     string,
     HdsAdvancedTablePixelString
   >();
-  private _columnDebts = new TrackedMap<string, Record<string, number>>(); // key -> { lenderKey -> amount }
+  private _resizeStartWidths = new TrackedMap<string, number>();
 
   syncWidthValues = modifier<HdsAdvancedTableSyncWidthValuesSignature>(() => {
     const { columns } = this.args;
@@ -99,12 +95,22 @@ export default class HdsAdvancedTableColumnManagerWidth extends Component<HdsAdv
     let style = isSelectable ? 'min-content ' : '';
 
     for (const col of orderedColumns) {
-      const appliedWidth = this.getAppliedWidth(col.key);
-
-      style += ` ${appliedWidth}`;
+      style += ` ${this._getColumnTrackSize(col)}`;
     }
 
     return style;
+  }
+
+  private _getColumnTrackSize(col: HdsAdvancedTableNormalizedColumn): string {
+    const appliedWidth = this.getAppliedWidth(col.key) ?? DEFAULT_WIDTH;
+
+    if (this._parseFrMultiplier(appliedWidth) !== undefined) {
+      const minWidth = col.minWidth ?? DEFAULT_MIN_WIDTH;
+
+      return `minmax(${minWidth}, ${appliedWidth})`;
+    }
+
+    return appliedWidth;
   }
 
   getAppliedWidth = (
@@ -156,279 +162,210 @@ export default class HdsAdvancedTableColumnManagerWidth extends Component<HdsAdv
     }
   }
 
-  private _getPxMinWidth(key: string): number {
-    const column = this.args.getColumnByKey(key);
+  private _colMinPx(
+    column: HdsAdvancedTableNormalizedColumn | undefined
+  ): number {
     const minWidth = column?.minWidth ?? DEFAULT_MIN_WIDTH;
 
     return isPixelSize(minWidth) ? pixelToNumber(minWidth) : 0;
   }
 
-  applyTransientWidth = (
-    columnKey: HdsAdvancedTableNormalizedColumn['key']
-  ) => {
-    if (columnKey == undefined) {
-      return;
+  private _colMaxPx(
+    column: HdsAdvancedTableNormalizedColumn | undefined
+  ): number {
+    const maxWidth = column?.maxWidth;
+
+    return maxWidth !== undefined && isPixelSize(maxWidth)
+      ? pixelToNumber(maxWidth)
+      : Infinity;
+  }
+
+  beginColumnResize = (): void => {
+    this._resizeStartWidths.clear();
+
+    for (const key of this.args.columnOrder) {
+      const pixelWidth = this._getPxWidth(key);
+
+      this._resizeStartWidths.set(key, pixelWidth);
+      this._transientColumnWidths.set(key, `${pixelWidth}px`);
     }
-
-    const transientWidth = this._transientColumnWidths.get(columnKey);
-
-    this._columnWidths.set(columnKey, transientWidth);
   };
 
-  setTransientColumnWidths = (
-    options: { roundValues?: boolean } = {}
-  ): void => {
-    const roundValues = options.roundValues ?? false;
+  private _distributeWidthChange(keys: string[], amount: number): void {
+    let remaining = amount;
 
-    this._columnWidths.forEach((width, key) => {
-      let _width: number;
+    for (const key of keys) {
+      const start = this._resizeStartWidths.get(key) ?? 0;
+      const column = this.args.getColumnByKey(key);
+      let applied = 0;
 
-      if (width !== undefined && isPixelSize(width)) {
-        _width = pixelToNumber(width as `${number}px`);
-      } else {
-        _width = this.args.thElements.get(key)?.offsetWidth ?? 0;
+      if (remaining > 0) {
+        applied = Math.min(
+          remaining,
+          Math.max(0, this._colMaxPx(column) - start)
+        );
+      } else if (remaining < 0) {
+        applied = -Math.min(
+          -remaining,
+          Math.max(0, start - this._colMinPx(column))
+        );
       }
 
-      this._transientColumnWidths.set(
-        key,
-        `${roundValues ? Math.round(_width) : _width}px`
+      this._transientColumnWidths.set(key, `${start + applied}px`);
+      remaining -= applied;
+    }
+  }
+
+  private _distributableCapacity(keys: string[], grow: boolean): number {
+    return keys.reduce((sum, key) => {
+      const start = this._resizeStartWidths.get(key) ?? 0;
+      const column = this.args.getColumnByKey(key);
+
+      return (
+        sum +
+        (grow
+          ? Math.max(0, this._colMaxPx(column) - start)
+          : Math.max(0, start - this._colMinPx(column)))
       );
-    });
+    }, 0);
+  }
+
+  resizeColumnByDelta = (
+    columnKey: HdsAdvancedTableNormalizedColumn['key'],
+    deltaPx: number
+  ): number => {
+    const order = this.args.columnOrder;
+    const index = order.indexOf(columnKey);
+
+    if (index === -1) {
+      return 0;
+    }
+
+    const draggedKeys = [columnKey];
+    // nearest-to-boundary first, so the cascade grows outward
+    const rightKeys = order.slice(index + 1);
+
+    let actualDelta: number;
+
+    if (deltaPx > 0) {
+      const capacity = Math.min(
+        this._distributableCapacity(draggedKeys, true),
+        this._distributableCapacity(rightKeys, false)
+      );
+
+      actualDelta = Math.max(0, Math.min(deltaPx, capacity));
+    } else if (deltaPx < 0) {
+      const capacity = Math.min(
+        this._distributableCapacity(draggedKeys, false),
+        this._distributableCapacity(rightKeys, true)
+      );
+
+      actualDelta = Math.min(0, -Math.min(-deltaPx, capacity));
+    } else {
+      actualDelta = 0;
+    }
+
+    this._distributeWidthChange(draggedKeys, actualDelta);
+    this._distributeWidthChange(rightKeys, -actualDelta);
+
+    return actualDelta;
   };
+
+  commitColumnWidths = (): void => {
+    const entries = this.args.columns.map((column) => {
+      const startPixelWidth = this._resizeStartWidths.get(column.key);
+      const transientWidth = this._transientColumnWidths.get(column.key);
+      const pixelWidth =
+        transientWidth !== undefined
+          ? pixelToNumber(transientWidth)
+          : this._getPxWidth(column.key);
+
+      return {
+        key: column.key,
+        pixelWidth,
+        startPixelWidth: startPixelWidth ?? pixelWidth,
+        frMultiplier: this._parseFrMultiplier(
+          this._columnWidths.get(column.key) ?? DEFAULT_WIDTH
+        ),
+        hasMoved:
+          startPixelWidth !== undefined &&
+          Math.abs(pixelWidth - startPixelWidth) > SUBPIXEL_TOLERANCE,
+      };
+    });
+
+    const pxPerFrUnit = this._resolvePxPerFrUnit(entries);
+
+    for (const entry of entries) {
+      if (!entry.hasMoved) {
+        continue;
+      }
+
+      if (entry.frMultiplier !== undefined && pxPerFrUnit > 0) {
+        // 6 decimals keeps the committed track within a thousandth of a pixel of
+        // the transient one, so there is no visible jump when the gesture ends
+        const weight = Math.round((entry.pixelWidth / pxPerFrUnit) * 1e6) / 1e6;
+
+        this._columnWidths.set(entry.key, `${weight}fr`);
+      } else {
+        this._columnWidths.set(entry.key, `${Math.round(entry.pixelWidth)}px`);
+      }
+    }
+  };
+
+  private _resolvePxPerFrUnit(
+    entries: {
+      pixelWidth: number;
+      startPixelWidth: number;
+      frMultiplier: number | undefined;
+      hasMoved: boolean;
+    }[]
+  ): number {
+    const flexible = entries.filter(
+      (entry) => entry.frMultiplier !== undefined && entry.frMultiplier > 0
+    );
+
+    const anchor = flexible.find((entry) => !entry.hasMoved);
+
+    if (anchor !== undefined) {
+      return anchor.startPixelWidth / (anchor.frMultiplier ?? 1);
+    }
+
+    const totalWeight = flexible.reduce(
+      (sum, entry) => sum + (entry.frMultiplier ?? 0),
+      0
+    );
+    const totalPixels = flexible.reduce(
+      (sum, entry) => sum + entry.pixelWidth,
+      0
+    );
+
+    return totalWeight > 0 ? totalPixels / totalWeight : 0;
+  }
 
   resetTransientColumnWidths = (): void => {
     this._transientColumnWidths.clear();
   };
 
-  setTransientColumnWidth = (
-    columnKey: HdsAdvancedTableNormalizedColumn['key'],
-    width: `${number}px`,
-    clamped: boolean = true
-  ): void => {
-    const column = this.args.getColumnByKey(columnKey);
-
-    if (column === undefined) {
-      return;
-    }
-
-    if (clamped) {
-      const { minWidth, maxWidth } = column;
-
-      const minWidthInPixels =
-        minWidth === undefined ? 1 : pixelToNumber(minWidth);
-      const maxWidthInPixels =
-        maxWidth === undefined ? Infinity : pixelToNumber(maxWidth);
-
-      const transientColumnWidthInPixels = Math.min(
-        Math.max(pixelToNumber(width), minWidthInPixels),
-        maxWidthInPixels
-      );
-
-      this._transientColumnWidths.set(
-        columnKey,
-        `${transientColumnWidthInPixels}px`
-      );
-    } else {
-      this._transientColumnWidths.set(columnKey, width);
-    }
-  };
-
-  updateResizeDebt = (
-    columnKey: HdsAdvancedTableNormalizedColumn['key'],
-    delta: number
-  ): void => {
-    if (delta === 0) {
-      return;
-    }
-
-    const { next: nextColumnKey } = this.getSiblingColumnKeys(columnKey);
-
-    if (nextColumnKey === undefined) {
-      return;
-    }
-
-    // determine borrower and lender
-    const borrowerKey = delta > 0 ? columnKey : nextColumnKey;
-    const lenderKey = delta > 0 ? nextColumnKey : columnKey;
-    let amount = Math.abs(delta);
-
-    // check if lender has existing debt to borrower
-    const lenderDebts = this._columnDebts.get(lenderKey) ?? {};
-    const existingDebt = lenderDebts[borrowerKey] ?? 0;
-
-    if (existingDebt > 0) {
-      const paymentAmount = Math.min(amount, existingDebt);
-      const newDebt = existingDebt - paymentAmount;
-
-      const updatedDebts = { ...lenderDebts };
-
-      if (newDebt <= 0) {
-        delete updatedDebts[borrowerKey];
-      } else {
-        updatedDebts[borrowerKey] = newDebt;
-      }
-
-      this._columnDebts.set(lenderKey, updatedDebts);
-
-      amount = amount - paymentAmount;
-    }
-
-    // if amount remains, create new debt
-    if (amount > 0) {
-      const borrowerDebts = this._columnDebts.get(borrowerKey) ?? {};
-
-      this._columnDebts.set(borrowerKey, {
-        ...borrowerDebts,
-        [lenderKey]: (borrowerDebts[lenderKey] ?? 0) + amount,
-      });
-    }
-  };
-
-  // restores a column to its original width, settling all debts first
   restoreColumnWidth = (
     columnKey: HdsAdvancedTableNormalizedColumn['key']
   ): void => {
-    // settle debts (collect from debtors, pay lenders)
-    this._settleWidthDebts(columnKey);
+    const originalWidth =
+      this._originalColumnWidths.get(columnKey) ?? DEFAULT_WIDTH;
 
-    // restore original width
-    const originalWidth = this._originalColumnWidths.get(columnKey);
-
-    if (originalWidth) {
-      this._columnWidths.set(columnKey, originalWidth);
-      this._transientColumnWidths.delete(columnKey);
-    }
+    this._transientColumnWidths.delete(columnKey);
+    this._columnWidths.set(columnKey, originalWidth);
   };
 
-  private _settleWidthDebts(key: string): void {
-    this._collectWidthDebts(key);
-    this._payWidthDebts(key);
-  }
+  getRenderedWidth = (
+    columnKey: HdsAdvancedTableNormalizedColumn['key']
+  ): HdsAdvancedTablePixelString | undefined => {
+    return measureColumnWidth(this.args.thElements.get(columnKey));
+  };
 
-  private _collectWidthDebts(collectorKey: string): void {
-    // iterate over all known columns to see if they owe the collector
-    this.args.columnOrder.forEach((debtorKey) => {
-      if (debtorKey === collectorKey) {
-        return;
-      }
+  private _parseFrMultiplier(value: string): number | undefined {
+    const match = /^(-?\d+(?:\.\d+)?)fr$/.exec(value);
 
-      const debtorDebts = this._columnDebts.get(debtorKey);
-      const debtToCollect = debtorDebts?.[collectorKey] ?? 0;
-
-      if (debtToCollect <= 0) {
-        return;
-      }
-
-      // attempt to source funds from the debtor
-      const amountPaid = this._sourceFundsForPayment(debtorKey, debtToCollect);
-
-      if (amountPaid > 0) {
-        // add funds to collector
-        const currentCollectorWidth = this._getPxWidth(collectorKey);
-
-        this._columnWidths.set(
-          collectorKey,
-          `${currentCollectorWidth + amountPaid}px`
-        );
-        this._transientColumnWidths.delete(collectorKey);
-
-        // update debtors ledger
-        const remainingDebt = debtToCollect - amountPaid;
-        const currentDebts = this._columnDebts.get(debtorKey) ?? {};
-        const updatedDebts = { ...currentDebts };
-
-        if (remainingDebt > 0) {
-          updatedDebts[collectorKey] = remainingDebt;
-        } else {
-          delete updatedDebts[collectorKey];
-        }
-
-        this._columnDebts.set(debtorKey, updatedDebts);
-      }
-    });
-  }
-
-  private _payWidthDebts(payerKey: string): void {
-    const debts = this._columnDebts.get(payerKey);
-
-    if (debts === undefined) {
-      return;
-    }
-
-    Object.entries(debts).forEach(([lenderKey, amount]) => {
-      // give width back to lender
-      const currentLenderWidth = this._getPxWidth(lenderKey);
-
-      this._columnWidths.set(lenderKey, `${currentLenderWidth + amount}px`);
-      this._transientColumnWidths.delete(lenderKey);
-    });
-
-    // lear payers debts
-    this._columnDebts.delete(payerKey);
-  }
-
-  private _sourceFundsForPayment(key: string, amountNeeded: number): number {
-    let fundsSourced = 0;
-
-    // preferentially source width from our own surplus first
-    const currentWidth = this._getPxWidth(key);
-    const minWidth = this._getPxMinWidth(key);
-    const surplus = Math.max(0, currentWidth - minWidth);
-    const paymentFromSurplus = Math.min(amountNeeded, surplus);
-
-    if (paymentFromSurplus > 0) {
-      this._columnWidths.set(key, `${currentWidth - paymentFromSurplus}px`);
-      this._transientColumnWidths.delete(key);
-
-      fundsSourced = fundsSourced + paymentFromSurplus;
-    }
-
-    // if shortfall, source from our debtors (recursive)
-    const shortfall = amountNeeded - fundsSourced;
-
-    if (shortfall > 0) {
-      // find who owes this column (key)
-      const ourDebtors = this.args.columnOrder.filter((debtorKey) => {
-        const debtorDebts = this._columnDebts.get(debtorKey);
-
-        return debtorDebts && debtorDebts[key] && debtorDebts[key] > 0;
-      });
-
-      for (const subDebtorKey of ourDebtors) {
-        const amountStillNeeded = amountNeeded - fundsSourced;
-
-        if (amountStillNeeded <= 0) {
-          break;
-        }
-
-        const subDebtorDebts = this._columnDebts.get(subDebtorKey)!;
-        const subDebtOwed = subDebtorDebts[key] ?? 0;
-        const amountToRequest = Math.min(amountStillNeeded, subDebtOwed);
-
-        const collectedFromSubDebtor = this._sourceFundsForPayment(
-          subDebtorKey,
-          amountToRequest
-        );
-
-        if (collectedFromSubDebtor > 0) {
-          fundsSourced = fundsSourced + collectedFromSubDebtor;
-
-          // update sub-debtor ledger
-          const remaining = subDebtOwed - collectedFromSubDebtor;
-          const updatedSubDebts = { ...subDebtorDebts };
-
-          if (remaining > 0) {
-            updatedSubDebts[key] = remaining;
-          } else {
-            delete updatedSubDebts[key];
-          }
-
-          this._columnDebts.set(subDebtorKey, updatedSubDebts);
-        }
-      }
-    }
-
-    return fundsSourced;
+    return match ? Number(match[1]) : undefined;
   }
 
   <template>
@@ -436,14 +373,14 @@ export default class HdsAdvancedTableColumnManagerWidth extends Component<HdsAdv
       (hash
         gridTemplateColumns=this.gridTemplateColumns
         syncWidthValues=this.syncWidthValues
-        applyTransientWidth=this.applyTransientWidth
+        beginColumnResize=this.beginColumnResize
+        resizeColumnByDelta=this.resizeColumnByDelta
+        commitColumnWidths=this.commitColumnWidths
         getAppliedWidth=this.getAppliedWidth
         getSiblingColumnKeys=this.getSiblingColumnKeys
+        getRenderedWidth=this.getRenderedWidth
         restoreColumnWidth=this.restoreColumnWidth
-        setTransientColumnWidths=this.setTransientColumnWidths
-        setTransientColumnWidth=this.setTransientColumnWidth
         resetTransientColumnWidths=this.resetTransientColumnWidths
-        updateResizeDebt=this.updateResizeDebt
       )
     }}
   </template>

--- a/packages/components/src/components/hds/advanced-table/column-manager/width.gts
+++ b/packages/components/src/components/hds/advanced-table/column-manager/width.gts
@@ -95,22 +95,10 @@ export default class HdsAdvancedTableColumnManagerWidth extends Component<HdsAdv
     let style = isSelectable ? 'min-content ' : '';
 
     for (const col of orderedColumns) {
-      style += ` ${this._getColumnTrackSize(col)}`;
+      style += ` ${this.getAppliedWidth(col.key)}`;
     }
 
     return style;
-  }
-
-  private _getColumnTrackSize(col: HdsAdvancedTableNormalizedColumn): string {
-    const appliedWidth = this.getAppliedWidth(col.key) ?? DEFAULT_WIDTH;
-
-    if (this._parseFrMultiplier(appliedWidth) !== undefined) {
-      const minWidth = col.minWidth ?? DEFAULT_MIN_WIDTH;
-
-      return `minmax(${minWidth}, ${appliedWidth})`;
-    }
-
-    return appliedWidth;
   }
 
   getAppliedWidth = (

--- a/packages/components/src/components/hds/advanced-table/column-manager/width.gts
+++ b/packages/components/src/components/hds/advanced-table/column-manager/width.gts
@@ -301,11 +301,16 @@ export default class HdsAdvancedTableColumnManagerWidth extends Component<HdsAdv
       }
 
       if (entry.frMultiplier !== undefined && pxPerFrUnit > 0) {
-        // 6 decimals keeps the committed track within a thousandth of a pixel of
-        // the transient one, so there is no visible jump when the gesture ends
-        const weight = Math.round((entry.pixelWidth / pxPerFrUnit) * 1e6) / 1e6;
+        const weight = Math.max(
+          0,
+          entry.frMultiplier +
+            (entry.pixelWidth - entry.startPixelWidth) / pxPerFrUnit
+        );
 
-        this._columnWidths.set(entry.key, `${weight}fr`);
+        this._columnWidths.set(
+          entry.key,
+          `${Math.round(weight * 1e6) / 1e6}fr`
+        );
       } else {
         this._columnWidths.set(entry.key, `${Math.round(entry.pixelWidth)}px`);
       }
@@ -314,28 +319,20 @@ export default class HdsAdvancedTableColumnManagerWidth extends Component<HdsAdv
 
   private _resolvePxPerFrUnit(
     entries: {
-      pixelWidth: number;
       startPixelWidth: number;
       frMultiplier: number | undefined;
-      hasMoved: boolean;
     }[]
   ): number {
     const flexible = entries.filter(
       (entry) => entry.frMultiplier !== undefined && entry.frMultiplier > 0
     );
 
-    const anchor = flexible.find((entry) => !entry.hasMoved);
-
-    if (anchor !== undefined) {
-      return anchor.startPixelWidth / (anchor.frMultiplier ?? 1);
-    }
-
     const totalWeight = flexible.reduce(
       (sum, entry) => sum + (entry.frMultiplier ?? 0),
       0
     );
     const totalPixels = flexible.reduce(
-      (sum, entry) => sum + entry.pixelWidth,
+      (sum, entry) => sum + entry.startPixelWidth,
       0
     );
 

--- a/packages/components/src/components/hds/advanced-table/index.gts
+++ b/packages/components/src/components/hds/advanced-table/index.gts
@@ -45,6 +45,7 @@ import type {
   HdsAdvancedTableVerticalAlignment,
   HdsAdvancedTableExpandState,
   HdsAdvancedTableColumnReorderCallback,
+  HdsAdvancedTableColumnResizeCallback,
   HdsAdvancedTableModel,
 } from './types.ts';
 
@@ -185,7 +186,7 @@ export interface HdsAdvancedTableSignature<T = HdsAdvancedTableModel> {
     childrenKey?: string;
     maxHeight?: string;
     onColumnReorder?: HdsAdvancedTableColumnReorderCallback;
-    onColumnResize?: (columnKey: string, newWidth?: string) => void;
+    onColumnResize?: HdsAdvancedTableColumnResizeCallback;
     onSelectionChange?: (
       selection: HdsAdvancedTableOnSelectionChangeSignature
     ) => void;
@@ -1076,7 +1077,6 @@ export default class HdsAdvancedTable<
                         CM.draggedColumnKey
                         (CM.getSiblingColumnKeys CM.draggedColumnKey)
                       }}
-                      @siblingColumnKeys={{CM.getSiblingColumnKeys column.key}}
                       @tableHeight={{this._tableHeight}}
                       @tooltip={{column.tooltip}}
                       @hasExpandAllButton={{this.hasRowsWithChildren}}
@@ -1086,26 +1086,25 @@ export default class HdsAdvancedTable<
                         (eq column.key this.currentSortBy)
                         this.currentSortOrder
                       }}
-                      @onApplyTransientWidth={{CM.applyTransientWidth}}
+                      @onBeginColumnResize={{CM.beginColumnResize}}
                       @onClickSort={{if
                         column.isSortable
                         (fn this.setSortBy column.key)
                       }}
                       @onClickToggle={{this.toggleExpandAll}}
                       @onColumnResize={{@onColumnResize}}
+                      @onCommitColumnWidths={{CM.commitColumnWidths}}
                       @onGetAppliedWidth={{CM.getAppliedWidth}}
-                      @onGetColumnByKey={{CM.getColumnByKey}}
+                      @onGetRenderedWidth={{CM.getRenderedWidth}}
                       @onMoveColumnToTerminalPosition={{CM.moveColumnToTerminalPosition}}
                       @onPinFirstColumn={{this._onPinFirstColumn}}
                       @onReorderDrop={{CM.moveColumnToDropTarget}}
-                      @onRestoreColumnWidth={{CM.restoreColumnWidth}}
                       @onResetTransientColumnWidths={{CM.resetTransientColumnWidths}}
+                      @onResizeColumnByDelta={{CM.resizeColumnByDelta}}
+                      @onRestoreColumnWidth={{CM.restoreColumnWidth}}
                       @onSetDraggedColumnKey={{CM.setDraggedColumnKey}}
                       @onSetReorderHoveredColumnKey={{CM.setReorderHoveredColumnKey}}
-                      @onSetTransientColumnWidth={{CM.setTransientColumnWidth}}
-                      @onSetTransientColumnWidths={{CM.setTransientColumnWidths}}
                       @onStepColumn={{CM.stepColumn}}
-                      @onUpdateResizeDebt={{CM.updateResizeDebt}}
                       {{CM.syncThElements column.key}}
                     >
                       {{column.label}}

--- a/packages/components/src/components/hds/advanced-table/th-context-menu.gts
+++ b/packages/components/src/components/hds/advanced-table/th-context-menu.gts
@@ -14,6 +14,7 @@ import { on } from '@ember/modifier';
 
 import HdsDropdown from '../dropdown/index.gts';
 import hdsT from '../../../helpers/hds-t.ts';
+import { requestAnimationFrameWaiter } from './utils.ts';
 
 import type { HdsDropdownSignature } from '../dropdown/index.gts';
 import type { HdsDropdownToggleIconSignature } from '../dropdown/toggle/icon.gts';
@@ -22,7 +23,10 @@ import type { HdsAdvancedTableThReorderHandleSignature } from './th-reorder-hand
 import type { HdsAdvancedTableThResizeHandleSignature } from './th-resize-handle.gts';
 import type { HdsDropdownToggleButtonSignature } from '../dropdown/toggle/button.gts';
 import type HdsIntlService from '../../../services/hds-intl.ts';
-import type { HdsAdvancedTableNormalizedColumn } from './types.ts';
+import type {
+  HdsAdvancedTableNormalizedColumn,
+  HdsAdvancedTablePixelString,
+} from './types.ts';
 
 interface HdsAdvancedTableThContextMenuOption {
   key: string;
@@ -44,6 +48,9 @@ export interface HdsAdvancedTableThContextMenuSignature {
     resizeHandleElement?: HdsAdvancedTableThResizeHandleSignature['Element'];
     onColumnResize?: HdsAdvancedTableSignature['Args']['onColumnResize'];
     onFocusReorderHandle?: () => void;
+    onGetRenderedWidth?: (
+      columnKey: HdsAdvancedTableNormalizedColumn['key']
+    ) => HdsAdvancedTablePixelString | undefined;
     onMoveColumnToTerminalPosition?: (
       columnKey: HdsAdvancedTableNormalizedColumn['key'],
       position: 'start' | 'end'
@@ -219,20 +226,27 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
   }
 
   private _resetColumnWidth(dropdownCloseCallback: () => void): void {
-    const { column, onColumnResize, onRestoreColumnWidth } = this.args;
+    const { column, onColumnResize, onGetRenderedWidth, onRestoreColumnWidth } =
+      this.args;
 
     if (
-      typeof onRestoreColumnWidth === 'function' &&
-      column.key !== undefined
+      typeof onRestoreColumnWidth !== 'function' ||
+      column.key === undefined
     ) {
-      onRestoreColumnWidth(column.key);
-
-      if (typeof onColumnResize === 'function') {
-        onColumnResize(column.key, column.width);
-      }
-
-      dropdownCloseCallback();
+      return;
     }
+
+    onRestoreColumnWidth(column.key);
+
+    if (typeof onColumnResize === 'function') {
+      // restoring re-flows every flexible column, so the resulting width is only
+      // knowable after the grid has re-laid-out
+      requestAnimationFrameWaiter(() => {
+        onColumnResize(column.key, onGetRenderedWidth?.(column.key));
+      });
+    }
+
+    dropdownCloseCallback();
   }
 
   private _moveColumn() {
@@ -252,7 +266,7 @@ export default class HdsAdvancedTableThContextMenu extends Component<HdsAdvanced
 
     onMoveColumnToTerminalPosition?.(column.key, position);
 
-    requestAnimationFrame(() => {
+    requestAnimationFrameWaiter(() => {
       dropdownCloseCallback?.();
 
       this._toggleElement?.focus();

--- a/packages/components/src/components/hds/advanced-table/th-resize-handle.gts
+++ b/packages/components/src/components/hds/advanced-table/th-resize-handle.gts
@@ -11,86 +11,39 @@ import { on } from '@ember/modifier';
 import style from 'ember-style-modifier';
 import { concat } from '@ember/helper';
 
-import { parsePixel, requestAnimationFrameWaiter } from './utils.ts';
-import { BORDER_WIDTH } from './index.gts';
 import {
-  DEFAULT_MIN_WIDTH,
-  DEFAULT_MAX_WIDTH,
-} from './column-manager/width.gts';
+  measureColumnWidth,
+  parsePixel,
+  requestAnimationFrameWaiter,
+} from './utils.ts';
+import { BORDER_WIDTH } from './index.gts';
+import { DEFAULT_MIN_WIDTH } from './column-manager/width.gts';
 import hdsT from '../../../helpers/hds-t.ts';
 
 import type Owner from '@ember/owner';
-import type { HdsAdvancedTableNormalizedColumn } from './types';
+import type {
+  HdsAdvancedTableNormalizedColumn,
+  HdsAdvancedTablePixelString,
+} from './types';
 import type { HdsAdvancedTableSignature } from './index.gts';
 
 const KEYBOARD_RESIZE_STEP = 10;
 
-function calculateEffectiveDelta(
-  deltaX: number,
-  col: HdsAdvancedTableNormalizedColumn,
-  startColW: number,
-  nextCol: HdsAdvancedTableNormalizedColumn,
-  startNextColW: number
-): number {
-  const colMin = parsePixel(col.minWidth ?? DEFAULT_MIN_WIDTH) ?? 0;
-  const colMax = parsePixel(col.maxWidth ?? DEFAULT_MAX_WIDTH) ?? Infinity;
-  const nextMin = parsePixel(nextCol.minWidth ?? DEFAULT_MIN_WIDTH) ?? 0;
-  const nextMax = parsePixel(nextCol.maxWidth ?? DEFAULT_MAX_WIDTH) ?? Infinity;
-
-  let effectiveDelta = 0;
-
-  // expanding col, shrinking nextCol
-  if (deltaX > 0) {
-    const maxCanExpandCol = colMax - startColW;
-    const maxCanShrinkNext = startNextColW - nextMin;
-
-    effectiveDelta = Math.min(deltaX, maxCanExpandCol, maxCanShrinkNext);
-    effectiveDelta = Math.max(0, effectiveDelta);
-  }
-  // shrinking col, expanding nextCol
-  else if (deltaX < 0) {
-    const absDeltaX = -deltaX;
-    const maxCanShrinkCol = startColW - colMin;
-
-    let maxCanExpandNext: number;
-    if (startNextColW > nextMax) {
-      maxCanExpandNext = Infinity;
-    } else {
-      maxCanExpandNext = nextMax - startNextColW;
-    }
-
-    effectiveDelta = -Math.min(absDeltaX, maxCanShrinkCol, maxCanExpandNext);
-    effectiveDelta = Math.min(0, effectiveDelta);
-  }
-
-  return effectiveDelta;
-}
-
 export interface HdsAdvancedTableThResizeHandleSignature {
   Args: {
     column?: HdsAdvancedTableNormalizedColumn;
-    siblingColumnKeys?: {
-      previous?: HdsAdvancedTableNormalizedColumn['key'];
-      next?: HdsAdvancedTableNormalizedColumn['key'];
-    };
     tableHeight?: number;
-    onApplyTransientWidth?: (
-      columnKey: HdsAdvancedTableNormalizedColumn['key']
-    ) => void;
+    onBeginColumnResize?: () => void;
+    onColumnResize?: HdsAdvancedTableSignature['Args']['onColumnResize'];
+    onCommitColumnWidths?: () => void;
     onGetAppliedWidth?: (
       columnKey: HdsAdvancedTableNormalizedColumn['key']
     ) => HdsAdvancedTableNormalizedColumn['width'];
-    onGetColumnByKey?: (
-      columnKey: HdsAdvancedTableNormalizedColumn['key']
-    ) => HdsAdvancedTableNormalizedColumn | undefined;
-    onSetTransientColumnWidth?: (
-      columnKey: HdsAdvancedTableNormalizedColumn['key'],
-      width: `${number}px`
-    ) => void;
-    onSetTransientColumnWidths?: (options: { roundValues?: boolean }) => void;
     onResetTransientColumnWidths?: () => void;
-    onUpdateResizeDebt?: (delta: number) => void;
-    onColumnResize?: HdsAdvancedTableSignature['Args']['onColumnResize'];
+    onResizeColumnByDelta?: (
+      columnKey: HdsAdvancedTableNormalizedColumn['key'],
+      deltaPx: number
+    ) => number;
   };
   Blocks: {
     default?: [];
@@ -99,12 +52,7 @@ export interface HdsAdvancedTableThResizeHandleSignature {
 }
 
 export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvancedTableThResizeHandleSignature> {
-  @tracked resizing: {
-    startX: number;
-    startColumnPxWidth: number;
-    startNextColumnPxWidth?: number;
-  } | null = null;
-  // track the width change as it is changing, applied when resizing stops
+  @tracked resizing: { startX: number } | null = null;
   @tracked private _transientDelta: number = 0;
   @tracked private _isUpdateQueued: boolean = false;
   @tracked private _lastPointerEvent: PointerEvent | null = null;
@@ -136,9 +84,15 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
       return 0;
     }
 
-    const appliedWidth = onGetAppliedWidth(column.key);
+    const pixelWidth = parsePixel(onGetAppliedWidth(column.key));
 
-    return parsePixel(appliedWidth) ?? 0;
+    if (pixelWidth !== undefined) {
+      return Math.round(pixelWidth);
+    }
+
+    // the applied width is an `fr` weight once a resize commits, and parsing that
+    // would report 0 — measure the rendered cell instead
+    return parsePixel(measureColumnWidth(this._handleElement)) ?? 0;
   }
 
   get minWidthInPixels(): number {
@@ -146,9 +100,21 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
   }
 
   get maxWidthInPixels(): number {
-    return (
-      parsePixel(this.args.column?.maxWidth ?? DEFAULT_MAX_WIDTH) ?? Infinity
-    );
+    const explicitMax = parsePixel(this.args.column?.maxWidth);
+
+    if (explicitMax !== undefined) {
+      return explicitMax;
+    }
+
+    const table = this._handleElement?.closest('.hds-advanced-table');
+
+    return table instanceof HTMLElement
+      ? table.offsetWidth
+      : this.minWidthInPixels;
+  }
+
+  get widthValueText(): string {
+    return `${this.currentWidthInPixels}px`;
   }
 
   get height(): string | undefined {
@@ -171,29 +137,32 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     return classes.join(' ');
   }
 
-  private _applyTransientWidths() {
-    const { column, siblingColumnKeys, onApplyTransientWidth } = this.args;
-
-    if (column === undefined || onApplyTransientWidth === undefined) {
-      return;
-    }
-
-    const { next: nextColumnKey } = siblingColumnKeys ?? {};
-
-    onApplyTransientWidth(column.key);
-
-    if (nextColumnKey !== undefined) {
-      onApplyTransientWidth(nextColumnKey);
-    }
-  }
-
   @action
-  onColumnResize(key?: string, width?: string): void {
+  onColumnResize(key?: string, width?: HdsAdvancedTablePixelString): void {
     const { onColumnResize } = this.args;
 
     if (typeof onColumnResize === 'function' && key !== undefined) {
       onColumnResize(key, width);
     }
+  }
+
+  private _finishColumnResize(
+    columnKey: HdsAdvancedTableNormalizedColumn['key']
+  ): void {
+    const { onCommitColumnWidths, onResetTransientColumnWidths } = this.args;
+
+    if (this._transientDelta !== 0) {
+      onCommitColumnWidths?.();
+    }
+
+    onResetTransientColumnWidths?.();
+
+    this.resizing = null;
+    this._transientDelta = 0;
+
+    requestAnimationFrameWaiter(() => {
+      this.onColumnResize(columnKey, measureColumnWidth(this._handleElement));
+    });
   }
 
   @action
@@ -209,48 +178,28 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
 
     const {
       column,
-      siblingColumnKeys,
-      onApplyTransientWidth,
-      onGetAppliedWidth,
-      onSetTransientColumnWidths,
+      onBeginColumnResize,
+      onResizeColumnByDelta,
+      onCommitColumnWidths,
       onResetTransientColumnWidths,
-      onUpdateResizeDebt,
     } = this.args;
-    const { next: nextColumnKey } = siblingColumnKeys ?? {};
 
     if (
       column === undefined ||
-      nextColumnKey === undefined ||
-      onApplyTransientWidth === undefined ||
-      onGetAppliedWidth === undefined ||
-      onSetTransientColumnWidths === undefined ||
-      onUpdateResizeDebt === undefined ||
+      onBeginColumnResize === undefined ||
+      onResizeColumnByDelta === undefined ||
+      onCommitColumnWidths === undefined ||
       onResetTransientColumnWidths === undefined
     ) {
       return;
     }
 
-    onSetTransientColumnWidths({ roundValues: true });
+    onBeginColumnResize();
 
-    const startColumnAppliedWidth = onGetAppliedWidth(column.key);
-    const startNextColumnAppliedWidth = onGetAppliedWidth(nextColumnKey);
-
-    const startColumnPxWidth = Math.round(
-      parsePixel(startColumnAppliedWidth) ?? 0
-    );
-    const startNextColumnPxWidth = Math.round(
-      parsePixel(startNextColumnAppliedWidth) ?? 0
-    );
     const deltaX =
       event.key === 'ArrowRight' ? KEYBOARD_RESIZE_STEP : -KEYBOARD_RESIZE_STEP;
 
-    this._applyResizeDelta(
-      deltaX,
-      startColumnPxWidth,
-      column,
-      nextColumnKey,
-      startNextColumnPxWidth
-    );
+    this._transientDelta = onResizeColumnByDelta(column.key, deltaX);
 
     // ensure the resize handle remains visible during keyboard navigation.
     this._handleElement.scrollIntoView({
@@ -260,19 +209,7 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     });
 
     // use a microtask to commit the final state after the render pass.
-    queueMicrotask(() => {
-      if (this._transientDelta !== 0) {
-        onUpdateResizeDebt(this._transientDelta);
-      }
-      // reset transient values
-      onApplyTransientWidth(column.key);
-      onApplyTransientWidth(nextColumnKey);
-
-      onResetTransientColumnWidths();
-      this._transientDelta = 0;
-
-      this.onColumnResize(column.key, column.width);
-    });
+    queueMicrotask(() => this._finishColumnResize(column.key));
   }
 
   @action
@@ -284,122 +221,18 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
     event.preventDefault();
     event.stopPropagation();
 
-    const {
-      column,
-      siblingColumnKeys,
-      onGetAppliedWidth,
-      onSetTransientColumnWidths,
-    } = this.args;
+    const { column, onBeginColumnResize } = this.args;
 
-    if (
-      column === undefined ||
-      onGetAppliedWidth === undefined ||
-      onSetTransientColumnWidths === undefined
-    ) {
+    if (column === undefined || onBeginColumnResize === undefined) {
       return;
     }
 
-    const { next: nextColumnKey } = siblingColumnKeys ?? {};
+    onBeginColumnResize();
 
-    onSetTransientColumnWidths({});
-
-    const startColumnAppliedWidth = onGetAppliedWidth(column.key);
-    const startNextColumnAppliedWidth =
-      nextColumnKey !== undefined
-        ? onGetAppliedWidth(nextColumnKey)
-        : undefined;
-
-    const startColumnPxWidth = Math.round(
-      parsePixel(startColumnAppliedWidth) ?? 0
-    );
-    const startNextColumnPxWidth = Math.round(
-      parsePixel(startNextColumnAppliedWidth) ?? 0
-    );
-
-    this.resizing = {
-      startX: event.clientX,
-      startColumnPxWidth,
-      startNextColumnPxWidth,
-    };
+    this.resizing = { startX: event.clientX };
 
     window.addEventListener('pointermove', this._boundResize);
     window.addEventListener('pointerup', this._boundStopResize);
-  }
-
-  private _setColumnWidth(
-    column: HdsAdvancedTableNormalizedColumn,
-    width: number
-  ): void {
-    const { onSetTransientColumnWidth } = this.args;
-
-    if (column === undefined || onSetTransientColumnWidth === undefined) {
-      return;
-    }
-
-    onSetTransientColumnWidth(column.key, `${width}px`);
-  }
-
-  private _applyResizeDelta(
-    deltaX: number,
-    startColumnPxWidth: number,
-    column?: HdsAdvancedTableNormalizedColumn,
-    nextColumnKey?: HdsAdvancedTableNormalizedColumn['key'],
-    startNextColumnPxWidth?: number
-  ): void {
-    const { onGetAppliedWidth, onGetColumnByKey, onSetTransientColumnWidth } =
-      this.args;
-
-    if (
-      column === undefined ||
-      onGetAppliedWidth === undefined ||
-      onGetColumnByKey === undefined
-    ) {
-      return;
-    }
-
-    const canResizeNeighbor =
-      nextColumnKey !== undefined && startNextColumnPxWidth !== undefined;
-
-    if (canResizeNeighbor) {
-      const nextColumn = onGetColumnByKey(nextColumnKey);
-
-      if (nextColumn === undefined) {
-        return;
-      }
-
-      const effectiveDelta = calculateEffectiveDelta(
-        deltaX,
-        column,
-        startColumnPxWidth,
-        nextColumn,
-        startNextColumnPxWidth
-      );
-
-      // set the width for the current column
-      this._setColumnWidth(
-        column,
-        Math.round(startColumnPxWidth + effectiveDelta)
-      );
-
-      // the actual new column width may differ from the intended width due to min/max constraints.
-      const columnAppliedWidth = onGetAppliedWidth(column.key);
-      const actualNewColumnWidth =
-        parsePixel(columnAppliedWidth) ?? startColumnPxWidth;
-      const actualAppliedDelta = actualNewColumnWidth - startColumnPxWidth;
-
-      // set the width for the next sibling column
-      this._setColumnWidth(
-        nextColumn,
-        Math.round(startNextColumnPxWidth - actualAppliedDelta)
-      );
-
-      this._transientDelta = actualAppliedDelta;
-    } else if (onSetTransientColumnWidth !== undefined) {
-      onSetTransientColumnWidth(
-        column.key,
-        `${Math.round(startColumnPxWidth + deltaX)}px`
-      );
-    }
   }
 
   private _resize(event: PointerEvent): void {
@@ -422,60 +255,34 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
 
       event.preventDefault();
 
-      const { column, siblingColumnKeys } = this.args;
-      const { next: nextColumnKey } = siblingColumnKeys ?? {};
-      const { startX, startColumnPxWidth, startNextColumnPxWidth } =
-        this.resizing;
-      const deltaX = event.clientX - startX;
+      const { column, onResizeColumnByDelta } = this.args;
 
-      this._applyResizeDelta(
-        deltaX,
-        startColumnPxWidth, // Width at the start of the drag
-        column,
-        nextColumnKey,
-        startNextColumnPxWidth // Width of next col at the start of the drag
-      );
+      if (column !== undefined && onResizeColumnByDelta !== undefined) {
+        const deltaX = event.clientX - this.resizing.startX;
+
+        this._transientDelta = onResizeColumnByDelta(column.key, deltaX);
+      }
 
       this._isUpdateQueued = false;
     });
   }
 
   private _stopResize(): void {
-    const {
-      column,
-      onGetAppliedWidth,
-      onResetTransientColumnWidths,
-      onUpdateResizeDebt,
-    } = this.args;
-
-    if (
-      column === undefined ||
-      onGetAppliedWidth === undefined ||
-      onResetTransientColumnWidths === undefined ||
-      onUpdateResizeDebt === undefined
-    ) {
-      return;
-    }
-
     window.removeEventListener('pointermove', this._boundResize);
     window.removeEventListener('pointerup', this._boundStopResize);
 
-    if (this._transientDelta !== 0) {
-      onUpdateResizeDebt(this._transientDelta);
+    const { column } = this.args;
+
+    if (column === undefined) {
+      this.args.onResetTransientColumnWidths?.();
+
+      this.resizing = null;
+      this._transientDelta = 0;
+
+      return;
     }
 
-    this._applyTransientWidths();
-
-    // reset the transient width
-    onResetTransientColumnWidths();
-
-    // reset the resizing state
-    this.resizing = null;
-    this._transientDelta = 0;
-
-    const appliedWidth = onGetAppliedWidth(column.key);
-
-    this.onColumnResize(column.key, appliedWidth);
+    this._finishColumnResize(column.key);
   }
 
   <template>
@@ -488,6 +295,7 @@ export default class HdsAdvancedTableThResizeHandle extends Component<HdsAdvance
       aria-valuenow={{this.currentWidthInPixels}}
       aria-valuemin={{this.minWidthInPixels}}
       aria-valuemax={{this.maxWidthInPixels}}
+      aria-valuetext={{this.widthValueText}}
       tabindex="0"
       aria-label={{hdsT
         "hds.components.advanced-table.th-resize-handle.aria-label"

--- a/packages/components/src/components/hds/advanced-table/th.gts
+++ b/packages/components/src/components/hds/advanced-table/th.gts
@@ -43,6 +43,7 @@ import type {
   HdsAdvancedTableNormalizedColumn,
   HdsAdvancedTableThSortOrderLabels,
   HdsAdvancedTableThSortOrder,
+  HdsAdvancedTablePixelString,
 } from './types.ts';
 
 import type { HdsCompositeSignature } from '../composite/index.gts';
@@ -83,10 +84,6 @@ export interface HdsAdvancedTableThSignature {
     reorderHoveredColumnKey?: HdsAdvancedTableNormalizedColumn['key'] | null;
     rowspan?: number;
     scope?: HdsAdvancedTableScope;
-    siblingColumnKeys?: {
-      previous?: HdsAdvancedTableNormalizedColumn['key'];
-      next?: HdsAdvancedTableNormalizedColumn['key'];
-    };
     draggedColumnSiblingColumnKeys?: {
       previous?: HdsAdvancedTableNormalizedColumn['key'];
       next?: HdsAdvancedTableNormalizedColumn['key'];
@@ -95,18 +92,14 @@ export interface HdsAdvancedTableThSignature {
     tableHeight?: number;
     tooltip?: string;
     didInsertExpandButton?: (button: HTMLButtonElement) => void;
-    onApplyTransientWidth?: (
-      columnKey: HdsAdvancedTableNormalizedColumn['key']
-    ) => void;
+    onBeginColumnResize?: () => void;
+    onCommitColumnWidths?: () => void;
     onClickSort?: HdsAdvancedTableThButtonSortSignature['Args']['onClick'];
     onClickToggle?: () => void;
     onColumnResize?: HdsAdvancedTableSignature['Args']['onColumnResize'];
     onGetAppliedWidth?: (
       columnKey: HdsAdvancedTableNormalizedColumn['key']
     ) => HdsAdvancedTableNormalizedColumn['width'];
-    onGetColumnByKey?: (
-      columnKey: HdsAdvancedTableNormalizedColumn['key']
-    ) => HdsAdvancedTableNormalizedColumn | undefined;
     onMoveColumnToTerminalPosition?: (
       columnKey: HdsAdvancedTableNormalizedColumn['key'],
       position: 'start' | 'end'
@@ -117,27 +110,25 @@ export interface HdsAdvancedTableThSignature {
       side: HdsAdvancedTableColumnReorderSide
     ) => void;
     onResetTransientColumnWidths?: () => void;
+    onResizeColumnByDelta?: (
+      columnKey: HdsAdvancedTableNormalizedColumn['key'],
+      deltaPx: number
+    ) => number;
     onRestoreColumnWidth?: (
       columnKey: HdsAdvancedTableNormalizedColumn['key']
     ) => void;
+    onGetRenderedWidth?: (
+      columnKey: HdsAdvancedTableNormalizedColumn['key']
+    ) => HdsAdvancedTablePixelString | undefined;
     onSetDraggedColumnKey?: (
       key: HdsAdvancedTableNormalizedColumn['key'] | null
     ) => void;
     onSetReorderHoveredColumnKey?: (
       key: HdsAdvancedTableNormalizedColumn['key'] | null
     ) => void;
-    onSetTransientColumnWidth?: (
-      columnKey: HdsAdvancedTableNormalizedColumn['key'],
-      width: `${number}px`
-    ) => void;
-    onSetTransientColumnWidths?: (options: { roundValues?: boolean }) => void;
     onStepColumn?: (
       columnKey: HdsAdvancedTableNormalizedColumn['key'],
       step: number
-    ) => void;
-    onUpdateResizeDebt?: (
-      columnKey: HdsAdvancedTableNormalizedColumn['key'],
-      delta: number
     ) => void;
     willDestroyExpandButton?: (button: HTMLButtonElement) => void;
   };
@@ -349,12 +340,6 @@ export default class HdsAdvancedTableTh extends Component<HdsAdvancedTableThSign
     this._reorderHandleElement.focus();
   }
 
-  @action applyTransientWidth(
-    columnKey: HdsAdvancedTableNormalizedColumn['key']
-  ): void {
-    this.args.onApplyTransientWidth?.(columnKey);
-  }
-
   @action resetTransientColumnWidths(): void {
     this.args.onResetTransientColumnWidths?.();
   }
@@ -365,31 +350,10 @@ export default class HdsAdvancedTableTh extends Component<HdsAdvancedTableThSign
     return this.args.onGetAppliedWidth?.(columnKey);
   }
 
-  @action getColumnByKey(
-    columnKey: HdsAdvancedTableNormalizedColumn['key']
-  ): HdsAdvancedTableNormalizedColumn | undefined {
-    return this.args.onGetColumnByKey?.(columnKey);
-  }
-
   @action setDraggedColumnKey(
     columnKey: HdsAdvancedTableNormalizedColumn['key'] | null
   ): void {
     this.args.onSetDraggedColumnKey?.(columnKey);
-  }
-
-  @action setTransientColumnWidth(
-    columnKey: HdsAdvancedTableNormalizedColumn['key'],
-    width: `${number}px`
-  ): void {
-    const { column, onSetTransientColumnWidth } = this.args;
-
-    if (column !== undefined && onSetTransientColumnWidth !== undefined) {
-      onSetTransientColumnWidth(columnKey, width);
-    }
-  }
-
-  @action setTransientColumnWidths(options: { roundValues?: boolean }): void {
-    this.args.onSetTransientColumnWidths?.(options);
   }
 
   @action stepColumn(step: number): void {
@@ -397,14 +361,6 @@ export default class HdsAdvancedTableTh extends Component<HdsAdvancedTableThSign
 
     if (column !== undefined && onStepColumn !== undefined) {
       onStepColumn(column.key, step);
-    }
-  }
-
-  @action updateResizeDebt(delta: number): void {
-    const { column, onUpdateResizeDebt } = this.args;
-
-    if (column !== undefined && onUpdateResizeDebt !== undefined) {
-      onUpdateResizeDebt(column.key, delta);
     }
   }
 
@@ -521,6 +477,7 @@ export default class HdsAdvancedTableTh extends Component<HdsAdvancedTableThSign
               @onMoveColumnToTerminalPosition={{@onMoveColumnToTerminalPosition}}
               @onPinFirstColumn={{@onPinFirstColumn}}
               @onRestoreColumnWidth={{@onRestoreColumnWidth}}
+              @onGetRenderedWidth={{@onGetRenderedWidth}}
             />
             {{#if (and @hasReorderableColumns (not @isStickyColumn))}}
               <HdsAdvancedTableThReorderHandle
@@ -536,16 +493,13 @@ export default class HdsAdvancedTableTh extends Component<HdsAdvancedTableThSign
             {{#if this.showResizeHandle}}
               <HdsAdvancedTableThResizeHandle
                 @column={{@column}}
-                @siblingColumnKeys={{@siblingColumnKeys}}
                 @tableHeight={{@tableHeight}}
-                @onApplyTransientWidth={{this.applyTransientWidth}}
                 @onColumnResize={{@onColumnResize}}
+                @onBeginColumnResize={{@onBeginColumnResize}}
+                @onResizeColumnByDelta={{@onResizeColumnByDelta}}
+                @onCommitColumnWidths={{@onCommitColumnWidths}}
                 @onGetAppliedWidth={{this.getAppliedWidth}}
-                @onGetColumnByKey={{this.getColumnByKey}}
-                @onSetTransientColumnWidth={{this.setTransientColumnWidth}}
-                @onSetTransientColumnWidths={{this.setTransientColumnWidths}}
                 @onResetTransientColumnWidths={{this.resetTransientColumnWidths}}
-                @onUpdateResizeDebt={{this.updateResizeDebt}}
                 {{this._registerResizeHandleElement}}
               />
             {{/if}}

--- a/packages/components/src/components/hds/advanced-table/types.ts
+++ b/packages/components/src/components/hds/advanced-table/types.ts
@@ -127,7 +127,7 @@ export type HdsAdvancedTableModel = Array<HdsAdvancedTableModelItem>;
 
 export type HdsAdvancedTableColumnResizeCallback = (
   columnKey: string,
-  newWidth?: string
+  newWidth?: HdsAdvancedTablePixelString
 ) => void;
 
 export type HdsAdvancedTableColumnReorderCallback = ({

--- a/packages/components/src/components/hds/advanced-table/utils.ts
+++ b/packages/components/src/components/hds/advanced-table/utils.ts
@@ -20,6 +20,18 @@ export function requestAnimationFrameWaiter(callback: () => void) {
   });
 }
 
+export function measureColumnWidth(
+  descendant: Element | null | undefined
+): `${number}px` | undefined {
+  const th = descendant?.closest('.hds-advanced-table__th');
+
+  if (!(th instanceof HTMLElement)) {
+    return undefined;
+  }
+
+  return `${th.offsetWidth}px`;
+}
+
 export function pixelToNumber(px: `${number}px`): number {
   return Number(px.replace('px', ''));
 }

--- a/showcase/app/components/page-components/advanced-table/sub-sections/base-elements.gts
+++ b/showcase/app/components/page-components/advanced-table/sub-sections/base-elements.gts
@@ -98,6 +98,8 @@ export default class SubSectionsBaseElements extends Component {
     ];
   }
 
+  returnZero = () => 0;
+
   mockIndeterminateState = (checkbox: HTMLInputElement) => {
     checkbox.indeterminate = true;
   };
@@ -1204,13 +1206,10 @@ export default class SubSectionsBaseElements extends Component {
                     <HdsAdvancedTableThResizeHandle
                       mock-state-value={{state}}
                       @column={{get this.columns 0}}
-                      @onApplyTransientWidth={{NOOP}}
-                      @onGetAppliedWidth={{this.returnString}}
-                      @onGetColumnByKey={{this.returnUndefined}}
-                      @onSetTransientColumnWidth={{NOOP}}
-                      @onSetTransientColumnWidths={{NOOP}}
+                      @onBeginColumnResize={{NOOP}}
+                      @onResizeColumnByDelta={{this.returnZero}}
+                      @onCommitColumnWidths={{NOOP}}
                       @onResetTransientColumnWidths={{NOOP}}
-                      @onUpdateResizeDebt={{NOOP}}
                       aria-valuenow="200"
                     />
                   </HdsLayoutFlex>

--- a/showcase/tests/integration/components/hds/advanced-table/features/column-resizing-test.gts
+++ b/showcase/tests/integration/components/hds/advanced-table/features/column-resizing-test.gts
@@ -758,6 +758,60 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
       );
     });
 
+    test('a resized column keeps the table filling its container when the container shrinks', async function (assert) {
+      const context = new TrackedObject({ width: '1000px' });
+
+      await render(
+        <template>
+          <div id="shrink-container" {{style width=context.width}}>
+            <HdsAdvancedTable
+              id="shrink-table"
+              @columns={{array
+                (hash key="name" label="Name")
+                (hash key="type" label="Type")
+                (hash key="status" label="Status")
+              }}
+              @model={{array
+                (hash name="Alpha" type="One" status="Active")
+                (hash name="Beta" type="Two" status="Inactive")
+              }}
+              @hasResizableColumns={{true}}
+            >
+              <:body as |B|>
+                <B.Tr>
+                  <B.Td>{{get B.data "name"}}</B.Td>
+                  <B.Td>{{get B.data "type"}}</B.Td>
+                  <B.Td>{{get B.data "status"}}</B.Td>
+                </B.Tr>
+              </:body>
+            </HdsAdvancedTable>
+          </div>
+        </template>,
+      );
+
+      await waitForLayout();
+
+      const handle = findOrThrow(
+        '#shrink-table .hds-advanced-table__th-resize-handle',
+      );
+      await simulateRightPointerDrag(handle);
+      await waitForLayout();
+
+      // 600px leaves room for all three columns above the 150px default
+      // minimum, so nothing is clamped and the table can still fit exactly
+      context.width = '600px';
+      await settled();
+      await waitForLayout();
+
+      const table = findOrThrow('#shrink-table');
+      const container = findOrThrow('#shrink-container');
+
+      assert.ok(
+        Math.abs(table.offsetWidth - container.offsetWidth) <= 1,
+        `table still fits its container after it shrinks (table=${table.offsetWidth}, container=${container.offsetWidth})`,
+      );
+    });
+
     test('resizing chains across columns when a neighbor reaches its minimum width', async function (assert) {
       // four columns at ~250px each (min 150): dragging 300px is more than any
       // single neighbor can give up, so the change must chain across the columns

--- a/showcase/tests/integration/components/hds/advanced-table/features/column-resizing-test.gts
+++ b/showcase/tests/integration/components/hds/advanced-table/features/column-resizing-test.gts
@@ -810,6 +810,73 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
       );
     });
 
+    test('repeated keyboard resizes leave the untouched columns alone', async function (assert) {
+      await render(
+        <template>
+          <div {{style width="1000px"}}>
+            <HdsAdvancedTable
+              id="kbd-table"
+              @columns={{array
+                (hash key="a" label="A")
+                (hash key="b" label="B")
+                (hash key="c" label="C")
+                (hash key="d" label="D")
+              }}
+              @model={{array
+                (hash a="a1" b="b1" c="c1" d="d1")
+                (hash a="a2" b="b2" c="c2" d="d2")
+              }}
+              @hasResizableColumns={{true}}
+            >
+              <:body as |B|>
+                <B.Tr>
+                  <B.Td>{{get B.data "a"}}</B.Td>
+                  <B.Td>{{get B.data "b"}}</B.Td>
+                  <B.Td>{{get B.data "c"}}</B.Td>
+                  <B.Td>{{get B.data "d"}}</B.Td>
+                </B.Tr>
+              </:body>
+            </HdsAdvancedTable>
+          </div>
+        </template>,
+      );
+
+      await waitForLayout();
+
+      const startFirst = columnWidth('#kbd-table', 0);
+
+      // the handle on column B's right edge, so column A sits outside the
+      // gesture entirely. columns to its RIGHT are expected to move — they
+      // cascade once column C reaches its minimum — but column A must not.
+      const handle = findAtOrThrow(
+        '#kbd-table .hds-advanced-table__th-resize-handle',
+        1,
+      );
+
+      await focus(handle);
+
+      // each keypress is a full begin/commit cycle, so any per-commit error
+      // compounds; twelve of them make a sub-pixel drift plainly visible
+      const trace: number[] = [];
+
+      for (let index = 0; index < 12; index++) {
+        await triggerKeyEvent(handle, 'keydown', 'ArrowRight');
+        await waitForLayout();
+
+        trace.push(columnWidth('#kbd-table', 0));
+      }
+
+      assert.strictEqual(
+        columnWidth('#kbd-table', 0),
+        startFirst,
+        `the column left of the boundary never moved (trace ${JSON.stringify(trace)})`,
+      );
+      assert.ok(
+        columnWidth('#kbd-table', 1) > startFirst,
+        'the resized column actually grew',
+      );
+    });
+
     test('the resize handle exposes accurate aria values after a resize', async function (assert) {
       await createResizableTable({});
 

--- a/showcase/tests/integration/components/hds/advanced-table/features/column-resizing-test.gts
+++ b/showcase/tests/integration/components/hds/advanced-table/features/column-resizing-test.gts
@@ -812,6 +812,44 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
       );
     });
 
+    test('a flexible column keeps its content width when the table overflows', async function (assert) {
+      await render(
+        <template>
+          <div {{style width="500px"}}>
+            <HdsAdvancedTable
+              id="of-table"
+              @columns={{array
+                (hash key="a" label="A" width="300px")
+                (hash key="b" label="B" width="300px")
+                (hash key="c" label="C")
+              }}
+              @model={{array
+                (hash a="a1" b="b1" c="/var/log/boundary_session.log")
+              }}
+              @hasResizableColumns={{true}}
+            >
+              <:body as |B|>
+                <B.Tr>
+                  <B.Td>{{get B.data "a"}}</B.Td>
+                  <B.Td>{{get B.data "b"}}</B.Td>
+                  <B.Td>{{get B.data "c"}}</B.Td>
+                </B.Tr>
+              </:body>
+            </HdsAdvancedTable>
+          </div>
+        </template>,
+      );
+
+      await waitForLayout();
+
+      const flexible = columnWidth('#of-table', 2);
+
+      assert.ok(
+        flexible > 160,
+        `flexible column kept its content width instead of collapsing to the 150px minimum (actual ${flexible})`,
+      );
+    });
+
     test('resizing chains across columns when a neighbor reaches its minimum width', async function (assert) {
       // four columns at ~250px each (min 150): dragging 300px is more than any
       // single neighbor can give up, so the change must chain across the columns

--- a/showcase/tests/integration/components/hds/advanced-table/features/column-resizing-test.gts
+++ b/showcase/tests/integration/components/hds/advanced-table/features/column-resizing-test.gts
@@ -8,26 +8,82 @@ import { array, hash, get } from '@ember/helper';
 import {
   click,
   find,
+  findAll,
   focus,
   render,
   settled,
   triggerEvent,
   triggerKeyEvent,
 } from '@ember/test-helpers';
-import { waitForLayout } from '../utils';
+import { performContextMenuAction, waitForLayout } from '../utils';
 import { TrackedObject } from 'tracked-built-ins';
 import sinon from 'sinon';
 import style from 'ember-style-modifier';
-
 import { HdsAdvancedTable } from '@hashicorp/design-system-components/components';
+import { setupRenderingTest } from 'showcase/tests/helpers';
+
 import type { HdsAdvancedTableColumn } from '@hashicorp/design-system-components/components/hds/advanced-table/types';
 
-import { setupRenderingTest } from 'showcase/tests/helpers';
+const POINTER_DRAG_START_X = 100;
+
+function assertReportedPixelWidth(
+  assert: Assert,
+  spy: sinon.SinonSpy,
+  selector: string,
+  label: string,
+) {
+  const [reportedKey, reportedWidth] = spy.lastCall.args as [
+    string,
+    string | undefined,
+  ];
+  const rendered = findOrThrow(selector).offsetWidth;
+
+  assert.strictEqual(reportedKey, 'col1', `${label}: reports the column key`);
+  assert.ok(
+    reportedWidth !== undefined && /^\d+px$/.test(reportedWidth),
+    `${label}: reports a pixel width (got ${JSON.stringify(reportedWidth)})`,
+  );
+  assert.ok(
+    Math.abs(parseInt(reportedWidth ?? '', 10) - rendered) <= 1,
+    `${label}: reported width matches the rendered width (reported ${reportedWidth}, rendered ${rendered}px)`,
+  );
+}
+
+function findOrThrow(selector: string): HTMLElement {
+  const element = find(selector);
+
+  if (element === null) {
+    throw new Error(`expected to find "${selector}" but nothing was found`);
+  }
+
+  return element as HTMLElement;
+}
+
+function findAtOrThrow(selector: string, index: number): HTMLElement {
+  const elements = findAll(selector);
+  const element = elements[index];
+
+  if (element === undefined) {
+    throw new Error(
+      `expected an element at index ${index} matching "${selector}" but found ${elements.length}`,
+    );
+  }
+
+  return element as HTMLElement;
+}
 
 function gridValuesAreEqual(
   newGridValues: string[],
   originalGridValues: string[],
 ) {
+  if (newGridValues.length === 0 || originalGridValues.length === 0) {
+    return false;
+  }
+
+  if (newGridValues.length !== originalGridValues.length) {
+    return false;
+  }
+
   return newGridValues.every((newGridValue, index) => {
     const newGridValueInt = parseInt(newGridValue, 10);
 
@@ -42,11 +98,22 @@ function gridValuesAreEqual(
   });
 }
 
-function getTableGridValues(tableElement: Element | null) {
-  if (!tableElement) {
-    return [];
+function columnWidth(tableSelector: string, index: number): number {
+  const headerCells = findAll(
+    `${tableSelector} .hds-advanced-table__thead .hds-advanced-table__th`,
+  );
+  const headerCell = headerCells[index];
+
+  if (headerCell === undefined) {
+    throw new Error(
+      `expected a header cell at index ${index} in "${tableSelector}" but found ${headerCells.length}`,
+    );
   }
 
+  return (headerCell as HTMLElement).offsetWidth;
+}
+
+function getTableGridValues(tableElement: Element) {
   const computedStyle = window.getComputedStyle(tableElement);
   const gridTemplateColumns = computedStyle.getPropertyValue(
     'grid-template-columns',
@@ -58,33 +125,27 @@ function getTableGridValues(tableElement: Element | null) {
   return gridValues;
 }
 
-async function performContextMenuAction(th: Element | null, key: string) {
-  const contextMenuToggle = th?.querySelector('.hds-dropdown-toggle-icon');
-
-  if (contextMenuToggle) {
-    await click(contextMenuToggle);
-    return click(`[data-test-context-option-key="${key}"]`);
-  }
-}
-
-async function simulateRightPointerDrag(handle: Element | null) {
-  if (!handle) return;
-
-  await triggerEvent(handle, 'pointerdown', { clientX: 100, button: 0 });
-  await triggerEvent(handle, 'pointermove', { clientX: 130, buttons: 1 });
+async function simulatePointerDrag(
+  handle: Element,
+  toX: number,
+  fromX: number = POINTER_DRAG_START_X,
+) {
+  await triggerEvent(handle, 'pointerdown', {
+    clientX: fromX,
+    button: 0,
+  });
+  await triggerEvent(handle, 'pointermove', { clientX: toX, buttons: 1 });
   await triggerEvent(window, 'pointerup', { button: 0 });
 
   await waitForLayout();
 }
 
-async function simulateLeftPointerDrag(handle: Element | null) {
-  if (!handle) return;
+async function simulateRightPointerDrag(handle: Element) {
+  return simulatePointerDrag(handle, POINTER_DRAG_START_X + 30);
+}
 
-  await triggerEvent(handle, 'pointerdown', { clientX: 100, button: 0 });
-  await triggerEvent(handle, 'pointermove', { clientX: 70, buttons: 1 });
-  await triggerEvent(window, 'pointerup', { button: 0 });
-
-  await waitForLayout();
+async function simulateLeftPointerDrag(handle: Element) {
+  return simulatePointerDrag(handle, POINTER_DRAG_START_X - 30);
 }
 
 const DEFAULT_RESIZABLE_COLUMNS: HdsAdvancedTableColumn[] = [
@@ -139,7 +200,7 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
     test('it should allow resizing columns with the resize handle (pointer events)', async function (assert) {
       await createResizableTable({});
 
-      const table = find('.hds-advanced-table');
+      const table = findOrThrow('.hds-advanced-table');
       const originalGridValues = getTableGridValues(table);
 
       assert
@@ -149,13 +210,13 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
           'There is one resize handle (not on last column)',
         );
 
-      const handle = find('.hds-advanced-table__th-resize-handle'); // get the first handle
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle'); // get the first handle
 
       // Simulate pointer drag to the right (increase width)
       await simulateRightPointerDrag(handle);
 
       const newGridValues = getTableGridValues(table);
-      assert.notEqual(
+      assert.notDeepEqual(
         newGridValues,
         originalGridValues,
         'Grid values changed after drag',
@@ -165,241 +226,231 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
     test('it should allow resizing columns with the resize handle (keyboard events)', async function (assert) {
       await createResizableTable({});
 
-      const table = find('.hds-advanced-table');
+      const table = findOrThrow('.hds-advanced-table');
       const originalGridValues = getTableGridValues(table);
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
 
-      if (handle) {
-        // Focus and send ArrowRight key
-        await focus(handle);
-        await triggerKeyEvent(handle, 'keydown', 'ArrowRight');
+      // Focus and send ArrowRight key
+      await focus(handle);
+      await triggerKeyEvent(handle, 'keydown', 'ArrowRight');
 
-        let newGridValues = getTableGridValues(table);
+      const afterRightGridValues = getTableGridValues(table);
 
-        assert.notOk(
-          gridValuesAreEqual(originalGridValues, newGridValues),
-          'Grid values are not equal after ArrowRight',
-        );
+      assert.notOk(
+        gridValuesAreEqual(originalGridValues, afterRightGridValues),
+        'Grid values are not equal after ArrowRight',
+      );
 
-        // Send ArrowLeft key
-        await triggerKeyEvent(handle, 'keydown', 'ArrowLeft');
+      // ArrowRight should grow the first column
+      assert.ok(
+        parseInt(afterRightGridValues[0] ?? '0', 10) >
+          parseInt(originalGridValues[0] ?? '0', 10),
+        'First column grew after ArrowRight',
+      );
 
-        await waitForLayout();
+      // Send ArrowLeft key
+      await triggerKeyEvent(handle, 'keydown', 'ArrowLeft');
 
-        newGridValues = getTableGridValues(table);
+      await waitForLayout();
 
-        assert.ok(
-          gridValuesAreEqual(originalGridValues, newGridValues),
-          'Grid values are equal after ArrowLeft',
-        );
-      }
+      const afterLeftGridValues = getTableGridValues(table);
+
+      // an exact pixel round-trip is not guaranteed once the table fills its
+      // container, but ArrowLeft must still shrink the column again
+      assert.ok(
+        parseInt(afterLeftGridValues[0] ?? '0', 10) <
+          parseInt(afterRightGridValues[0] ?? '0', 10),
+        'First column shrank again after ArrowLeft',
+      );
     });
 
     test('it should not allow resizing columns below their minimum width (pointer events)', async function (assert) {
       await createResizableTable({});
 
-      const table = find('.hds-advanced-table');
+      const table = findOrThrow('.hds-advanced-table');
       const originalGridValues = getTableGridValues(table);
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
 
-      if (handle) {
-        // Try to resize column to a very small width (well below minWidth of 60px)
-        await triggerEvent(handle, 'pointerdown', { clientX: 100 });
-        await triggerEvent(window, 'pointermove', { clientX: 1 });
-        await triggerEvent(window, 'pointerup');
+      // Try to resize column to a very small width (well below minWidth of 60px)
+      await simulatePointerDrag(handle, 1);
 
-        await waitForLayout();
+      const newGridValues = getTableGridValues(table);
+      assert.notDeepEqual(
+        newGridValues,
+        originalGridValues,
+        'Grid values changed after pointer drag',
+      );
 
-        const newGridValues = getTableGridValues(table);
-        assert.notEqual(
-          newGridValues,
-          originalGridValues,
-          'Grid values changed after pointer drag',
-        );
+      const [firstColumnGridValue = ''] = newGridValues;
 
-        const firstColumnGridValue = newGridValues[0];
-
-        if (firstColumnGridValue) {
-          assert.ok(
-            parseInt(firstColumnGridValue, 10) >= 60,
-            `Column width respects minimum width constraint (actual: ${firstColumnGridValue}, min: 60px)`,
-          );
-        }
-      }
+      assert.ok(
+        parseInt(firstColumnGridValue, 10) >= 60,
+        `Column width respects minimum width constraint (actual: ${firstColumnGridValue}, min: 60px)`,
+      );
     });
 
     test('it should not allow resizing columns above their maximum width (pointer events)', async function (assert) {
       await createResizableTable({});
 
-      const table = find('.hds-advanced-table');
+      const table = findOrThrow('.hds-advanced-table');
       const originalGridValues = getTableGridValues(table);
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
 
-      if (handle) {
-        // Try to resize column to a very large width (well below minWidth of 60px)
-        await triggerEvent(handle, 'pointerdown', { clientX: 100 });
-        await triggerEvent(window, 'pointermove', { clientX: 10000 });
-        await triggerEvent(window, 'pointerup');
+      // Try to resize column to a very large width (well above maxWidth of 300px)
+      await simulatePointerDrag(handle, 10000);
 
-        await waitForLayout();
+      // Check the new width
+      const newGridValues = getTableGridValues(table);
+      assert.notDeepEqual(
+        newGridValues,
+        originalGridValues,
+        'Grid values changed after pointer drag',
+      );
 
-        // Check the new width
-        const newGridValues = getTableGridValues(table);
-        assert.notEqual(
-          newGridValues,
-          originalGridValues,
-          'Grid values changed after pointer drag',
-        );
+      const [firstColumnGridValue = ''] = newGridValues;
 
-        const firstColumnGridValue = newGridValues[0];
-
-        if (firstColumnGridValue) {
-          assert.ok(
-            parseInt(firstColumnGridValue, 10) <= 300,
-            `Column width respects maximum width constraint (actual: ${firstColumnGridValue}px, max: 300px)`,
-          );
-        }
-      }
+      assert.ok(
+        parseInt(firstColumnGridValue, 10) <= 300,
+        `Column width respects maximum width constraint (actual: ${firstColumnGridValue}px, max: 300px)`,
+      );
     });
 
     test('it should not allow resizing columns below their minimum width (keyboard events)', async function (assert) {
       await createResizableTable({});
 
-      const table = find('.hds-advanced-table');
+      const table = findOrThrow('.hds-advanced-table');
       const originalGridValues = getTableGridValues(table);
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
 
-      if (handle) {
-        // Focus handle and press ArrowLeft multiple times to try going below min width
-        await focus(handle);
+      // Focus handle and press ArrowLeft multiple times to try going below min width
+      await focus(handle);
 
-        for (let i = 0; i < 10; i++) {
-          // moves left 10px each time
-          await triggerKeyEvent(handle, 'keydown', 'ArrowLeft');
-        }
-
-        await waitForLayout();
-
-        const newGridValues = getTableGridValues(table);
-        assert.notEqual(
-          newGridValues,
-          originalGridValues,
-          'Grid values changed after ArrowLeft',
-        );
-
-        const firstColumnGridValue = newGridValues[0];
-
-        if (firstColumnGridValue) {
-          assert.ok(
-            parseInt(firstColumnGridValue, 10) >= 60,
-            `Column width respects minimum width constraint with keyboard events (actual: ${firstColumnGridValue}, min: 60px)`,
-          );
-        }
+      for (let i = 0; i < 10; i++) {
+        // moves left 10px each time
+        await triggerKeyEvent(handle, 'keydown', 'ArrowLeft');
       }
+
+      await waitForLayout();
+
+      const newGridValues = getTableGridValues(table);
+      assert.notDeepEqual(
+        newGridValues,
+        originalGridValues,
+        'Grid values changed after ArrowLeft',
+      );
+
+      const [firstColumnGridValue = ''] = newGridValues;
+
+      assert.ok(
+        parseInt(firstColumnGridValue, 10) >= 60,
+        `Column width respects minimum width constraint with keyboard events (actual: ${firstColumnGridValue}, min: 60px)`,
+      );
     });
 
     test('it should not allow resizing columns above their maximum width (keyboard events)', async function (assert) {
       await createResizableTable({});
 
-      const table = find('.hds-advanced-table');
+      const table = findOrThrow('.hds-advanced-table');
       const originalGridValues = getTableGridValues(table);
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
 
-      if (handle) {
-        // Focus handle and press ArrowLeft multiple times to try going below min width
-        await focus(handle);
+      // Focus handle and press ArrowRight multiple times to try going above max width
+      await focus(handle);
 
-        for (let i = 0; i < 10; i++) {
-          // moves right 10px each time
-          await triggerKeyEvent(handle, 'keydown', 'ArrowRight');
-        }
-
-        await waitForLayout();
-
-        const newGridValues = getTableGridValues(table);
-        assert.notEqual(
-          newGridValues,
-          originalGridValues,
-          'Grid values changed after ArrowRight',
-        );
-
-        const firstColumnGridValue = newGridValues[0];
-
-        if (firstColumnGridValue) {
-          assert.ok(
-            parseInt(firstColumnGridValue, 10) <= 300,
-            `Column width respects maximum width constraint with keyboard events (actual: ${firstColumnGridValue}px, max: 300px)`,
-          );
-        }
+      for (let i = 0; i < 10; i++) {
+        // moves right 10px each time
+        await triggerKeyEvent(handle, 'keydown', 'ArrowRight');
       }
+
+      await waitForLayout();
+
+      const newGridValues = getTableGridValues(table);
+      assert.notDeepEqual(
+        newGridValues,
+        originalGridValues,
+        'Grid values changed after ArrowRight',
+      );
+
+      const [firstColumnGridValue = ''] = newGridValues;
+
+      assert.ok(
+        parseInt(firstColumnGridValue, 10) <= 300,
+        `Column width respects maximum width constraint with keyboard events (actual: ${firstColumnGridValue}px, max: 300px)`,
+      );
     });
 
     test('it should show the context menu when resizing is enabled', async function (assert) {
       await createResizableTable({});
 
-      const th = find('.hds-advanced-table__th'); // find the first header cell
+      const th = findOrThrow('.hds-advanced-table__th'); // find the first header cell
 
-      if (th) {
-        assert.ok(
-          th.querySelector('.hds-advanced-table__th-context-menu'),
-          'context menu exists',
-        );
+      assert.ok(
+        th.querySelector('.hds-advanced-table__th-context-menu'),
+        'context menu exists',
+      );
 
-        const contextMenuToggle = th.querySelector('.hds-dropdown-toggle-icon');
+      await click(
+        findOrThrow('.hds-advanced-table__th .hds-dropdown-toggle-icon'),
+      );
 
-        if (contextMenuToggle) {
-          await click(contextMenuToggle);
-
-          assert
-            .dom('[data-test-context-option-key="reset-column-width"]')
-            .exists();
-        }
-      }
+      assert
+        .dom('[data-test-context-option-key="reset-column-width"]')
+        .exists();
     });
 
     test('it should resize the column to the initial width when resetting column width', async function (assert) {
       await createResizableTable({});
 
-      const table = find('.hds-advanced-table');
+      const table = findOrThrow('.hds-advanced-table');
       const originalGridValues = getTableGridValues(table);
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
-      const th = handle?.closest('.hds-advanced-table__th');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
+      const th = findOrThrow('.hds-advanced-table__th');
 
       await simulateRightPointerDrag(handle);
 
-      let newGridValues = getTableGridValues(table);
+      const newGridValues = getTableGridValues(table);
 
       assert.notOk(
         gridValuesAreEqual(originalGridValues, newGridValues),
         'Grid values are not equal after resizing',
       );
 
-      if (th) {
-        await performContextMenuAction(th, 'reset-column-width');
+      await performContextMenuAction(th, 'reset-column-width');
+      await waitForLayout();
 
-        newGridValues = getTableGridValues(table);
-        assert.ok(
-          gridValuesAreEqual(originalGridValues, newGridValues),
-          'Grid values reset to initial state after resetting column width',
-        );
-      }
+      // asserted directly rather than against the initial grid snapshot, which a
+      // transient scroll bar at render time can skew
+      const resetTable = findOrThrow('.hds-advanced-table');
+      const firstColumn = findOrThrow('.hds-advanced-table__th');
+
+      assert.ok(
+        Math.abs(firstColumn.offsetWidth - 120) <= 1,
+        `first column reset to its initial 120px width (actual ${firstColumn.offsetWidth})`,
+      );
+      assert.ok(
+        Math.abs(
+          resetTable.offsetWidth -
+            (resetTable.parentElement as HTMLElement).offsetWidth,
+        ) <= 1,
+        'table fills its container after reset',
+      );
     });
 
-    test('it should restore a column with no explicit width back to its default when reset', async function (assert) {
+    test('it should restore a column with no explicit width to its original share when reset', async function (assert) {
       await createResizableTable({});
 
-      const table = find('.hds-advanced-table');
+      const table = findOrThrow('.hds-advanced-table');
       const originalGridValues = getTableGridValues(table);
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
 
-      // drag col1 left so it shrinks and col2 (no explicit width) grows into a pixel value
+      // drag col1 left so it shrinks and col2 (no explicit width) grows
       await simulateLeftPointerDrag(handle);
 
       assert.notOk(
@@ -407,54 +458,112 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
         'grid changed after resize',
       );
 
-      // find col2 by walking from col1's resize handle
-      const col1Th = handle?.closest('.hds-advanced-table__th');
-      const col2Th = col1Th?.nextElementSibling;
+      const col2Th = findAtOrThrow('.hds-advanced-table__th', 1);
 
       assert.ok(
-        col2Th?.querySelector('.hds-dropdown-toggle-icon'),
+        col2Th.querySelector('.hds-dropdown-toggle-icon'),
         'col2 has a context menu toggle',
       );
 
-      await performContextMenuAction(col2Th ?? null, 'reset-column-width');
+      await performContextMenuAction(col2Th, 'reset-column-width');
+      await waitForLayout();
 
+      await performContextMenuAction(
+        findAtOrThrow('.hds-advanced-table__th', 0),
+        'reset-column-width',
+      );
       await waitForLayout();
 
       assert.ok(
-        gridValuesAreEqual(originalGridValues, getTableGridValues(table)),
-        'grid returns to original after resetting column with no explicit width',
+        gridValuesAreEqual(getTableGridValues(table), originalGridValues),
+        'resetting every column restores the original grid',
+      );
+    });
+
+    test('resetting a column width is idempotent', async function (assert) {
+      await render(
+        <template>
+          <div {{style width="900px"}}>
+            <HdsAdvancedTable
+              id="reset-table"
+              @columns={{array
+                (hash key="a" label="A")
+                (hash key="b" label="B")
+                (hash key="c" label="C")
+              }}
+              @model={{array
+                (hash a="a1" b="b1" c="c1")
+                (hash a="a2" b="b2" c="c2")
+              }}
+              @hasResizableColumns={{true}}
+            >
+              <:body as |B|>
+                <B.Tr>
+                  <B.Td>{{get B.data "a"}}</B.Td>
+                  <B.Td>{{get B.data "b"}}</B.Td>
+                  <B.Td>{{get B.data "c"}}</B.Td>
+                </B.Tr>
+              </:body>
+            </HdsAdvancedTable>
+          </div>
+        </template>,
+      );
+
+      await waitForLayout();
+
+      const widths = () =>
+        [0, 1, 2].map((index) => columnWidth('#reset-table', index));
+      const resetEveryColumn = async () => {
+        for (const index of [0, 1, 2]) {
+          await performContextMenuAction(
+            findAtOrThrow('#reset-table .hds-advanced-table__th', index),
+            'reset-column-width',
+          );
+          await waitForLayout();
+        }
+      };
+
+      const originalWidths = widths();
+
+      await simulatePointerDrag(
+        findOrThrow('#reset-table .hds-advanced-table__th-resize-handle'),
+        250,
+      );
+
+      assert.notDeepEqual(
+        widths(),
+        originalWidths,
+        'the drag actually changed the column widths',
+      );
+
+      await resetEveryColumn();
+
+      const afterFirstPass = widths();
+
+      assert.deepEqual(
+        afterFirstPass,
+        originalWidths,
+        'resetting every column returns the table to its original layout',
+      );
+
+      await resetEveryColumn();
+
+      assert.deepEqual(
+        widths(),
+        afterFirstPass,
+        'resetting already-reset columns leaves every width unchanged',
       );
     });
 
     test('it should focus the resize handle when the "resize column" context menu option is clicked', async function (assert) {
       await createResizableTable({});
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
-      const th = handle?.closest('.hds-advanced-table__th');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
+      const th = findOrThrow('.hds-advanced-table__th');
 
-      if (th) {
-        await performContextMenuAction(th, 'resize-column');
-        assert.ok(
-          handle === document.activeElement,
-          'Resize handle is focused',
-        );
-      }
-    });
+      await performContextMenuAction(th, 'resize-column');
 
-    test('it should call `onColumnResize` when a column is resized by dragging', async function (assert) {
-      const onColumnResizeSpy = sinon.spy();
-      await createResizableTable({
-        onColumnResize: onColumnResizeSpy,
-      });
-
-      const handle = find('.hds-advanced-table__th-resize-handle');
-
-      if (handle) {
-        await focus(handle);
-        await triggerKeyEvent(handle, 'keydown', 'ArrowRight');
-
-        assert.ok(onColumnResizeSpy.calledOnce, 'onColumnResize was called');
-      }
+      assert.ok(handle === document.activeElement, 'Resize handle is focused');
     });
 
     test('it should call `onColumnResize` when a column is resized by keyboard', async function (assert) {
@@ -463,42 +572,72 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
         onColumnResize: onColumnResizeSpy,
       });
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
+
+      await focus(handle);
+      await triggerKeyEvent(handle, 'keydown', 'ArrowRight');
+      await waitForLayout();
+
+      assert.ok(onColumnResizeSpy.calledOnce, 'onColumnResize was called');
+      assertReportedPixelWidth(
+        assert,
+        onColumnResizeSpy,
+        '.hds-advanced-table__th',
+        'keyboard',
+      );
+    });
+
+    test('it should call `onColumnResize` when a column is resized by dragging', async function (assert) {
+      const onColumnResizeSpy = sinon.spy();
+      await createResizableTable({
+        onColumnResize: onColumnResizeSpy,
+      });
+
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
 
       // Simulate pointer drag to the right (increase width)
       await simulateRightPointerDrag(handle);
 
       assert.ok(onColumnResizeSpy.calledOnce, 'onColumnResize was called');
+      assertReportedPixelWidth(
+        assert,
+        onColumnResizeSpy,
+        '.hds-advanced-table__th',
+        'drag',
+      );
     });
 
     test('it should call `onColumnResize` when a column width is reset', async function (assert) {
-      const onColumnResizeSpy = sinon.spy((key) => {
-        console.log('Column resized', key);
-      });
+      const onColumnResizeSpy = sinon.spy();
 
       await createResizableTable({
         onColumnResize: onColumnResizeSpy,
       });
 
-      const handle = find('.hds-advanced-table__th-resize-handle');
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
 
       await simulateRightPointerDrag(handle);
 
       assert.ok(onColumnResizeSpy.calledOnce, 'onColumnResize was called');
 
-      if (handle) {
-        await performContextMenuAction(
-          handle.closest('.hds-advanced-table__th'),
-          'reset-column-width',
-        );
+      await performContextMenuAction(
+        findOrThrow('.hds-advanced-table__th'),
+        'reset-column-width',
+      );
 
-        await waitForLayout();
+      await waitForLayout();
 
-        assert.ok(
-          onColumnResizeSpy.calledTwice,
-          'onColumnResize was called again after resetting column width',
-        );
-      }
+      assert.strictEqual(
+        onColumnResizeSpy.callCount,
+        2,
+        'the reset reported the column it restored',
+      );
+      assertReportedPixelWidth(
+        assert,
+        onColumnResizeSpy,
+        '.hds-advanced-table__th',
+        'reset',
+      );
     });
 
     // Resize behavior tests
@@ -549,26 +688,149 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
         </template>,
       );
 
-      const table = find('#data-test-advanced-table');
-      const container = find('#resize-test-container');
+      const table = findOrThrow('#data-test-advanced-table');
+      const container = findOrThrow('#resize-test-container');
 
-      if (table && container) {
-        const tableAsHTMLElement = table as HTMLElement;
-        const containerAsHTMLElement = container as HTMLElement;
+      assert.ok(
+        table.offsetWidth >= container.offsetWidth,
+        'Table width is greater than the container width',
+      );
 
-        assert.ok(
-          tableAsHTMLElement.offsetWidth >= containerAsHTMLElement.offsetWidth,
-          'Table width is greater than the container width',
-        );
+      context.width = '100%';
+      await settled();
 
-        context.width = '100%';
-        await settled();
+      assert.strictEqual(
+        table.offsetWidth,
+        container.offsetWidth,
+        'Table width grows to fit container width',
+      );
+    });
 
-        assert.ok(
-          tableAsHTMLElement.offsetWidth === containerAsHTMLElement.offsetWidth,
-          'Table width grows to fit container width',
-        );
-      }
+    test('a resized column keeps the table filling its container when the container grows', async function (assert) {
+      const context = new TrackedObject({ width: '600px' });
+
+      await render(
+        <template>
+          <div id="repro-container" {{style width=context.width}}>
+            <HdsAdvancedTable
+              id="repro-table"
+              @columns={{array
+                (hash key="name" label="Name")
+                (hash key="type" label="Type")
+                (hash key="status" label="Status")
+              }}
+              @model={{array
+                (hash name="Alpha" type="One" status="Active")
+                (hash name="Beta" type="Two" status="Inactive")
+              }}
+              @hasResizableColumns={{true}}
+            >
+              <:body as |B|>
+                <B.Tr>
+                  <B.Td>{{get B.data "name"}}</B.Td>
+                  <B.Td>{{get B.data "type"}}</B.Td>
+                  <B.Td>{{get B.data "status"}}</B.Td>
+                </B.Tr>
+              </:body>
+            </HdsAdvancedTable>
+          </div>
+        </template>,
+      );
+
+      await waitForLayout();
+
+      const handle = findOrThrow(
+        '#repro-table .hds-advanced-table__th-resize-handle',
+      );
+      await simulateRightPointerDrag(handle);
+      await waitForLayout();
+
+      context.width = '1000px';
+      await settled();
+      await waitForLayout();
+
+      const table = findOrThrow('#repro-table');
+      const container = findOrThrow('#repro-container');
+
+      assert.ok(
+        Math.abs(table.offsetWidth - container.offsetWidth) <= 1,
+        `table still fills its container after it grows (table=${table.offsetWidth}, container=${container.offsetWidth})`,
+      );
+    });
+
+    test('resizing chains across columns when a neighbor reaches its minimum width', async function (assert) {
+      // four columns at ~250px each (min 150): dragging 300px is more than any
+      // single neighbor can give up, so the change must chain across the columns
+      await render(
+        <template>
+          <div {{style width="1000px"}}>
+            <HdsAdvancedTable
+              id="chain-table"
+              @columns={{array
+                (hash key="a" label="A")
+                (hash key="b" label="B")
+                (hash key="c" label="C")
+                (hash key="d" label="D")
+              }}
+              @model={{array
+                (hash a="a1" b="b1" c="c1" d="d1")
+                (hash a="a2" b="b2" c="c2" d="d2")
+              }}
+              @hasResizableColumns={{true}}
+            >
+              <:body as |B|>
+                <B.Tr>
+                  <B.Td>{{get B.data "a"}}</B.Td>
+                  <B.Td>{{get B.data "b"}}</B.Td>
+                  <B.Td>{{get B.data "c"}}</B.Td>
+                  <B.Td>{{get B.data "d"}}</B.Td>
+                </B.Tr>
+              </:body>
+            </HdsAdvancedTable>
+          </div>
+        </template>,
+      );
+
+      await waitForLayout();
+
+      const handle = findOrThrow(
+        '#chain-table .hds-advanced-table__th-resize-handle',
+      );
+
+      await simulatePointerDrag(handle, 400);
+
+      assert.ok(
+        columnWidth('#chain-table', 1) <= 152,
+        `second column reached its minimum width (actual ${columnWidth('#chain-table', 1)})`,
+      );
+      // the change chains past the immediate neighbor to the third column
+      assert.ok(
+        columnWidth('#chain-table', 2) < 240,
+        `third column also shrank, proving the chain continued (actual ${columnWidth('#chain-table', 2)})`,
+      );
+    });
+
+    test('the resize handle exposes accurate aria values after a resize', async function (assert) {
+      await createResizableTable({});
+
+      const handle = findOrThrow('.hds-advanced-table__th-resize-handle');
+
+      await simulateRightPointerDrag(handle);
+
+      const th = findOrThrow('.hds-advanced-table__th');
+      const renderedWidth = th.offsetWidth;
+      const valueNow = parseInt(handle.getAttribute('aria-valuenow') ?? '', 10);
+      const valueMax = parseInt(handle.getAttribute('aria-valuemax') ?? '', 10);
+
+      assert.ok(
+        valueNow > 0 && Math.abs(valueNow - renderedWidth) <= 2,
+        `aria-valuenow reflects the rendered pixel width (valuenow ${valueNow}, rendered ${renderedWidth})`,
+      );
+      assert.ok(
+        valueMax >= valueNow,
+        `aria-valuemax is present and not below the current value (max ${valueMax}, now ${valueNow})`,
+      );
+      assert.dom(handle).hasAttribute('aria-valuetext', `${valueNow}px`);
     });
   });
 });

--- a/showcase/tests/integration/components/hds/advanced-table/utils.ts
+++ b/showcase/tests/integration/components/hds/advanced-table/utils.ts
@@ -3,10 +3,22 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { settled } from '@ember/test-helpers';
+import { click, settled } from '@ember/test-helpers';
 
 export async function waitForLayout(): Promise<void> {
   await new Promise((resolve) => requestAnimationFrame(resolve));
 
   return settled();
+}
+
+export async function performContextMenuAction(th: Element, key: string) {
+  const contextMenuToggle = th.querySelector('.hds-dropdown-toggle-icon');
+
+  if (contextMenuToggle === null) {
+    throw new Error('expected the header cell to render a context menu toggle');
+  }
+
+  await click(contextMenuToggle);
+
+  return click(`[data-test-context-option-key="${key}"]`);
 }


### PR DESCRIPTION
### :pushpin: Summary

Refactors the `AdvancedTable` column resize behavior. The old approach coordinated resize across columns using a debt/credit ledger system that tracked borrowed widths between neighboring columns. This replaces it with a snapshot-based model: at the start of each drag gesture, all column widths are frozen to their current rendered pixel values, and delta distribution cascades outward from the drag boundary without any bookkeeping state.

### :hammer_and_wrench: Detailed description

- Removed the `_columnDebts` ledger and related methods from `column-manager/width.gts`.
- Replaced them with
  - `beginColumnResize()`: snapshots rendered widths
  - `resizeColumnByDelta()`: distributes delta outward from the drag boundary, respecting min/max
  - `commitColumnWidths()`: promotes transient widths to persistent state
- Removed `DEFAULT_MAX_WIDTH` — the table's own bounding width is now used as the natural cap.
- Simplified `th-resize-handle.gts` by removing the standalone delta-calculation function and `siblingColumnKeys` arg; all width math is now delegated to `resizeColumnByDelta`.
- Updated `th.gts` and `index.gts` to thread the new API and remove the unused props.

### :camera_flash: Screenshots

<img width="1174" height="505" alt="toggle" src="https://github.com/user-attachments/assets/49c7607e-d0cf-4cb2-a8ce-f2ad79df2fe3" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6533](https://hashicorp.atlassian.net/browse/HDS-6533)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6533]: https://hashicorp.atlassian.net/browse/HDS-6533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ