### PR TITLE
AdvancedTable - Reordering handle and empty state + tooltip visual bugs

### DIFF
--- a/.changeset/wise-socks-read.md
+++ b/.changeset/wise-socks-read.md
@@ -1,0 +1,11 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/table/advanced-table -->
+`AdvancedTable` - Updated reorder handle to not be visible on resize handle hover / focus
+<!-- END -->
+
+<!-- START components/table/advanced-table -->
+`AdvancedTable` - Fixed an issue where the table header tooltip was not visible with the table empty state
+<!-- END -->

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -789,6 +789,7 @@ $hds-advanced-table-drag-preview-background-color: rgba(204, 227, 254, 30%);
 // EMPTY STATE
 
 .hds-advanced-table:has(+ .hds-advanced-table__empty-state) {
+  overflow: visible;
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 

--- a/packages/components/src/styles/components/advanced-table.scss
+++ b/packages/components/src/styles/components/advanced-table.scss
@@ -113,10 +113,12 @@ $hds-advanced-table-drag-preview-background-color: rgba(204, 227, 254, 30%);
         isolation: isolate;
       }
 
+      // The reorder should be visible on hover or focus of the header cell, but not on hover or focus of the resize handle
       &:hover,
       &.mock-hover,
       &:focus-within {
-        .hds-advanced-table__th-reorder-handle {
+        &:not(:has(.hds-advanced-table__th-resize-handle:hover, .hds-advanced-table__th-resize-handle:focus))
+          .hds-advanced-table__th-reorder-handle {
           visibility: visible;
           opacity: 1;
         }

--- a/showcase/app/components/page-components/advanced-table/sub-sections/empty-state.gts
+++ b/showcase/app/components/page-components/advanced-table/sub-sections/empty-state.gts
@@ -16,7 +16,12 @@ import {
 } from '@hashicorp/design-system-components/components';
 
 const DEFAULT_COLUMNS = [
-  { key: 'id', label: 'ID' },
+  {
+    key: 'id',
+    label: 'ID',
+    tooltip: 'Unique identifier for the user',
+    isSortable: true,
+  },
   { key: 'name', label: 'Name' },
   { key: 'email', label: 'Email' },
   { key: 'role', label: 'Role' },
@@ -32,6 +37,7 @@ const SubSectionEmptyState: TemplateOnlyComponent = <template>
   <HdsAdvancedTable
     @model={{EMPTY_MODEL}}
     @columns={{DEFAULT_COLUMNS}}
+    @hasResizableColumns={{true}}
     @maxHeight="400px"
   />
 
@@ -42,6 +48,7 @@ const SubSectionEmptyState: TemplateOnlyComponent = <template>
   <HdsAdvancedTable
     @model={{EMPTY_MODEL}}
     @columns={{DEFAULT_COLUMNS}}
+    @hasResizableColumns={{true}}
     @maxHeight="400px"
   >
     <:emptyState>
@@ -62,6 +69,7 @@ const SubSectionEmptyState: TemplateOnlyComponent = <template>
   <HdsAdvancedTable
     @model={{EMPTY_MODEL}}
     @columns={{DEFAULT_COLUMNS}}
+    @hasResizableColumns={{true}}
     @maxHeight="400px"
   >
     <:emptyState>


### PR DESCRIPTION
### :pushpin: Summary

This PR addresses bugs in the `AdvancedTable` for the following issues

- On hover / focus of the table column resize handle the reorder handle is still visisble
- When the table is in its empty state the tooltips from a table column header are not visible

Previews: 
- [Resize](https://hds-showcase-git-dchyun-advanced-table-visual-bugs-hashicorp.vercel.app/components/advanced-table#resizable-and-reorderable-columns)
- [Empty state](https://hds-showcase-git-dchyun-advanced-table-visual-bugs-hashicorp.vercel.app/components/advanced-table#empty-state)

### :hammer_and_wrench: Detailed description

#### Resize handle + reorder

Currently, if a table both has column resizing and reordering, on hover of the table column resize handle the reorder handle is also visible. The styles have been updated so that the reorder handle is only shown on a hover / focus within the header cell excluding the resize handle.

#### Table empty state + tooltip

Currently, in a table with an `EmptyState` if the table's headers have a tooltip, it is getting cut off by the empty state. This has been updated to remove the `overflow: hidden` on the table when it is in empty state view.

### :camera_flash: Screenshots

**Resize handle - Before**

https://github.com/user-attachments/assets/07973a74-f4e1-45c2-bf88-249d06d143b2

**Resize handle - After**

https://github.com/user-attachments/assets/8595c86b-3b74-4098-90fe-e8de14b24dcc

**Empty state - Before**
<img width="1115" height="475" alt="Screenshot 2026-08-04 at 1 47 09 PM" src="https://github.com/user-attachments/assets/d28989c2-e56a-4d3c-ac9b-7da7f7294c88" />

**Empty state - After**
<img width="1107" height="475" alt="Screenshot 2026-08-04 at 1 47 24 PM" src="https://github.com/user-attachments/assets/312e9e8b-2297-4a4b-bbca-3a3c550d5f0d" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6573](https://hashicorp.atlassian.net/browse/HDS-6573)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6573]: https://hashicorp.atlassian.net/browse/HDS-6573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ