### PR TITLE
Add "Tooling" docs category to website

### DIFF
--- a/website/app/components/doc/page/header/index.gts
+++ b/website/app/components/doc/page/header/index.gts
@@ -62,6 +62,11 @@ const DocPageHeader: TemplateOnlyComponent<DocPageHeaderSignature> = <template>
           @route="patterns"
           @currentTopRoute={{@currentTopRoute}}
         />
+        <DocPageHeaderNavItem
+          @label="Tooling"
+          @route="tooling"
+          @currentTopRoute={{@currentTopRoute}}
+        />
         <li
           class="doc-page-header__nav-item-generic doc-page-header__nav-item--split"
         >

--- a/website/app/components/doc/page/sidebar.gjs
+++ b/website/app/components/doc/page/sidebar.gjs
@@ -23,6 +23,7 @@ const getTocSectionsBundle = (section) => {
   const COMPONENTS = ['components', 'layouts', 'overrides', 'utilities'];
   const CONTENT = ['content'];
   const PATTERNS = ['patterns'];
+  const TOOLING = ['tooling'];
   // this will be removed later
   const TESTING = ['testing'];
 
@@ -36,6 +37,8 @@ const getTocSectionsBundle = (section) => {
     return PATTERNS;
   } else if (CONTENT.includes(section)) {
     return CONTENT;
+  } else if (TOOLING.includes(section)) {
+    return TOOLING;
   } else if (TESTING.includes(section)) {
     return TESTING;
   } else {
@@ -224,6 +227,14 @@ export default class DocPageSidebarComponent extends Component {
                 class="doc-table-of-contents__link"
                 @route="patterns"
               >Patterns</LinkTo>
+            </li>
+            <li
+              class="doc-table-of-contents__item doc-table-of-contents__item--depth-2"
+            >
+              <LinkTo
+                class="doc-table-of-contents__link"
+                @route="tooling"
+              >Tooling</LinkTo>
             </li>
             <li
               class="doc-table-of-contents__item doc-table-of-contents__item--depth-2"

--- a/website/app/controllers/tooling.js
+++ b/website/app/controllers/tooling.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Controller from '@ember/controller'
+import Controller from '@ember/controller';
 
 export default class ToolingController extends Controller {
   get cards() {

--- a/website/app/controllers/tooling.js
+++ b/website/app/controllers/tooling.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright IBM Corp. 2021, 2026
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller'
+
+export default class ToolingController extends Controller {
+  get cards() {
+    const tocTree = this.model.toc.flat;
+    const sections = ['tooling'];
+    const cards = {};
+    sections.forEach((section) => {
+      cards[section] = tocTree
+        .filter(
+          (page) =>
+            page.pageParents[0] === section &&
+            !page.pageAttributes?.navigation?.hidden,
+        )
+        .map((page) => {
+          return {
+            image: page.pageAttributes.previewImage,
+            title:
+              page.pageAttributes?.navigation?.label ||
+              page.pageAttributes?.title,
+            caption: page.pageAttributes.caption,
+            status: page.pageAttributes.status,
+            route: 'show',
+            model: page.pageURL,
+          };
+        });
+    });
+    return cards;
+  }
+}

--- a/website/app/router.js
+++ b/website/app/router.js
@@ -17,6 +17,7 @@ Router.map(function () {
   this.route('components');
   this.route('patterns');
   this.route('content');
+  this.route('tooling');
 
   this.route('error');
 

--- a/website/app/styles/breakpoints/index.scss
+++ b/website/app/styles/breakpoints/index.scss
@@ -11,7 +11,7 @@ $doc-breakpoint-large: 1280px;
 $doc-breakpoint-x-large: 1450px;
 
 // we have a special breakpoint for when we show the sidebar
-$doc-breakpoint-for-sidebar: 880px;
+$doc-breakpoint-for-sidebar: 938px;
 
 
 @mixin small {

--- a/website/app/styles/pages/application/sidebar.scss
+++ b/website/app/styles/pages/application/sidebar.scss
@@ -92,7 +92,7 @@ body.application:not(.index) {
       content: "";
     }
 
-    @include breakpoint.medium () {
+    @include breakpoint.with-fixed-sidebar () {
       display: none;
     }
   }

--- a/website/app/templates/tooling.hbs
+++ b/website/app/templates/tooling.hbs
@@ -1,0 +1,13 @@
+{{!
+Copyright IBM Corp. 2021, 2026
+SPDX-License-Identifier: MPL-2.0
+}}
+
+{{page-title "Tooling"}}
+
+<Doc::Page::Stage>
+  <Doc::Page::Cover @title="Tooling" />
+  <Doc::Page::Content @breakthrough={{true}}>
+    <Doc::Cards::Deck @cols="4" @cards={{this.cards.tooling}} />
+  </Doc::Page::Content>
+</Doc::Page::Stage>

--- a/website/docs/tooling/codemods/index.md
+++ b/website/docs/tooling/codemods/index.md
@@ -1,0 +1,18 @@
+---
+title: Codemods
+description: >-
+  Codemods to help adopt HDS breaking changes and assist with major version bumps.
+caption: Codemods to help adopt HDS breaking changes and assist with major version bumps.
+previewImage: assets/testing/big_cat.png
+navigation:
+  hidden: false
+  order: 3
+  keywords:
+    - version
+    - codemod
+    - breaking
+---
+
+<section data-tab="Overview">
+  @include "partials/overview.md"
+</section>

--- a/website/docs/tooling/codemods/partials/overview.md
+++ b/website/docs/tooling/codemods/partials/overview.md
@@ -1,0 +1,1 @@
+Overview of codemods.

--- a/website/docs/tooling/design-tooling-figma-plugin/index.md
+++ b/website/docs/tooling/design-tooling-figma-plugin/index.md
@@ -1,0 +1,18 @@
+---
+title: Design Tooling Figma Plugin
+description: >-
+  A Figma plugin to help designers work more efficiently and effectively with HDS assets.
+caption: A Figma plugin to help designers work efficiently with HDS assets.
+previewImage: assets/testing/big_cat.png
+navigation:
+  hidden: false
+  order: 2
+  keywords:
+    - figma
+    - table
+    - generator
+---
+
+<section data-tab="Overview">
+  @include "partials/overview.md"
+</section>

--- a/website/docs/tooling/design-tooling-figma-plugin/partials/overview.md
+++ b/website/docs/tooling/design-tooling-figma-plugin/partials/overview.md
@@ -1,0 +1,1 @@
+Here is an overview of the HDS Design Tooling Figma Plugin.

--- a/website/docs/tooling/mcp-server/index.md
+++ b/website/docs/tooling/mcp-server/index.md
@@ -2,11 +2,11 @@
 title: Helios MCP Server
 description: >-
   An MCP server that provides an LLM with the context necessary to work with HDS assets.
-caption: An MCP server that provides an LLM with the context necessary to work with HDS assets
-previewImage: assets/testing/big_cat.png
+caption: An MCP server that provides an LLM with the context necessary to work with HDS assets.
+previewImage: assets/testing/small_cat.png
 navigation:
   hidden: false
-  order: 2
+  order: 1
   keywords:
     - mcp
     - llm

--- a/website/docs/tooling/mcp-server/index.md
+++ b/website/docs/tooling/mcp-server/index.md
@@ -1,0 +1,18 @@
+---
+title: Helios MCP Server
+description: >-
+  An MCP server that provides an LLM with the context necessary to work with HDS assets.
+caption: An MCP server that provides an LLM with the context necessary to work with HDS assets
+previewImage: assets/testing/big_cat.png
+navigation:
+  hidden: false
+  order: 2
+  keywords:
+    - mcp
+    - llm
+    - ai
+---
+
+<section data-tab="Overview">
+  @include "partials/overview.md"
+</section>

--- a/website/docs/tooling/mcp-server/partials/overview.md
+++ b/website/docs/tooling/mcp-server/partials/overview.md
@@ -1,0 +1,1 @@
+Here is an overview of the MCP server

--- a/website/lib/markdown/index.js
+++ b/website/lib/markdown/index.js
@@ -75,6 +75,7 @@ module.exports = {
       'foundations',
       'components',
       'patterns',
+      'tooling',
       'error',
     ];
     const docsURLs = flatPageListJson.flat

--- a/website/lib/markdown/table-of-contents.js
+++ b/website/lib/markdown/table-of-contents.js
@@ -18,6 +18,7 @@ const CATEGORIES = [
   'overrides',
   'utilities',
   'patterns',
+  'tooling',
   'testing',
 ];
 


### PR DESCRIPTION
[WIP]

[Preview Link](https://hds-website-git-jt-new-tooling-docs-category-hashicorp.vercel.app/tooling)

### :pushpin: Summary

Add a new category to the docs website for tooling, including the scaffold of content for:
- Helios MCP Server
- HDS Design Tooling Figma Plugin

Could potentially include codemods in this as well.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6316](https://hashicorp.atlassian.net/browse/HDS-6316)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6316]: https://hashicorp.atlassian.net/browse/HDS-6316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ