### PR TITLE
Add Figma changelog entry for FilterBar wrapping

### DIFF
--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -2,7 +2,7 @@
 
 ## August 11th, 2026
 
-`FilterBar` - Added wrapping to the "main" auto-layout container to scale more elegantly with complex generic content.
+`FilterBar` - Added wrapping to the "main" auto-layout container to ensure generic content wraps as expected.
 
 ## February 4th, 2026
 

--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -1,5 +1,9 @@
 # [HDS Components UI Kit v2.0](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?m=auto&node-id=2-7&t=HYGTIoXBy2YkVWDP-1)
 
+## August 11th, 2026
+
+`FilterBar` - Added wrapping to the "main" auto-layout container to scale more elegantly with complex generic content.
+
 ## February 4th, 2026
 
 `FilterBar` - New component added.

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -14,7 +14,7 @@
 
 ### August 11th, 2026
 
-`FilterBar` - Added wrapping to the "main" auto-layout container to scale more elegantly with complex generic content.
+`FilterBar` - Added wrapping to the "main" auto-layout container to ensure generic content wraps as expected.
 
 ### February 4th, 2026
 

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -12,6 +12,10 @@
 </p>
 
 
+### August 11th, 2026
+
+`FilterBar` - Added wrapping to the "main" auto-layout container to scale more elegantly with complex generic content.
+
 ### February 4th, 2026
 
 `FilterBar` - New component added.
@@ -89,29 +93,6 @@ This changelog corresponds with the [4.20](/whats-new/release-notes#4200) releas
 - Refactored the component to support a list coupled with the context switcher
 - Reorganized the local component dependencies
 - Updated the focus ring to use dark variables
-
-### May 7th, 2025
-
-This changelog corresponds with the [4.19](/whats-new/release-notes#4190) release.
-
-`AppHeader` and `AppSideNav` - Components added.
-
-`AdvancedTable` [Template] - Multi-select column added.
-
-`CodeBlock`, `CodeEditor`, `SideNav` - Updated styling for the focus ring.
-
-`SuperSelect / Multiple` - Multiple design improvements including:
-
-- Displaying a selected number in the trigger when not empty.
-- Correcting truncation of tags to maintain the trigger height.
-
-`Select`, `TextInput`, `TextArea`, and `MaskedInput` - Fixed the overflow to not extend beyond the container or wrap, which mirrors the overflow behavior in the browser.
-
-`RadioCard` - Fixed a bug in the border setting.
-
-`Dropdown` - Radio and Checkbox list items updated to match font weight.
-
-`SideNav` - **Deprecated** the component. Use the `AppHeader` and `AppSideNav` instead.
 
 
 ---


### PR DESCRIPTION
### :pushpin: Summary

Adds a changelog entry for adding wrapping to the FilterBar in Figma.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6560](https://hashicorp.atlassian.net/browse/HDS-6560)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6560]: https://hashicorp.atlassian.net/browse/HDS-6560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ