### PR TITLE
`Table`, `AdvancedTable`: add CSS class when a row is selected

### DIFF
--- a/.changeset/violet-webs-invent.md
+++ b/.changeset/violet-webs-invent.md
@@ -3,9 +3,9 @@
 ---
 
 <!-- START components/table/table -->
-`Table` - Added `.hds-table__tr--is-selected` class to table rows when they are selected to support Carbonization.
+`Table` - Added `.hds-table__tr--is-selected` class to table rows when they are selected.
 <!-- END -->
 
 <!-- START components/table/advanced-table -->
-`AdvancedTable` - Added `.hds-advanced-table__tr--is-selected` class to table rows when they are selected to support Carbonization.
+`AdvancedTable` - Added `.hds-advanced-table__tr--is-selected` class to table rows when they are selected.
 <!-- END -->

--- a/.changeset/violet-webs-invent.md
+++ b/.changeset/violet-webs-invent.md
@@ -1,0 +1,11 @@
+---
+"@hashicorp/design-system-components": minor
+---
+
+<!-- START components/table/table -->
+`Table` - Added `.hds-table__tr--is-selected` class to table rows when they are selected to support Carbonization.
+<!-- END -->
+
+<!-- START components/table/advanced-table -->
+`AdvancedTable` - Added `.hds-advanced-table__tr--is-selected` class to table rows when they are selected to support Carbonization.
+<!-- END -->

--- a/packages/components/src/components/hds/advanced-table/index.gts
+++ b/packages/components/src/components/hds/advanced-table/index.gts
@@ -238,6 +238,7 @@ export default class HdsAdvancedTable<
   @tracked private _isSelectAllCheckboxSelected?: boolean = undefined;
   @tracked private _tableHeight = 0;
   private _selectableRows: HdsAdvancedTableSelectableRow[] = [];
+  private _isBulkSelectionChange = false;
   private _captionId = 'caption-' + guidFor(this);
   private _scrollHandler!: (event: Event) => void;
   private _dragOverHandler!: (event: DragEvent) => void;
@@ -801,9 +802,14 @@ export default class HdsAdvancedTable<
 
   @action
   onSelectionAllChange(): void {
+    this._isBulkSelectionChange = true;
+
     this._selectableRows.forEach((row) => {
       row.checkbox.checked = this._selectAllCheckbox?.checked ?? false;
+      row.checkbox.dispatchEvent(new Event('change', { bubbles: true }));
     });
+
+    this._isBulkSelectionChange = false;
     this._isSelectAllCheckboxSelected =
       this._selectAllCheckbox?.checked ?? false;
     this.onSelectionChangeCallback(this._selectAllCheckbox, 'all');
@@ -814,6 +820,10 @@ export default class HdsAdvancedTable<
     checkbox?: HdsFormCheckboxBaseSignature['Element'],
     selectionKey?: string
   ): void {
+    if (this._isBulkSelectionChange) {
+      return;
+    }
+
     this.setSelectAllState();
     this.onSelectionChangeCallback(checkbox, selectionKey);
   }

--- a/packages/components/src/components/hds/advanced-table/tr.gts
+++ b/packages/components/src/components/hds/advanced-table/tr.gts
@@ -6,6 +6,7 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { hash } from '@ember/helper';
+import { tracked } from '@glimmer/tracking';
 import { eq } from 'ember-truth-helpers';
 
 import HdsAdvancedTableThSelectable from './th-selectable.gts';
@@ -87,6 +88,8 @@ export type HdsAdvancedTableTrSignature<T> = BaseHdsAdvancedTableTrSignature<T>;
 export default class HdsAdvancedTableTr<T> extends Component<
   HdsAdvancedTableTrSignature<T>
 > {
+  @tracked private isSelectedOverride?: boolean;
+
   get selectionKey(): string | undefined {
     if (this.args.isSelectable && this.args.selectionScope === 'row') {
       assert(
@@ -96,6 +99,11 @@ export default class HdsAdvancedTableTr<T> extends Component<
       return this.args.selectionKey;
     }
     return undefined;
+  }
+
+  // Carbon applies styles to the entire row when it is selected, so we need a state to track the selection state to toggle the appropriate class.
+  get isSelected(): boolean {
+    return this.isSelectedOverride ?? this.args.isSelected ?? false;
   }
 
   get classNames(): string {
@@ -116,6 +124,10 @@ export default class HdsAdvancedTableTr<T> extends Component<
 
     if (isLastRow) {
       classes.push('hds-advanced-table__tr--last-row');
+    }
+
+    if (this.isSelected) {
+      classes.push(`hds-advanced-table__tr--is-selected`);
     }
 
     return classes.join(' ');
@@ -156,6 +168,18 @@ export default class HdsAdvancedTableTr<T> extends Component<
     }
   }
 
+  onSelectionChange = (
+    checkbox?: HdsFormCheckboxBaseSignature['Element'],
+    selectionKey?: string
+  ): void => {
+    this.isSelectedOverride = checkbox?.checked ?? false;
+
+    const { onSelectionChange } = this.args;
+    if (typeof onSelectionChange === 'function') {
+      onSelectionChange(checkbox, selectionKey);
+    }
+  };
+
   <template>
     <div class={{this.classNames}} role="row" {{@compositeGroup}} ...attributes>
       {{#if @isSelectable}}
@@ -163,7 +187,7 @@ export default class HdsAdvancedTableTr<T> extends Component<
           role={{if (eq @selectionScope "row") "gridcell" "columnheader"}}
           @compositeItem={{@compositeItem}}
           @isCompositeItemDisabled={{@isCompositeItemDisabled}}
-          @isSelected={{@isSelected}}
+          @isSelected={{this.isSelected}}
           @selectionScope={{@selectionScope}}
           @selectionKey={{this.selectionKey}}
           @selectionAriaLabelSuffix={{@selectionAriaLabelSuffix}}
@@ -171,7 +195,7 @@ export default class HdsAdvancedTableTr<T> extends Component<
           @didInsert={{@didInsert}}
           @willDestroy={{@willDestroy}}
           @onClickSortBySelected={{@onClickSortBySelected}}
-          @onSelectionChange={{@onSelectionChange}}
+          @onSelectionChange={{this.onSelectionChange}}
           @isStickyColumn={{@hasStickyColumn}}
           @isStickyColumnPinned={{@isStickyColumnPinned}}
         />

--- a/packages/components/src/components/hds/table/index.gts
+++ b/packages/components/src/components/hds/table/index.gts
@@ -124,6 +124,7 @@ export default class HdsTable<T = HdsTableModel> extends Component<
     undefined;
   private _selectableRows: HdsTableSelectableRow[] = [];
   @tracked private _isSelectAllCheckboxSelected?: boolean = undefined;
+  private _isBulkSelectionChange = false;
 
   constructor(owner: Owner, args: HdsTableSignature<T>['Args']) {
     super(owner, args);
@@ -297,9 +298,14 @@ export default class HdsTable<T = HdsTableModel> extends Component<
   };
 
   onSelectionAllChange = (): void => {
+    this._isBulkSelectionChange = true;
+
     this._selectableRows.forEach((row) => {
       row.checkbox.checked = this._selectAllCheckbox?.checked ?? false;
+      row.checkbox.dispatchEvent(new Event('change', { bubbles: true }));
     });
+
+    this._isBulkSelectionChange = false;
     this._isSelectAllCheckboxSelected =
       this._selectAllCheckbox?.checked ?? false;
     this.onSelectionChangeCallback(this._selectAllCheckbox, 'all');
@@ -309,6 +315,10 @@ export default class HdsTable<T = HdsTableModel> extends Component<
     checkbox?: HdsFormCheckboxBaseSignature['Element'],
     selectionKey?: string
   ): void => {
+    if (this._isBulkSelectionChange) {
+      return;
+    }
+
     this.setSelectAllState();
     this.onSelectionChangeCallback(checkbox, selectionKey);
   };

--- a/packages/components/src/components/hds/table/tr.gts
+++ b/packages/components/src/components/hds/table/tr.gts
@@ -5,6 +5,7 @@
 
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import { tracked } from '@glimmer/tracking';
 
 // import { HdsTableScopeValues } from './types.ts';
 import HdsTableThSelectable from './th-selectable.gts';
@@ -60,6 +61,8 @@ export type HdsTableTrSignature = BaseHdsTableTrSignature;
 // | SelectableHdsTableTrArgs;
 
 export default class HdsTableTr extends Component<HdsTableTrSignature> {
+  @tracked private isSelectedOverride?: boolean;
+
   get selectionKey(): string | undefined {
     if (this.args.isSelectable && this.args.selectionScope === 'row') {
       assert(
@@ -71,11 +74,38 @@ export default class HdsTableTr extends Component<HdsTableTrSignature> {
     return undefined;
   }
 
+  // Carbon applies styles to the entire row when it is selected, so we need a state to track the selection state to toggle the appropriate class.
+  get isSelected(): boolean {
+    return this.isSelectedOverride ?? this.args.isSelected ?? false;
+  }
+
+  get classNames(): string {
+    const classes = ['hds-table__tr'];
+
+    if (this.isSelected) {
+      classes.push(`hds-table__tr--is-selected`);
+    }
+
+    return classes.join(' ');
+  }
+
+  onSelectionChange = (
+    checkbox?: HdsFormCheckboxBaseSignature['Element'],
+    selectionKey?: string
+  ): void => {
+    this.isSelectedOverride = checkbox?.checked ?? false;
+
+    const { onSelectionChange } = this.args;
+    if (typeof onSelectionChange === 'function') {
+      onSelectionChange(checkbox, selectionKey);
+    }
+  };
+
   <template>
-    <tr class="hds-table__tr" ...attributes>
+    <tr class={{this.classNames}} ...attributes>
       {{#if @isSelectable}}
         <HdsTableThSelectable
-          @isSelected={{@isSelected}}
+          @isSelected={{this.isSelected}}
           @selectionScope={{@selectionScope}}
           @selectionKey={{this.selectionKey}}
           @selectionAriaLabelSuffix={{@selectionAriaLabelSuffix}}
@@ -83,7 +113,7 @@ export default class HdsTableTr extends Component<HdsTableTrSignature> {
           @didInsert={{@didInsert}}
           @willDestroy={{@willDestroy}}
           @onClickSortBySelected={{@onClickSortBySelected}}
-          @onSelectionChange={{@onSelectionChange}}
+          @onSelectionChange={{this.onSelectionChange}}
         />
       {{/if}}
 

--- a/showcase/tests/integration/components/hds/advanced-table/features/multi-selection-test.gts
+++ b/showcase/tests/integration/components/hds/advanced-table/features/multi-selection-test.gts
@@ -86,6 +86,8 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
       '#data-test-selectable-advanced-table .hds-advanced-table__thead .hds-advanced-table__th[role="columnheader"] .hds-advanced-table__checkbox';
     const rowCheckboxesSelector =
       '#data-test-selectable-advanced-table .hds-advanced-table__tbody .hds-advanced-table__th .hds-advanced-table__checkbox';
+    const selectedRowsSelector =
+      '#data-test-selectable-advanced-table .hds-advanced-table__tbody .hds-advanced-table__tr--is-selected';
 
     test('it renders a multi-select table when isSelectable is set to true for a table with a model', async function (assert) {
       await createSelectableTable({});
@@ -106,6 +108,9 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
       await click(selectAllCheckboxSelector);
       assert.dom(selectAllCheckboxSelector).isChecked();
       assert.dom(rowCheckboxesSelector).isChecked().exists({ count: 3 });
+      assert
+        .dom(selectedRowsSelector)
+        .exists({ count: DEFAULT_SELECTABLE_MODEL.length });
     });
 
     test('it deselects all rows when the "select all" checkbox unchecked state is triggered', async function (assert) {
@@ -116,6 +121,24 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
       await click(selectAllCheckboxSelector);
       assert.dom(selectAllCheckboxSelector).isNotChecked();
       assert.dom(rowCheckboxesSelector).isNotChecked().exists({ count: 3 });
+      assert.dom(selectedRowsSelector).doesNotExist();
+    });
+
+    test('it toggles the selected row class when a row checkbox is clicked', async function (assert) {
+      await createSelectableTable({});
+
+      assert.dom(selectedRowsSelector).doesNotExist();
+
+      const rowCheckboxes = findAll(rowCheckboxesSelector);
+      const firstRowCheckbox = rowCheckboxes[0];
+
+      if (firstRowCheckbox) {
+        await click(firstRowCheckbox);
+        assert.dom(selectedRowsSelector).exists({ count: 1 });
+
+        await click(firstRowCheckbox);
+        assert.dom(selectedRowsSelector).doesNotExist();
+      }
     });
 
     test('if some rows are selected but not all, the "select all" checkbox should be in an indeterminate state', async function (assert) {

--- a/showcase/tests/integration/components/hds/advanced-table/tr-test.gts
+++ b/showcase/tests/integration/components/hds/advanced-table/tr-test.gts
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { render, click, setupOnerror } from '@ember/test-helpers';
-import { TrackedObject } from 'tracked-built-ins';
+import { tracked, TrackedObject } from 'tracked-built-ins';
 
 import { HdsAdvancedTableTr } from '@hashicorp/design-system-components/components';
 
@@ -85,6 +85,68 @@ module('Integration | Component | hds/advanced-table/tr', function (hooks) {
       </template>,
     );
     assert.dom(checkboxSelector).isChecked();
+  });
+
+  test('it should toggle the selected row class when the checkbox is clicked', async function (assert) {
+    await render(
+      <template>
+        <HdsAdvancedTableTr
+          id="data-test-advanced-table-tr"
+          @isSelectable={{true}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom('#data-test-advanced-table-tr')
+      .doesNotHaveClass('hds-advanced-table__tr--is-selected');
+
+    await click(checkboxSelector);
+    assert
+      .dom('#data-test-advanced-table-tr')
+      .hasClass('hds-advanced-table__tr--is-selected');
+
+    await click(checkboxSelector);
+    assert
+      .dom('#data-test-advanced-table-tr')
+      .doesNotHaveClass('hds-advanced-table__tr--is-selected');
+  });
+
+  test('it should toggle the selected row class when @isSelected is provided', async function (assert) {
+    const context = tracked<{ selectionChangeCount: number }>({
+      selectionChangeCount: 0,
+    });
+
+    const onSelectionChange = () => {
+      context.selectionChangeCount += 1;
+    };
+
+    await render(
+      <template>
+        <HdsAdvancedTableTr
+          id="data-test-advanced-table-tr"
+          @isSelectable={{true}}
+          @isSelected={{false}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom('#data-test-advanced-table-tr')
+      .doesNotHaveClass('hds-advanced-table__tr--is-selected');
+
+    await click(checkboxSelector);
+    assert.strictEqual(context.selectionChangeCount, 1);
+    assert
+      .dom('#data-test-advanced-table-tr')
+      .hasClass('hds-advanced-table__tr--is-selected');
+
+    await click(checkboxSelector);
+    assert.strictEqual(context.selectionChangeCount, 2);
+    assert
+      .dom('#data-test-advanced-table-tr')
+      .doesNotHaveClass('hds-advanced-table__tr--is-selected');
   });
 
   test('the checkbox contains the `@selectionAriaLabelSuffix` suffix', async function (assert) {

--- a/showcase/tests/integration/components/hds/table/index-test.gts
+++ b/showcase/tests/integration/components/hds/table/index-test.gts
@@ -534,6 +534,8 @@ module('Integration | Component | hds/table/index', function (hooks) {
     '#data-test-selectable-table thead th[scope="col"] .hds-table__checkbox';
   const rowCheckboxesSelector =
     '#data-test-selectable-table tbody th[scope="row"] .hds-table__checkbox';
+  const selectableRowsSelector =
+    '#data-test-selectable-table tbody .hds-table__tr';
 
   // basic multi-select
 
@@ -593,6 +595,9 @@ module('Integration | Component | hds/table/index', function (hooks) {
     await click(selectAllCheckboxSelector);
     assert.dom(selectAllCheckboxSelector).isChecked();
     assert.dom(rowCheckboxesSelector).isChecked().exists({ count: 3 });
+    assert
+      .dom(`${selectableRowsSelector}.hds-table__tr--is-selected`)
+      .exists({ count: 3 });
   });
 
   test('it deselects all rows when the "select all" checkbox unchecked state is triggered', async function (assert) {
@@ -603,6 +608,9 @@ module('Integration | Component | hds/table/index', function (hooks) {
     await click(selectAllCheckboxSelector);
     assert.dom(selectAllCheckboxSelector).isNotChecked();
     assert.dom(rowCheckboxesSelector).isNotChecked().exists({ count: 3 });
+    assert
+      .dom(`${selectableRowsSelector}.hds-table__tr--is-selected`)
+      .doesNotExist();
   });
 
   test('if some rows are selected but not all, the "select all" checkbox should be in an indeterminate state', async function (assert) {

--- a/showcase/tests/integration/components/hds/table/tr-test.gts
+++ b/showcase/tests/integration/components/hds/table/tr-test.gts
@@ -5,6 +5,7 @@
 
 import { module, test } from 'qunit';
 import { render, click, setupOnerror } from '@ember/test-helpers';
+import { tracked } from 'tracked-built-ins';
 
 import { HdsTableTr } from '@hashicorp/design-system-components/components';
 
@@ -60,6 +61,61 @@ module('Integration | Component | hds/table/tr', function (hooks) {
       </template>,
     );
     assert.dom(checkboxSelector).isChecked();
+  });
+
+  test('it should toggle the selected row class when the checkbox is clicked', async function (assert) {
+    await render(
+      <template>
+        <HdsTableTr id="data-test-table-tr" @isSelectable={{true}} />
+      </template>,
+    );
+
+    assert
+      .dom('#data-test-table-tr')
+      .doesNotHaveClass('hds-table__tr--is-selected');
+
+    await click(checkboxSelector);
+    assert.dom('#data-test-table-tr').hasClass('hds-table__tr--is-selected');
+
+    await click(checkboxSelector);
+    assert
+      .dom('#data-test-table-tr')
+      .doesNotHaveClass('hds-table__tr--is-selected');
+  });
+
+  test('it should toggle the selected row class when @isSelected is provided', async function (assert) {
+    const context = tracked<{ selectionChangeCount: number }>({
+      selectionChangeCount: 0,
+    });
+
+    const onSelectionChange = () => {
+      context.selectionChangeCount += 1;
+    };
+
+    await render(
+      <template>
+        <HdsTableTr
+          id="data-test-table-tr"
+          @isSelectable={{true}}
+          @isSelected={{false}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom('#data-test-table-tr')
+      .doesNotHaveClass('hds-table__tr--is-selected');
+
+    await click(checkboxSelector);
+    assert.strictEqual(context.selectionChangeCount, 1);
+    assert.dom('#data-test-table-tr').hasClass('hds-table__tr--is-selected');
+
+    await click(checkboxSelector);
+    assert.strictEqual(context.selectionChangeCount, 2);
+    assert
+      .dom('#data-test-table-tr')
+      .doesNotHaveClass('hds-table__tr--is-selected');
   });
 
   test('the checkbox contains the `@selectionAriaLabelSuffix` suffix', async function (assert) {


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would cherry pick the changes to Table and AdvancedTable in the Carbonization PR: https://github.com/hashicorp/design-system/pull/3988

The class does not change any styles now, it will happen when project solar is merged.

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>