### PR TITLE
FilterBar - Remove structuredClone investigation comments

### DIFF
--- a/packages/components/src/components/hds/filter-bar/filter-group/index.gts
+++ b/packages/components/src/components/hds/filter-bar/filter-group/index.gts
@@ -69,7 +69,6 @@ export default class HdsFilterBarFilterGroup extends Component<HdsFilterBarFilte
 
   private _setUpFilterPanel = modifier(() => {
     // Note: Due to the filters being an Ember object, structuredClone cannot be used here.
-    // Further investigation will be done in a follow-up task: https://hashicorp.atlassian.net/browse/HDS-5907
     if (this.keyFilter) {
       this.internalFilters = JSON.parse(
         JSON.stringify(this.keyFilter.data)

--- a/packages/components/src/components/hds/filter-bar/filters-dropdown.gts
+++ b/packages/components/src/components/hds/filter-bar/filters-dropdown.gts
@@ -100,7 +100,6 @@ export default class HdsFilterBarFiltersDropdown extends Component<HdsFilterBarF
     const newFilters = {} as HdsFilterBarFilters;
 
     // Note: Due to the filters being an Ember object, structuredClone cannot be used here.
-    // Further investigation will be done in a follow-up task: https://hashicorp.atlassian.net/browse/HDS-5907
     Object.keys(filters).forEach((k) => {
       newFilters[k] = JSON.parse(
         JSON.stringify(filters[k])

--- a/packages/components/src/components/hds/filter-bar/index.gts
+++ b/packages/components/src/components/hds/filter-bar/index.gts
@@ -163,7 +163,6 @@ export default class HdsFilterBar extends Component<HdsFilterBarSignature> {
     const newFilters = {} as HdsFilterBarFilters;
 
     // Note: Due to the filters being an Ember object, structuredClone cannot be used here.
-    // Further investigation will be done in a follow-up task: https://hashicorp.atlassian.net/browse/HDS-5907
     Object.keys(filters).forEach((k) => {
       newFilters[k] = JSON.parse(
         JSON.stringify(filters[k])


### PR DESCRIPTION
### :pushpin: Summary

One follow up task to the development of the `FilterBar` was to investigate the usage of `structuredClone` instead of the existing process which relies on `JSON.clone` and `JSON.parse` to copy the `filters` object.

Upon further investigation, `structuredClone` works for most situations. For certain instances, such as when a consumer is using `deepTracked` to track a filters object, `structuredClone` can [throw a `DataCloneError`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). 

Due to this it is safer to keep the existing implementation. This PR removes the comments from the `FilterBar` that mention this being explored further.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-5907](https://hashicorp.atlassian.net/browse/HDS-5907)

***

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-5907]: https://hashicorp.atlassian.net/browse/HDS-5907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ