### PR TITLE
MCP: Fail when the committed component catalog is stale

### DIFF
--- a/.github/workflows/ci-components.yml
+++ b/.github/workflows/ci-components.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build Components
         run: pnpm build
         working-directory: packages/components
+      - name: Check Component Catalog
+        run: pnpm test:component-catalog
+        working-directory: packages/components
       - name: Lint Showcase
         run: pnpm lint
         working-directory: showcase

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Build Components
         run: pnpm build
         working-directory: packages/components
+      - name: Check Component Catalog
+        run: pnpm test:component-catalog
+        working-directory: packages/components
       - name: Run Tests
         run: pnpm test:ember
         working-directory: website

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,6 +32,7 @@
     "lint:types": "ember-tsc --noEmit",
     "start": "rollup --config --watch --environment development",
     "test:dist-files": "node scripts/check-dist-files.mjs",
+    "test:component-catalog": "node scripts/check-component-catalog.mjs",
     "prepublishOnly": "pnpm build && pnpm test:dist-files"
   },
   "dependencies": {

--- a/packages/components/scripts/check-component-catalog.mjs
+++ b/packages/components/scripts/check-component-catalog.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Copyright IBM Corp. 2021, 2026
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// fails when the committed `component-catalog.json` is not what the current sources produce
+
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PACKAGE_ROOT = path.resolve(fileURLToPath(import.meta.url), '../..');
+const CATALOG_FILE = 'component-catalog.json';
+const GENERATOR = './scripts/build-component-catalog.mjs';
+const MAX_DIFF_LINES = 100;
+
+function fail(message) {
+  console.error(`\n\x1b[31m⚠️  Error: ${message}\x1b[0m\n`);
+
+  process.exit(1);
+}
+
+function git(args) {
+  return execFileSync('git', args, { cwd: PACKAGE_ROOT, encoding: 'utf8' });
+}
+
+try {
+  execFileSync(process.execPath, [GENERATOR], {
+    cwd: PACKAGE_ROOT,
+    stdio: 'inherit',
+  });
+} catch {
+  process.exit(1);
+}
+
+const drift = git(['diff', '--stat', 'HEAD', '--', CATALOG_FILE]).trim();
+
+if (drift.length > 0) {
+  const lines = git(['diff', 'HEAD', '--', CATALOG_FILE]).split('\n');
+
+  console.error(`\n${drift}\n`);
+  console.error(lines.slice(0, MAX_DIFF_LINES).join('\n'));
+
+  if (lines.length > MAX_DIFF_LINES) {
+    console.error(`… ${lines.length - MAX_DIFF_LINES} more lines`);
+  }
+
+  fail(
+    `\`${CATALOG_FILE}\` is out of date. It has been regenerated in place — ` +
+      `commit the result.`
+  );
+}


### PR DESCRIPTION
### :pushpin: Summary

`component-catalog.json` records a `docsPath` for every component, the website page
that documents it. The MCP server hands those paths to AI agents as links.

The generator matches a component to its page using the page's `links.github`
frontmatter, not the page's URL. That's deliberate and normally good: rename a docs
folder and it still finds the right page. But it also means a rename **silently
changes the answer** instead of failing.

So: a docs-only PR renames `website/docs/components/badge` -> `components/status-badge`.
CI rebuilds the catalog, gets the new path, and throws it away, nothing compares it
to the committed file. The PR merges green, and `main` now ships a pointer to a page
that no longer exists. Every future build stays green too, because the generator keeps
self-correcting in a workspace nobody inspects.

### :hammer_and_wrench: Detailed description

Regenerate the catalog, then `git diff HEAD` it. If the committed file no longer
matches what the sources produce, fail and print the diff.

`ci-components` and `ci-website` already run the build that regenerates it, so this is
one added step in each rather than a new job. They cover different causes: a docs
rename (`ci-website`) and a source change whose catalog was never committed
(`ci-components`).

When it fails, the corrected file is already in your working tree — commit it, and the
rename and its fix land in the same PR.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6598](https://hashicorp.atlassian.net/browse/HDS-6598)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6598]: https://hashicorp.atlassian.net/browse/HDS-6598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ