### PR TITLE
`AdvancedTable`: fix bottom scroll indicator + reorderable columns

### DIFF
--- a/.changeset/happy-pots-push.md
+++ b/.changeset/happy-pots-push.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/table/advanced-table -->
+`AdvancedTable` - Fixed bug where the bottom scroll indicator was always present if reordering was enabled.
+<!-- END -->

--- a/packages/components/src/components/hds/advanced-table/index.gts
+++ b/packages/components/src/components/hds/advanced-table/index.gts
@@ -272,6 +272,27 @@ export default class HdsAdvancedTable<
       this.showScrollIndicatorRight = element.clientWidth < element.scrollWidth;
     };
 
+    const updateBottomScrollIndicator = () => {
+      // when hasReorderableColumns is true, the reorder handles are absolutely
+      // positioned with translateY(50%), which causes them to overflow the
+      // header's bottom edge by half their height, inflating scrollHeight even
+      // when there is no actual scrollable content. visibility:hidden means
+      // getBoundingClientRect() returns zeros at mount time, so we use
+      // offsetHeight / 2 instead.
+      let reorderHandleOverflow = 0;
+      if (this.args.hasReorderableColumns) {
+        const firstHandle = this._theadElement?.querySelector(
+          '.hds-advanced-table__th-reorder-handle'
+        ) as HTMLElement;
+        if (firstHandle) {
+          reorderHandleOverflow = firstHandle.offsetHeight / 2;
+        }
+      }
+
+      this.showScrollIndicatorBottom =
+        element.scrollHeight - reorderHandleOverflow - element.clientHeight > 0;
+    };
+
     this._scrollHandler = () => {
       this._updateScrollIndicators(element);
     };
@@ -379,6 +400,7 @@ export default class HdsAdvancedTable<
       entries.forEach(() => {
         updateMeasurements();
         updateHorizontalScrollIndicators();
+        updateBottomScrollIndicator();
       });
     });
 
@@ -390,9 +412,7 @@ export default class HdsAdvancedTable<
     updateHorizontalScrollIndicators();
 
     // on render check if should show bottom scroll indicator
-    if (element.clientHeight < element.scrollHeight) {
-      this.showScrollIndicatorBottom = true;
-    }
+    updateBottomScrollIndicator();
 
     return () => {
       element.removeEventListener('scroll', this._scrollHandler);


### PR DESCRIPTION
### :pushpin: Summary

Currently, if reorderable columns is enabled, the bottom scroll indicator is always present. This is because the reorder handle affects the height way the height of the table is calculated. This PR fixes this issue.

* [Current showcase](https://hds-showcase.vercel.app/components/advanced-table#reorderable-columns)
* [Fixed showcase](https://hds-showcase-git-fix-advanced-table-reorder-sc-f51624-hashicorp.vercel.app/components/advanced-table#reorderable-columns)

This was discovered in https://github.com/hashicorp/design-system/pull/3988

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>