### PR TITLE
FilterBar - Support wrapping content in `ActionGeneric`

### DIFF
--- a/.changeset/bitter-cups-wink.md
+++ b/.changeset/bitter-cups-wink.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/filter-bar -->
+`FilterBar` - Added support for `ActionsGeneric` wrapping to new line
+<!-- END -->

--- a/packages/components/src/components/hds/filter-bar/index.gts
+++ b/packages/components/src/components/hds/filter-bar/index.gts
@@ -358,51 +358,52 @@ export default class HdsFilterBar extends Component<HdsFilterBarSignature> {
             default="Filters will be applied automatically as selections are made"
           }}</span>
       {{/if}}
-      <HdsLayoutFlex @align="center" @gap="8" class="hds-filter-bar__actions">
-        <HdsButton
-          @text={{hdsT
-            "hds.components.filter-bar.applied-filters.toggle-button"
-            default="View applied filters"
-          }}
-          @color="secondary"
-          @size="small"
-          @icon={{if this._isExpanded "unfold-close" "unfold-open"}}
-          @isIconOnly={{true}}
-          id={{this._appliedFiltersButtonId}}
-          aria-controls={{this._appliedFiltersContentId}}
-          aria-expanded={{if this._isExpanded "true" "false"}}
-          class="hds-filter-bar__applied-filters-toggle-button"
-          {{on "click" this.toggleExpand}}
-        />
-        {{yield
-          (hash
-            FiltersDropdown=(component
-              HdsFilterBarFiltersDropdown
-              filters=@filters
-              isLiveFilter=@isLiveFilter
-              onFilter=this.onFilter
-            )
-          )
-        }}
-        {{#if @hasSearch}}
-          <HdsFormTextInputBase
-            @type="search"
-            @value={{this.searchValue}}
-            class="hds-filter-bar__search"
-            placeholder={{this.searchPlaceholder}}
-            aria-label={{this.searchAriaLabel}}
-            name="search"
-            {{on "change" this.onSearch}}
+      <HdsLayoutFlex
+        @align="center"
+        @wrap={{true}}
+        @gap="8"
+        class="hds-filter-bar__actions"
+      >
+        <div class="hds-filter-bar__actions__left">
+          <HdsButton
+            @text={{hdsT
+              "hds.components.filter-bar.applied-filters.toggle-button"
+              default="View applied filters"
+            }}
+            @color="secondary"
+            @size="small"
+            @icon={{if this._isExpanded "unfold-close" "unfold-open"}}
+            @isIconOnly={{true}}
+            id={{this._appliedFiltersButtonId}}
+            aria-controls={{this._appliedFiltersContentId}}
+            aria-expanded={{if this._isExpanded "true" "false"}}
+            class="hds-filter-bar__applied-filters-toggle-button"
+            {{on "click" this.toggleExpand}}
           />
-        {{/if}}
-        <HdsLayoutFlex
-          @gap="8"
-          @align="center"
-          class="hds-filter-bar__actions__right"
-        >
-          {{yield (hash ActionsGeneric=HdsYield)}}
-          {{yield (hash ActionsDropdown=HdsFilterBarActionsDropdown)}}
-        </HdsLayoutFlex>
+          {{yield
+            (hash
+              FiltersDropdown=(component
+                HdsFilterBarFiltersDropdown
+                filters=@filters
+                isLiveFilter=@isLiveFilter
+                onFilter=this.onFilter
+              )
+            )
+          }}
+          {{#if @hasSearch}}
+            <HdsFormTextInputBase
+              @type="search"
+              @value={{this.searchValue}}
+              class="hds-filter-bar__search"
+              placeholder={{this.searchPlaceholder}}
+              aria-label={{this.searchAriaLabel}}
+              name="search"
+              {{on "change" this.onSearch}}
+            />
+          {{/if}}
+        </div>
+        {{yield (hash ActionsGeneric=HdsYield)}}
+        {{yield (hash ActionsDropdown=HdsFilterBarActionsDropdown)}}
       </HdsLayoutFlex>
       <div
         class="hds-filter-bar__applied-filters-list"

--- a/packages/components/src/styles/components/filter-bar.scss
+++ b/packages/components/src/styles/components/filter-bar.scss
@@ -31,6 +31,10 @@
   align-items: center;
 }
 
+// Setting `margin-right: auto` on the last element of the toggle, filters dropdown,
+// or search fills the leftover space and shoves the right-side items
+// (ActionsGeneric, ActionsDropdown) to the end of the row. Using `margin-left:
+// auto` on those right-side items instead would break row wrapping.
 .hds-filter-bar__actions__left {
   display: contents;
 

--- a/packages/components/src/styles/components/filter-bar.scss
+++ b/packages/components/src/styles/components/filter-bar.scss
@@ -31,8 +31,12 @@
   align-items: center;
 }
 
-.hds-filter-bar__actions__right {
-  margin-left: auto;
+.hds-filter-bar__actions__left {
+  display: contents;
+
+  > :last-child {
+    margin-right: auto;
+  }
 }
 
 .hds-filter-bar__search.hds-form-text-input {

--- a/showcase/app/components/page-components/filter-bar/code-fragments/with-generic-content.gts
+++ b/showcase/app/components/page-components/filter-bar/code-fragments/with-generic-content.gts
@@ -74,7 +74,7 @@ export default class CodeFragmentWithGenericContent extends Component<CodeFragme
     >
       {{#if @hasActionsGeneric}}
         <F.ActionsGeneric>
-          <ShwPlaceholder @text="generic content" @height="24" />
+          <ShwPlaceholder @text="generic content" @width="300" @height="24" />
         </F.ActionsGeneric>
       {{/if}}
       {{#if @hasActionsDropdown}}


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would update the `FilterBar` to support content wrapping to multiple lines when overflowing on narrower viewports. This is specifically related to supporting wider content within the `ActionsGeneric`.

[PREVIEW](https://hds-showcase-git-dchyun-filter-bar-wrapping-hashicorp.vercel.app/components/filter-bar)

### :hammer_and_wrench: Detailed description

Currently in the `FilterBar` the content does not wrap to multiple lines, across all viewports. This means if the content a consumer is using inside the `ActionsGeneric` is wide enough, on narrower viewports that content will become squished, or cause an overflow.

To support wider content within the `ActionsGeneric`, such as groups of buttons, the component has been updated to wrap to multiple lines.

### :camera_flash: Screenshots

**Before**

<img width="590" height="93" alt="Screenshot 2026-08-04 at 9 25 30 AM" src="https://github.com/user-attachments/assets/ff1272a7-29b6-4fa8-83fa-ebfd5b99c6b3" />

**After**

<img width="547" height="124" alt="Screenshot 2026-08-04 at 9 13 18 AM" src="https://github.com/user-attachments/assets/9e7d03be-776b-4d51-a14a-b0324018be05" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6559](https://hashicorp.atlassian.net/browse/HDS-6559)
Figma file: [File](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/branch/epOTcJuNapoPyQ9I5PNqJl/HDS-Components-v2.0?m=auto&node-id=108933-5153&t=b3XYyDHW9TDkjTuq-1)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6559]: https://hashicorp.atlassian.net/browse/HDS-6559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ