### PR TITLE
AI instructions: Release notes updates

### DIFF
--- a/.bob/skills/add-release-notes/SKILL.md
+++ b/.bob/skills/add-release-notes/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: add-release-notes
+description: "Update release notes prior to a release of the @hashicorp/design-system-components package"
+---
+
+## Context
+
+This skill provides instructions on how to update changelogs and website docs with release notes prior to a release of the `@hashicorp/design-system-components` package from `packages/components`. It is to be run on the `changeset-release/main` branch prior to the PR for that branch being merged to trigger a release.
+
+## Non-negotiables
+
+- Do not run this skill on any branch except for `changeset-release/main`
+- Do not push any changes to the git remote
+
+## Procedure
+
+1. Review changelog entries
+  - In `packages/components/CHANGELOG.md` review all of the entries related to components in the upcoming release to ensure they follow the rules listed in `.bob/rules/directories/components/changeset.instructions.md`
+  - Check that all of the `<!-- START {components/path} -->` paths match those component's docs path in `website/docs`
+  - Raise any issues caught with the user and wait for their response to proceed
+
+2. Update the components package release notes
+  - Determine the new package release version number from `packages/components/package.json`
+  - Open `packages/components/CHANGELOG.md`
+  - Add a link to the upcoming components package release after the heading for that release
+    - Example: `[X.Y.Z documentation](https://hds-website-X-Y-Z.vercel.app/)`
+  - In the root of the repo, run `pnpm --filter website run generate-changelog-markdown-files`
+    - This will copy content from `packages/components/CHANGELOG.md` to `website/docs/whats-new/release-notes/index.md`
+  - Make a commit with these changes with the message `Chore: Add link to X.Y.Z docs`.
+
+3. Update website version history and release badges for changed components
+  - In the root of the repo, run `pnpm --filter website run generate-component-changelog-entries`
+    - This will copy relevant changelog entries for each component from the main `packages/components/CHANGELOG.md` to `website/docs/components/[component-name]/partials/version-history/version-history.md`
+    - It will update the frontmatter:
+      - Removes any previous badges if the new release is a minor or major release.
+      - Sets the current version in `status.updated` for each changed component.
+  - Review each changed component doc:
+    - Check all entries have been copied to the component's `version-history.md` file
+      - If a component's `version-history.md` file was newly created, add a new section into the `index.md` file
+        ```
+          <section data-tab="Version history">
+            @include "partials/version-history/version-history.md"
+          </section>
+        ```
+    - If a component is new for this release, change `status.updated` to `status.added` in `index.md` frontmatter.
+  - Make a commit with these changes with the message `Chore: Update badges and website history of components`.

--- a/.bob/skills/add-release-notes/SKILL.md
+++ b/.bob/skills/add-release-notes/SKILL.md
@@ -10,7 +10,7 @@ This skill provides instructions on how to update changelogs and website docs wi
 ## Non-negotiables
 
 - Do not run this skill on any branch except for `changeset-release/main`
-- Do not push any changes to the git remote
+- Do not commit any changes or push any changes to the git remote
 
 ## Procedure
 
@@ -26,7 +26,7 @@ This skill provides instructions on how to update changelogs and website docs wi
     - Example: `[X.Y.Z documentation](https://hds-website-X-Y-Z.vercel.app/)`
   - In the root of the repo, run `pnpm --filter website run generate-changelog-markdown-files`
     - This will copy content from `packages/components/CHANGELOG.md` to `website/docs/whats-new/release-notes/index.md`
-  - Make a commit with these changes with the message `Chore: Add link to X.Y.Z docs`.
+  - STOP and wait for a user to review and commit these changes before proceeding
 
 3. Update website version history and release badges for changed components
   - In the root of the repo, run `pnpm --filter website run generate-component-changelog-entries`
@@ -43,4 +43,3 @@ This skill provides instructions on how to update changelogs and website docs wi
           </section>
         ```
     - If a component is new for this release, change `status.updated` to `status.added` in `index.md` frontmatter.
-  - Make a commit with these changes with the message `Chore: Update badges and website history of components`.


### PR DESCRIPTION
### :pushpin: Summary

This PR adds a new skill `add-release-notes` which performs the actions on the Version Packages PR to perform docs tasks needed before a release such as
- Adding a release vercel alias link
- Copying changelog entries from the `CHANGELOG.md` to the website
- Moving changelog entries to each component's version history file
- Updating component status badges

These instructions are based on those available in our [Release Procedure documentation](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3511910428/Release+procedure#Update-the-release-notes)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6554](https://hashicorp.atlassian.net/browse/HDS-6554)
***

### :eyes: Component checklist
:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6554]: https://hashicorp.atlassian.net/browse/HDS-6554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ