### PR TITLE
Set permissions for github workflows

### DIFF
--- a/.github/workflows/ci-compress-images.yml
+++ b/.github/workflows/ci-compress-images.yml
@@ -10,6 +10,9 @@ env:
 jobs:
   build:
     name: Compress Images & Open PR
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/open-pull-request-for-icon-update.yml
+++ b/.github/workflows/open-pull-request-for-icon-update.yml
@@ -9,6 +9,9 @@ env:
 jobs:
   sync_iconset:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install PNPM

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -18,6 +18,9 @@ env:
 jobs:
   release-candidate:
     name: Release Candidate
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'release-candidate')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would set explicit permissions for Github actions which use the Github token per recent rules now requiring such permissions to be set explicitly.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6557](https://hashicorp.atlassian.net/browse/HDS-6557)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6557]: https://hashicorp.atlassian.net/browse/HDS-6557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ