### PR TITLE
[Docs] Add `FilterGroup::Generic` to `FilterBar` component API

### DIFF
--- a/website/docs/components/filter-bar/partials/code/component-api.md
+++ b/website/docs/components/filter-bar/partials/code/component-api.md
@@ -241,10 +241,13 @@ The `FilterBar::FiltersDropdown` is yielded as the `[F].FiltersDropdown` context
 The `FilterBar::FilterGroup` is yielded as the `[D].FilterGroup` contextual component in the `FilterBar::FiltersDropdown`.
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="<[F].Checkbox>" @type="yielded component">
+  <C.Property @name="<[FG].Checkbox>" @type="yielded component">
     `FilterBar::FilterGroup::Checkbox` yielded as contextual component (see below).
   </C.Property>
-  <C.Property @name="<[F].Radio>" @type="yielded component">
+  <C.Property @name="<[FG].Generic>" @type="yielded component">
+    `FilterBar::FilterGroup::Generic` yielded as contextual component (see below).
+  </C.Property>
+  <C.Property @name="<[FG].Radio>" @type="yielded component">
     `FilterBar::FilterGroup::Radio` yielded as contextual component (see below).
   </C.Property>
   <C.Property @name="key" @type="string" @required={{true}}>
@@ -261,22 +264,9 @@ The `FilterBar::FilterGroup` is yielded as the `[D].FilterGroup` contextual comp
   </C.Property>
 </Doc::ComponentApi>
 
-#### FilterBar::FilterGroup::Radio
-
-The `FilterBar::FilterGroup::Radio` is yielded as the `[F].Radio` contextual component in the `FilterBar::FilterGroup`.
-
-<Doc::ComponentApi as |C|>
-  <C.Property @name="value" @type="string" @required={{true}}>
-    The value of the radio button.
-  </C.Property>
-  <C.Property @name="label" @type="string" @required={{true}}>
-    The label of the radio button. It is also passed to the applied filter object on filter change.
-  </C.Property>
-</Doc::ComponentApi>
-
 #### FilterBar::FilterGroup::Checkbox
 
-The `FilterBar::FilterGroup::Checkbox` is yielded as the `[F].Checkbox` contextual component in the `FilterBar::FilterGroup`.
+The `FilterBar::FilterGroup::Checkbox` is yielded as the `[FG].Checkbox` contextual component in the `FilterBar::FilterGroup`.
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="value" @type="string" @required={{true}}>
@@ -284,6 +274,29 @@ The `FilterBar::FilterGroup::Checkbox` is yielded as the `[F].Checkbox` contextu
   </C.Property>
   <C.Property @name="label" @type="string" @required={{true}}>
     The label of the checkbox button. It is also passed to the applied filter object on filter change.
+  </C.Property>
+</Doc::ComponentApi>
+
+#### FilterBar::FilterGroup::Generic
+
+The `FilterBar::FilterGroup::Generic` is yielded as the `[FG].Generic` contextual component in the `FilterBar::FilterGroup`.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="[G].updateFilter" @type="function">
+    Function to programmatically trigger updates to the filter inside the `FiltersDropdown`. Requires to be passed a filters object of the [generic filter type](#generic).
+  </C.Property>
+</Doc::ComponentApi>
+
+#### FilterBar::FilterGroup::Radio
+
+The `FilterBar::FilterGroup::Radio` is yielded as the `[FG].Radio` contextual component in the `FilterBar::FilterGroup`.
+
+<Doc::ComponentApi as |C|>
+  <C.Property @name="value" @type="string" @required={{true}}>
+    The value of the radio button.
+  </C.Property>
+  <C.Property @name="label" @type="string" @required={{true}}>
+    The label of the radio button. It is also passed to the applied filter object on filter change.
   </C.Property>
 </Doc::ComponentApi>
 


### PR DESCRIPTION
### :pushpin: Summary

This PR adds the `FilterGroup::Generic` to the component api docs for the `FilterBar` where previously it was undocumented.

[PREVIEW](https://hds-website-git-dchyun-docs-filter-bar-generic-block-hashicorp.vercel.app/components/filter-bar?tab=code#filterbarfiltergroupgeneric)

### :hammer_and_wrench: Detailed description

The `FilterGroup::Generic` is a contextual component of the `FilterBar::FilterGroup` and was previously undocumented. It is used for `generic` type filters to allow users a way through the `updateFilter` yielded function of triggering updates to a generic filter ([see example](https://hds-website-git-dchyun-docs-filter-bar-generic-block-hashicorp.vercel.app/components/filter-bar?tab=code#custom-filtering-1))

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>