### PR TITLE
`AdvancedTable`: fix sorting table doesnt change keyboard order

### DIFF
--- a/.changeset/shaggy-icons-find.md
+++ b/.changeset/shaggy-icons-find.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/table/advanced-table -->
+`AdvancedTable` - Fixed issue where keyboard order did not match visual order after sorting the table.
+<!-- END -->

--- a/packages/components/src/components/hds/composite/index.gts
+++ b/packages/components/src/components/hds/composite/index.gts
@@ -193,6 +193,12 @@ export default class Composite extends Component<HdsCompositeSignature> {
     };
   }
 
+  private _resortRegisteredElements(): void {
+    this._groups = sortByDOMPosition(this._groups);
+    this._items = sortByDOMPosition(this._items);
+    this._reassociateGroups();
+  }
+
   private _registerItem(newItem: HdsCompositeItem): void {
     newItem.groupId = findGroupId(newItem.element, this._groups);
 
@@ -340,6 +346,8 @@ export default class Composite extends Component<HdsCompositeSignature> {
         if (managedKeys.includes(event.key)) {
           event.preventDefault();
         }
+
+        this._resortRegisteredElements();
 
         const target = handleKey(event, this._navigationSnapshot, this._config);
 

--- a/showcase/tests/integration/components/hds/advanced-table/features/sorting-test.gts
+++ b/showcase/tests/integration/components/hds/advanced-table/features/sorting-test.gts
@@ -5,7 +5,14 @@
 
 import { module, test } from 'qunit';
 import { array, hash, get } from '@ember/helper';
-import { click, focus, render, settled } from '@ember/test-helpers';
+import {
+  click,
+  focus,
+  render,
+  settled,
+  triggerKeyEvent,
+  find,
+} from '@ember/test-helpers';
 import { TrackedObject } from 'tracked-built-ins';
 import sinon from 'sinon';
 
@@ -534,6 +541,53 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
         sortSpy.calledWith('isSelected', 'asc'),
         'it invokes the `onSort` callback with the `selectableColumnKey` when a sort is performed on the selectable column',
       );
+    });
+
+    test('it should navigate rows in sorted visual order after sorting', async function (assert) {
+      await createSortableTable({});
+
+      // check initial order
+      assert
+        .dom(
+          '.hds-advanced-table__tbody .hds-advanced-table__tr:nth-child(1) .hds-advanced-table__td:nth-child(1)',
+        )
+        .hasText('Nick Drake');
+      assert
+        .dom(
+          '.hds-advanced-table__tbody .hds-advanced-table__tr:nth-child(2) .hds-advanced-table__td:nth-child(1)',
+        )
+        .hasText('The Beatles');
+
+      const firstHeaderCell = find('.hds-advanced-table__th');
+
+      if (firstHeaderCell) {
+        await triggerKeyEvent(firstHeaderCell, 'keydown', 'ArrowDown');
+      }
+
+      // check that the first cell below header is correct
+      assert
+        .dom(
+          '.hds-advanced-table__tbody .hds-advanced-table__tr:nth-child(1) .hds-advanced-table__td:nth-child(1)',
+        )
+        .hasText('Nick Drake')
+        .isFocused();
+
+      // sort the table
+      await click(
+        '#data-test-advanced-table .hds-advanced-table__th--sort:nth-of-type(1) button',
+      );
+
+      if (firstHeaderCell) {
+        await triggerKeyEvent(firstHeaderCell, 'keydown', 'ArrowDown');
+      }
+
+      // check that the first cell below header changed
+      assert
+        .dom(
+          '.hds-advanced-table__tbody .hds-advanced-table__tr:nth-child(1) .hds-advanced-table__td:nth-child(1)',
+        )
+        .isFocused()
+        .hasText('Melanie');
     });
   });
 });


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix a bug where the keyboard order does not match the visual order after you sort the table.

To check the fix: 
1. Navigate table with keyboard, notice keyboard order when moving up + down the column it matches the visual order
2. sort the table
3. Navigate the sorted column with the keyboard, notice that the keyboard order no longer matches the visual order 

[Current showcase](https://hds-showcase.vercel.app/components/advanced-table)
[FIxed showcase](https://hds-showcase-git-hds-6553-advanced-table-sort-678b36-hashicorp.vercel.app/components/advanced-table#keyboard-interaction)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6553](https://hashicorp.atlassian.net/browse/HDS-6553)

***

### :eyes: Component checklist

- [x] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6553]: https://hashicorp.atlassian.net/browse/HDS-6553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ