### PR TITLE
Add Figma changelog for icon color fixes

### DIFF
--- a/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
+++ b/packages/components/CHANGELOG-FIGMA-COMPONENTS.md
@@ -1,5 +1,9 @@
 # [HDS Components UI Kit v2.0](https://www.figma.com/design/iweq3r2Pi8xiJfD9e6lOhF/HDS-Components-v2.0?m=auto&node-id=2-7&t=HYGTIoXBy2YkVWDP-1)
 
+## August 18, 2026
+
+Resolved an issue that was causing icon instances to either revert to the "dynamic" color, or fail to persist colors applied to them in component instances.
+
 ## August 11th, 2026
 
 `FilterBar` - Added wrapping to the "main" auto-layout container to ensure generic content wraps as expected.

--- a/website/docs/whats-new/release-notes/partials/components.md
+++ b/website/docs/whats-new/release-notes/partials/components.md
@@ -101,7 +101,7 @@
 
 
 
-`AdvancedTable` - Fixed an issue where the table header tooltip was not visible with the table empty state
+`AdvancedTable` - FIxed a bug where tooltips in the table header would be cut off behind the empty state message.
 
 
 <small class="doc-whats-new-changelog-metadata">[#4038](https://github.com/hashicorp/design-system/pull/4038)</small>

--- a/website/docs/whats-new/release-notes/partials/figma-library-components.md
+++ b/website/docs/whats-new/release-notes/partials/figma-library-components.md
@@ -12,6 +12,10 @@
 </p>
 
 
+### August 18, 2026
+
+Resolved an issue that was causing icon instances to either revert to the "dynamic" color, or fail to persist colors applied to them in component instances.
+
 ### August 11th, 2026
 
 `FilterBar` - Added wrapping to the "main" auto-layout container to ensure generic content wraps as expected.
@@ -79,20 +83,6 @@ This changelog corresponds with the [4.21](/whats-new/release-notes#4210) releas
 `AppHeader` - Added `text` property to the home link.
 
 `AdvancedTable` - Added support for resizing columns, restructured the component to support functions within a context menu.
-
-### June 4th, 2025
-
-This changelog corresponds with the [4.20](/whats-new/release-notes#4200) release.
-
-`CodeBlock` - Added height toggle for overflowing code.
-
-#### Breaking changes
-
-`AppHeader` - Multiple changes include:
-
-- Refactored the component to support a list coupled with the context switcher
-- Reorganized the local component dependencies
-- Updated the focus ring to use dark variables
 
 
 ---


### PR DESCRIPTION
### :pushpin: Summary

Adds a changelog entry for a bugfix in the icon color in several Figma components.

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>