### PR TITLE
MCP - Set up changesets

### DIFF
--- a/.bob/rules/directories/mcp/changeset.instructions.md
+++ b/.bob/rules/directories/mcp/changeset.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: ".changeset/**"
+description: "Instructions for how changeset files should be formatted for the MCP package."
+---
+
+For every consumer-facing change made to the `@hashicorp/design-system-mcp` package, a changeset file must be created in the `.changeset` folder. The changeset file should follow the formatting rules outlined below.
+
+## MCP package changeset formatting
+
+Each changeset entry related to the `@hashicorp/design-system-mcp` package should follow this template:
+
+```
+---
+"@hashicorp/design-system-mcp": minor
+---
+
+Added the `list-components` tool for querying the component catalog.
+```
+
+For further instructions on changesets review the `.bob/skills/add-changeset/SKILL.md` file.

--- a/.bob/rules/directories/mcp/context.instructions.md
+++ b/.bob/rules/directories/mcp/context.instructions.md
@@ -1,0 +1,38 @@
+---
+applyTo: "packages/mcp/**"
+description: "Context for the HDS MCP server"
+---
+
+## Overview
+
+The `packages/mcp` package is the Model Context Protocol (MCP) server for the Helios Design System. It exposes design system knowledge — component APIs, tokens, and usage guidance — to MCP-capable clients over a stdio transport, so that AI tools can consume HDS data directly.
+
+## Key files
+
+- `src/index.ts` - Server entry point; builds the `McpServer`, installs lifecycle handlers, and connects the stdio transport
+- `src/prompts/` - Prompt descriptors and the `registerPrompts` registration loop
+- `src/resources/` - Resource descriptors, the `registerResources` registration loop, and shared response/error helpers
+- `src/tools/` - Tool descriptors and the `registerTools` registration loop
+- `src/catalogs/` - Static design system data served by resources and tools, each with a Zod schema describing its shape
+- `tests/` - Vitest suites, with shared helpers under `tests/support/`
+
+## Common build commands
+
+- `pnpm build` - Compiles the server to `dist/`
+- `pnpm start` - Rebuilds on file changes and restarts the server
+- `pnpm start:dev` - Rebuilds on file changes and runs the server under the MCP Inspector
+- `pnpm typecheck` - Runs the TypeScript compiler without emitting output
+- `pnpm lint` - Runs ESLint to check code quality and style
+- `pnpm test` - Runs the Vitest suites
+
+## Requirements
+
+- All user-facing changes to the server must be accompanied by a changeset
+- Never write to stdout; the stdio transport reserves it for protocol messages, so all diagnostics must go to stderr
+- Register prompts, resources, and tools by adding descriptors to the arrays in the relevant `index.ts`, rather than calling the server registration methods directly
+- Catalog data must conform to the Zod schema that sits alongside it
+
+## Related instructions
+
+- `changeset.instructions.md`
+  Instructions for creating changesets when making changes to the MCP server.

--- a/.bob/skills/add-changeset/SKILL.md
+++ b/.bob/skills/add-changeset/SKILL.md
@@ -37,7 +37,7 @@ Follow the below template to add the required parameters to the changeset file:
 {Summary}
 ```
 
-**IMPORTANT** If changes are to the `@hashicorp/design-system-components` package, the summary must follow the formatting guidelines outlined in the "Components package changeset formatting" section.
+**IMPORTANT** If changes are to the `@hashicorp/design-system-components` package, the summary must follow the formatting guidelines outlined in the "Components package changeset formatting" section. If changes are to the `@hashicorp/design-system-mcp` package, the summary must follow the guidelines outlined in the "MCP package changeset formatting" section instead.
 
 ## Components package changeset formatting
 Each changeset entry related to the `@hashicorp/design-system-components` package should follow this template:
@@ -70,6 +70,21 @@ Changes to multiple components in a single changeset entry:
 `ComponentName2` - Fixed {...additional details}.
 <!-- END -->
 ```
+
+## MCP package changeset formatting
+
+Each changeset entry related to the `@hashicorp/design-system-mcp` package should follow this template:
+
+```
+---
+"@hashicorp/design-system-mcp": minor
+---
+
+Added the `list-components` tool for querying the component catalog.
+```
+
+For further instructions on changesets review the `.bob/skills/add-changeset/SKILL.md` file.
+
 
 ## Requirements
 - Include a short description of the change with relevant details.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,7 @@
     "updateInternalDependents": "always"
   },
   "ignore": ["showcase", "website"],
+  "privatePackages": { "version": true, "tag": false },
   "snapshot": {
     "useCalculatedVersion": true
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,23 @@ pnpm lint
 pnpm lint:fix
 ```
 
+### packages/mcp
+
+The `packages/mcp` package is a Model Context Protocol server that exposes design system knowledge — component APIs, tokens, and usage guidance — to MCP-capable clients over a stdio transport.
+
+#### Key commands
+```bash
+pnpm build      # compile to dist/
+pnpm start      # rebuild and restart the server on file changes
+pnpm start:dev  # rebuild on file changes and run under the MCP Inspector
+pnpm test       # Vitest (not QUnit/Jest)
+pnpm typecheck
+pnpm lint
+```
+
+#### Additional context
+Read through further context and guidance for this package at `.bob/rules/directories/mcp`
+
 ### showcase
 
 The `showcase` app is an Ember application used to develop, test, and visually validate all HDS components from the `packages/components` library. It serves as a live component playground, source for Percy visual regression snapshots, and houses the component acceptance and integration test suite.


### PR DESCRIPTION
### :pushpin: Summary

Brings `@hashicorp/design-system-mcp` into the changesets workflow in line with the other packages in the monorepo, and documents how to author changesets for it.

The package was already versionable by changesets. It is private but was never added to `ignore`, and `privatePackages` defaults to `{ version: true, tag: false }`. So it would have silently started bumping and generating a changelog the first time anyone wrote a changeset for it. Nothing was broken; the behavior just rested on an undocumented default. This PR makes the intent explicit and fills in the missing documentation.

### :hammer_and_wrench: Detailed description

**`.changeset/config.json`**

Pins `"privatePackages": { "version": true, "tag": false }`. This is functionally a no-op today because it matches the current defaults, but it states the intent explicitly and survives a future change to those defaults.

- `version: true` keeps the package versioned with its own `CHANGELOG.md`
- `tag: false` avoids creating a git tag for a package that is never published

`changeset publish` continues to skip the package because it is private, so no release behavior changes.

**`.bob/rules/directories/mcp/`**

New `context.instructions.md` and `changeset.instructions.md`, following the structure already used by `components` and `showcase`.

**`.bob/skills/add-changeset/SKILL.md`**

Adds an "MCP package changeset formatting" section.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6550](https://hashicorp.atlassian.net/browse/HDS-6550)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6550]: https://hashicorp.atlassian.net/browse/HDS-6550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ