### PR TITLE
Exploration: Identifying inconsistencies in component API docs

### DIFF
--- a/component-api-docs-audit/final-analysis.md
+++ b/component-api-docs-audit/final-analysis.md
@@ -1,10 +1,10 @@
 # Component API Audit Summary
 
-**Total issues: 34** (+ 8 potential source bugs noted separately, + 2 minor docs formatting inconsistencies noted but excluded from count)
+**Total issues: 37**
 
 | Issue type                          | Count |
 |-------------------------------------|-------|
-| Wrong default                       | 6     |
+| Wrong default                       | 9     |
 | Wrong type                          | 7     |
 | Missing arg                         | 8     |
 | Wrong required flag                 | 4     |
@@ -14,10 +14,12 @@
 | Wrong values                        | 2     |
 | Wrong arg name                      | 1     |
 | Wrong content                       | 1     |
-| Potential source bug                | 8     |
-| Minor docs formatting inconsistency | 2     |
 
-**Components with issues: 27 / 66 audited**
+Noted separately from total count:
+- 8 potential source bugs
+- 2 minor docs formatting inconsistencies
+
+**Components with issues: 28 / 66 audited**
 
 ---
 
@@ -32,13 +34,15 @@ Docs: `website/docs/components/accordion/partials/code/component-api.md`
 ### [A].Item
 
 - **`ariaLabel`: default specified but none exists**
-  - Description: The docs claim a hardcoded string default that does not exist in source; the actual fallback is a completely different accessibility mechanism.
+  - Description: The docs claim a hardcoded string default of `Toggle display` that does not exist in source. The actual fallback is a different accessibility mechanism.
   - Source (`item/index.gts:42`):
     - `ariaLabel?: string`, optional, no default value
   - Source (`item/index.gts:68-71`):
     - When `ariaLabel` is absent, `ariaLabelledBy` is set to `_titleId`, pointing to the element wrapping the toggle block content; the accessible name is derived from whatever the consumer puts in the toggle block
   - Docs (`component-api.md:50`):
-    - `@default='"Toggle display"'`, the string `"Toggle display"` does not exist anywhere in the source
+    - `@default='"Toggle display"'`
+  - Docs (`how-to-use.md:45`):
+    - `The default value is "Toggle display" but you can set a custom value useful for translated text for example.`
 
 ---
 
@@ -62,6 +66,20 @@ Docs: `website/docs/components/table/advanced-table/partials/code/component-api.
     - `model: T[]`, no `?`, required
   - Docs (`component-api.md:39`):
     - Not marked `@required`
+
+- **`reorderedMessageText`: wrong default**
+  - Description: The docs default omits the word "position" that appears in the actual default string.
+  - Source (`index.gts:753`):
+    - Default: `` `Moved ${column.label} column to position ${newPosition}` ``
+  - Docs (`component-api.md:101`):
+    - `@default="Moved (label) column to (position)"` — missing "position" before the placeholder
+
+- **`sortedMessageText`: wrong default**
+  - Description: The docs default includes a comma after `(label)` that is not present in the actual default string.
+  - Source (`index.gts:554`):
+    - Default: `` `Sorted by ${this.currentSortBy} ${this.currentSortOrder}ending` ``
+  - Docs (`component-api.md:174`):
+    - `@default="Sorted by (label), (asc/desc)ending"` — spurious comma after `(label)`
 
 ### AdvancedTable::Th
 
@@ -368,6 +386,22 @@ Docs: `website/docs/components/rich-tooltip/partials/code/component-api.md`
 
 ---
 
+## Table
+
+Source: `packages/components/src/components/hds/table/index.gts`, `th-sort.gts`, `types.ts`
+Docs: `website/docs/components/table/table/partials/code/component-api.md`
+
+### Table (root)
+
+- **`sortedMessageText`: wrong default**
+  - Description: The docs default includes a comma after `(label)` that is not present in the actual default string.
+  - Source (`index.gts:181`):
+    - Default: `` `Sorted by ${this.sortBy} ${lowerCaseTranslatedSortOrder}` ``
+  - Docs (`component-api.md:112`):
+    - `@default="Sorted by (label), (asc/desc)ending"` — spurious comma after `(label)`
+
+---
+
 ## Time
 
 Source: `packages/components/src/components/hds/time/index.gts`, `single.gts`, `range.gts`
@@ -419,7 +453,7 @@ Docs: `website/docs/components/form/layout/partials/code/component-api.md`
   - Docs (`component-api.md:42`):
     - `@valueNote="any valid CSS width (px, rem, etc)" @default="672px"`, `@default` is dead markup here; `672px` never appears on the rendered page
   - Note:
-    - Have it match the pattern used for documenting `Dropdown` `@width`.
+    - Should maybe match pattern used for documenting `Dropdown` `@width`
 
 ### Form::Header::Title
 
@@ -454,6 +488,8 @@ Docs: `website/docs/components/form/primitives/partials/code/component-api.md`
     - `id` absent from `Args`
   - Docs (`component-api.md:176`):
     - Correctly documented as `<C.Property @name="id" @type="string">`
+  - Note:
+    - Should match the pattern of `Form::Field` with `id` in `Args`
 
 ---
 

--- a/component-api-docs-audit/final-analysis.md
+++ b/component-api-docs-audit/final-analysis.md
@@ -1,0 +1,259 @@
+# Component API Audit — Summary
+
+> This summary covers components audited so far. It will be updated as more components are reviewed.
+**Total issues: 19** (+ 2 potential source bugs noted separately)
+
+| Issue type                          | Count |
+|-------------------------------------|-------|
+| Wrong default                       | 3     |
+| Wrong type                          | 6     |
+| Missing arg                         | 2     |
+| Wrong required flag                 | 3     |
+| Default specified but none exists   | 1     |
+| Undocumented default                | 1     |
+| Wrong values                        | 1     |
+| Wrong arg name                      | 1     |
+| Wrong content                       | 1     |
+| Potential source bug                | 2     |
+
+**Components with issues: 7 / 9 audited**
+
+**Flagged for review: 2** (`density`, `isSelected`)
+
+---
+
+
+# Component API Audit — Findings
+
+---
+
+## Accordion
+
+Source: `packages/components/src/components/hds/accordion/index.gts`, `item/index.gts`, `types.ts`
+Docs: `website/docs/components/accordion/partials/code/component-api.md`
+
+### [A].Item
+
+- **`ariaLabel`: default specified but none exists**
+  - Description: The docs claim a hardcoded string default that does not exist in source; the actual fallback is a completely different accessibility mechanism.
+  - Source (`item/index.gts:42`):
+    - `ariaLabel?: string`, optional, no default value
+  - Source (`item/index.gts:68-71`):
+    - When `ariaLabel` is absent, `ariaLabelledBy` is set to `_titleId`, pointing to the element wrapping the toggle block content; the accessible name is derived from whatever the consumer puts in the toggle block
+  - Docs (`component-api.md:50`):
+    - `@default='"Toggle display"'`, the string `"Toggle display"` does not exist anywhere in the source
+
+---
+
+## AdvancedTable
+
+Source: `packages/components/src/components/hds/advanced-table/index.gts`, `tr.gts`, `th.gts`, `td.gts`, `types.ts`
+Docs: `website/docs/components/table/advanced-table/partials/code/component-api.md`
+
+### AdvancedTable (root)
+
+- **`columns`: wrong required flag**
+  - Description: `columns` is required in source but not marked required in the docs.
+  - Source (`index.gts:168`):
+    - `columns: HdsAdvancedTableColumn[]`, no `?`, required
+  - Docs (`component-api.md:50`):
+    - Not marked `@required`
+
+- **`model`: wrong required flag**
+  - Description: `model` is required in source but not marked required in the docs.
+  - Source (`index.gts:174`):
+    - `model: T[]`, no `?`, required
+  - Docs (`component-api.md:39`):
+    - Not marked `@required`
+
+- **`selectionAriaLabelSuffix`: missing arg**
+  - Description: This arg exists in source but is not documented on the root component.
+  - Source (`index.gts:176`):
+    - `selectionAriaLabelSuffix?: string`
+  - Docs:
+    - Not documented
+
+- **`align`: missing arg**
+  - Description: This arg exists in source but is not documented on the root component.
+  - Source (`index.gts:166`):
+    - `align?: HdsAdvancedTableHorizontalAlignment`
+  - Docs:
+    - Not documented
+
+- **`density`: wrong values, FLAG FOR REVIEW**
+  - Description: The source enum includes `"default"` which is absent from the docs; may be an intentional internal sentinel omission.
+  - Source (`types.ts:8-13`):
+    - `HdsAdvancedTableDensityValues`, values are `default`, `medium`, `short`, `tall`
+  - Docs (`component-api.md:159`):
+    - `@values={{array "short" "medium" "tall"}}`, `"default"` absent
+
+- **`reorderedMessageText`: wrong default**
+  - Description: The documented default uses different placeholder syntax than the actual translation string.
+  - Source (`advanced-table/en-us.yaml:1`, `index.gts:750-757`):
+    - Resolved via `hdsIntl.t` to `"Moved {columnLabel} column to position {newPosition}"`
+  - Docs (`component-api.md:101`):
+    - `@default="Moved (label) column to (position)"`, uses `(label)` / `(position)` instead of `{columnLabel}` / `{newPosition}`
+
+- **`sortedMessageText`: wrong default**
+  - Description: The documented default adds a comma not in source and uses an abstracted placeholder rather than the actual interpolation pattern.
+  - Source (`index.gts:554`):
+    - `` `Sorted by ${this.currentSortBy} ${this.currentSortOrder}ending` ``
+  - Docs (`component-api.md:174`):
+    - `@default="Sorted by (label), (asc/desc)ending"`, spurious comma after `(label)` and `(asc/desc)ending` does not reflect the actual interpolation
+
+### AdvancedTable::Tr
+
+- **`isSelected`: wrong default, FLAG FOR REVIEW**
+  - Description: The default of `false` is attributed to the arg in docs, but it actually comes from the getter, not the `Args` interface.
+  - Source (`tr.gts:106`):
+    - `isSelected?: boolean`, no default in `Args`; `false` is the `?? false` fallback in the getter
+  - Docs (`component-api.md:202`):
+    - `@default="false"`, correct in practice but attributed to the arg rather than the getter
+
+### AdvancedTable::Th
+
+- **`colspan`: wrong type**
+  - Description: Source defines `colspan` as `number` but docs document it as `string`.
+  - Source (`th.gts:65`):
+    - `colspan?: number`
+  - Docs (`component-api.md:239`):
+    - `@type="string"`
+
+- **`rowspan`: wrong type**
+  - Description: Source defines `rowspan` as `number` but docs document it as `string`.
+  - Source (`th.gts:85`):
+    - `rowspan?: number`
+  - Docs (`component-api.md:242`):
+    - `@type="string"`
+
+### AdvancedTable::Td
+
+- **`colspan`: wrong type**
+  - Description: Source defines `colspan` as `number` but docs document it as `string`.
+  - Source (`td.gts:33`):
+    - `colspan?: number`
+  - Docs (`component-api.md:264`):
+    - `@type="string"`
+
+- **`rowspan`: wrong type**
+  - Description: Source defines `rowspan` as `number` but docs document it as `string`.
+  - Source (`td.gts:32`):
+    - `rowspan?: number`
+  - Docs (`component-api.md:261`):
+    - `@type="string"`
+
+---
+
+## Alert
+
+Source: `packages/components/src/components/hds/alert/index.gts`, `title.gts`, `description.gts`, `types.ts`
+Docs: `website/docs/components/alert/partials/code/component-api.md`
+
+### [A].LinkStandalone
+
+- **`@size` description: wrong content**
+  - Description: The description sentence is cut off mid-way, leaving the pre-bound value unstated.
+  - Source (`index.gts:86`):
+    - `WithBoundArgs<typeof HdsLinkStandalone, 'size'>`, `size` is pre-bound to `"small"`
+  - Docs (`component-api.md:93`):
+    - Sentence reads: "apart from the `@size` argument, which is pre-defined to be", ends without stating the value
+
+---
+
+## AppFooter
+
+Source: `packages/components/src/components/hds/app-footer/index.gts`, `status-link.gts`, `legal-links.gts`, `link.gts`, `item.gts`, `copyright.gts`, `types.ts`
+Docs: `website/docs/components/app-footer/partials/code/component-api.md`
+
+### [AF].LegalLinks
+
+- **`hrefForAccessibility`: wrong arg name**
+  - Description: The arg in source is `hrefForAccessibility` but the docs document it as `Accessibility`.
+  - Source (`legal-links.gts:22`):
+    - `hrefForAccessibility?: string`
+  - Docs (`component-api.md:96`):
+    - `@name="Accessibility"`, incorrect name, missing the `hrefFor` prefix
+
+### [AF].StatusLink
+
+- **`href`: undocumented default**
+  - Description: Source falls back to `https://status.hashicorp.com` when `href` is absent, but docs do not document this default.
+  - Source (`status-link.gts:96`):
+    - `this.args.href ?? 'https://status.hashicorp.com'`
+  - Docs (`component-api.md:59-61`):
+    - `@name="href"` with no `@default` specified
+
+### [AF].Link
+
+- **`iconPosition`: wrong default**
+  - Description: The docs document a default of `"trailing"` but the source does not set any default; `iconPosition` is passed directly to `HdsLinkInline` without a fallback.
+  - Source (`link.gts:21`, `link.gts:44`):
+    - `iconPosition?: HdsLinkIconPositions`, optional, no default; passed as `@iconPosition={{@iconPosition}}`
+  - Docs (`component-api.md:130`):
+    - `@default="trailing"`
+
+- **`color`: potential source bug**
+  - Description: `color` is declared as an optional arg in the signature but is hardcoded to `"secondary"` in the template and never forwarded, so the arg has no effect. Should it be removed from the `Args` interface?
+  - Source (`link.gts:19`, `link.gts:34`):
+    - `color?: HdsLinkColors` in `Args`; template hardcodes `@color="secondary"` and does not pass `@color={{@color}}`
+  - Docs:
+    - Correctly not documented
+
+---
+
+## AppHeader
+
+Source: `packages/components/src/components/hds/app-header/index.gts`, `home-link.gts`, `menu-button.gts`
+Docs: `website/docs/components/app-header/partials/code/component-api.md`
+
+### AppHeader (root)
+
+- **`a11yRefocusRouteChangeValidator`: wrong type**
+  - Description: Docs document this as `@type="string"` but the type is a callback function.
+  - Source (`index.gts:29`, `navigation-narrator.d.ts:12`):
+    - `a11yRefocusRouteChangeValidator?: (transition: Transition) => boolean`, a function that receives an Ember `Transition` and returns a boolean indicating whether the route change should trigger an accessibility announcement
+  - Docs (`component-api.md:33`):
+    - `@type="string"`
+
+---
+
+## AppSideNav
+
+Source: `packages/components/src/components/hds/app-side-nav/index.gts`, `list/index.gts`, `list/link.gts`, `list/back-link.gts`, `portal/index.gts`, `portal/target.gts`
+Docs: `website/docs/components/app-side-nav/partials/code/component-api.md`
+
+### AppSideNav::List::BackLink
+
+- **`text`: wrong required flag**
+  - Description: `text` is required in source (no `?`) but is not marked `@required` in the docs.
+  - Source (`list/back-link.gts:16`):
+    - `text: string`, no `?`, required
+  - Docs (`component-api.md:131`):
+    - Not marked `@required`
+
+### AppSideNav::List::Link
+
+- **`isActive`: wrong type**
+  - Description: `isActive` is a boolean but `@type` is not set in the docs.
+  - Source (`list/link.gts:24`):
+    - `isActive?: boolean`
+  - Docs (`component-api.md:187`):
+    - No `@type` specified, should be `@type="boolean"`
+
+---
+
+## ApplicationState
+
+Source: `packages/components/src/components/hds/application-state/index.gts`, `header.gts`, `body.gts`, `footer.gts`, `media.gts`, `types.ts`
+Docs: `website/docs/components/application-state/partials/code/component-api.md`
+
+### [A].Footer
+
+- **`hasDivider`: potential source bug**
+  - Description: `hasDivider` is declared as an optional arg in the signature but is never referenced in the template, so it has no effect. Should it be removed from the `Args` interface?
+  - Source (`footer.gts:15`):
+    - `hasDivider?: boolean` in `Args`; template does not reference it
+  - Docs:
+    - Correctly not documented
+
+---

--- a/component-api-docs-audit/final-analysis.md
+++ b/component-api-docs-audit/final-analysis.md
@@ -1,31 +1,28 @@
-# Component API Audit — Summary
+# Component API Audit Summary
 
-> This summary covers components audited so far. It will be updated as more components are reviewed.
-**Total issues: 19** (+ 2 potential source bugs noted separately)
+**Total issues: 34** (+ 8 potential source bugs noted separately, + 2 minor docs formatting inconsistencies noted but excluded from count)
 
 | Issue type                          | Count |
 |-------------------------------------|-------|
-| Wrong default                       | 3     |
-| Wrong type                          | 6     |
-| Missing arg                         | 2     |
-| Wrong required flag                 | 3     |
+| Wrong default                       | 6     |
+| Wrong type                          | 7     |
+| Missing arg                         | 8     |
+| Wrong required flag                 | 4     |
+| Extra arg                           | 2     |
 | Default specified but none exists   | 1     |
-| Undocumented default                | 1     |
-| Wrong values                        | 1     |
+| Undocumented default                | 2     |
+| Wrong values                        | 2     |
 | Wrong arg name                      | 1     |
 | Wrong content                       | 1     |
-| Potential source bug                | 2     |
+| Potential source bug                | 8     |
+| Minor docs formatting inconsistency | 2     |
 
-**Components with issues: 7 / 9 audited**
-
-**Flagged for review: 2** (`density`, `isSelected`)
-
----
-
-
-# Component API Audit — Findings
+**Components with issues: 27 / 66 audited**
 
 ---
+
+
+# Component API Audit Findings - Components
 
 ## Accordion
 
@@ -65,50 +62,6 @@ Docs: `website/docs/components/table/advanced-table/partials/code/component-api.
     - `model: T[]`, no `?`, required
   - Docs (`component-api.md:39`):
     - Not marked `@required`
-
-- **`selectionAriaLabelSuffix`: missing arg**
-  - Description: This arg exists in source but is not documented on the root component.
-  - Source (`index.gts:176`):
-    - `selectionAriaLabelSuffix?: string`
-  - Docs:
-    - Not documented
-
-- **`align`: missing arg**
-  - Description: This arg exists in source but is not documented on the root component.
-  - Source (`index.gts:166`):
-    - `align?: HdsAdvancedTableHorizontalAlignment`
-  - Docs:
-    - Not documented
-
-- **`density`: wrong values, FLAG FOR REVIEW**
-  - Description: The source enum includes `"default"` which is absent from the docs; may be an intentional internal sentinel omission.
-  - Source (`types.ts:8-13`):
-    - `HdsAdvancedTableDensityValues`, values are `default`, `medium`, `short`, `tall`
-  - Docs (`component-api.md:159`):
-    - `@values={{array "short" "medium" "tall"}}`, `"default"` absent
-
-- **`reorderedMessageText`: wrong default**
-  - Description: The documented default uses different placeholder syntax than the actual translation string.
-  - Source (`advanced-table/en-us.yaml:1`, `index.gts:750-757`):
-    - Resolved via `hdsIntl.t` to `"Moved {columnLabel} column to position {newPosition}"`
-  - Docs (`component-api.md:101`):
-    - `@default="Moved (label) column to (position)"`, uses `(label)` / `(position)` instead of `{columnLabel}` / `{newPosition}`
-
-- **`sortedMessageText`: wrong default**
-  - Description: The documented default adds a comma not in source and uses an abstracted placeholder rather than the actual interpolation pattern.
-  - Source (`index.gts:554`):
-    - `` `Sorted by ${this.currentSortBy} ${this.currentSortOrder}ending` ``
-  - Docs (`component-api.md:174`):
-    - `@default="Sorted by (label), (asc/desc)ending"`, spurious comma after `(label)` and `(asc/desc)ending` does not reflect the actual interpolation
-
-### AdvancedTable::Tr
-
-- **`isSelected`: wrong default, FLAG FOR REVIEW**
-  - Description: The default of `false` is attributed to the arg in docs, but it actually comes from the getter, not the `Args` interface.
-  - Source (`tr.gts:106`):
-    - `isSelected?: boolean`, no default in `Args`; `false` is the `?? false` fallback in the getter
-  - Docs (`component-api.md:202`):
-    - `@default="false"`, correct in practice but attributed to the arg rather than the getter
 
 ### AdvancedTable::Th
 
@@ -257,3 +210,388 @@ Docs: `website/docs/components/application-state/partials/code/component-api.md`
     - Correctly not documented
 
 ---
+
+## CodeBlock
+
+Source: `packages/components/src/components/hds/code-block/index.gts`, `copy-button.gts`, `title.gts`, `description.gts`, `types.ts`
+Docs: `website/docs/components/code-block/partials/code/component-api.md`
+
+### CodeBlock (root)
+
+- **`copySuccessMessageText`: missing arg**
+  - Description: This arg exists in source but is not documented.
+  - Source (`index.gts:71`):
+    - `copySuccessMessageText?: HdsCopyButtonSignature['Args']['ariaMessageText']`
+  - Docs:
+    - Not documented
+
+---
+
+## CodeEditor
+
+Source: `packages/components/src/components/hds/code-editor/index.gts`, `title.gts`, `description.gts`, `generic.gts`
+Docs: `website/docs/components/code-editor/partials/code/component-api.md`
+
+### CodeEditor (root)
+
+- **`extraKeys`: missing arg**
+  - Description: This arg exists in the modifier signature and is forwarded from the component, but is not documented.
+  - Source (`index.gts:223`, `modifiers/hds-code-editor.ts:55`):
+    - `extraKeys?: HdsCodeEditorExtraKeys` (typed as `{ [key: string]: () => boolean }`)
+  - Docs:
+    - Not documented
+
+---
+
+## Dropdown
+
+Source: `packages/components/src/components/hds/dropdown/index.gts`, `toggle/button.gts`, `toggle/icon.gts`, `list-item/interactive.gts`, `list-item/copy-item.gts`, `list-item/checkmark.gts`, `types.ts`
+Docs: `website/docs/components/dropdown/partials/code/component-api.md`
+
+### [D].ToggleButton
+
+- **`isFullWidth`: missing arg**
+  - Description: `isFullWidth` exists in source but is not documented.
+  - Source (`toggle/button.gts:46`):
+    - `isFullWidth?: boolean`
+  - Docs:
+    - Not documented
+
+---
+
+## FilterBar
+
+Source: `packages/components/src/components/hds/filter-bar/index.gts`, `types.ts`
+Docs: `website/docs/components/filter-bar/partials/code/component-api.md`
+
+### Filter types
+
+- **`type`: minor docs formatting inconsistency**
+  - Description: The `@required` attribute uses a string value `"true"` instead of the boolean `{{true}}`, which is inconsistent with the rest of the docs. This is a docs template authoring quirk, not a source/docs mismatch; excluded from the issue count.
+  - Docs (`component-api.md:45`):
+    - `@required="true"` (string), should be `@required={{true}}`
+
+---
+
+## Icon
+
+Source: `packages/components/src/components/hds/icon/index.gts`, `types.ts`
+Docs: `website/docs/components/icon/partials/code/component-api.md`
+
+### Icon (root)
+
+- **`name`: minor docs formatting inconsistency**
+  - Description: The `@required` attribute uses a string value `"true"` instead of the boolean `{{true}}`, which is inconsistent with the rest of the docs. This is a docs template authoring quirk, not a source/docs mismatch; excluded from the issue count.
+  - Docs (`component-api.md:4`):
+    - `@required="true"` (string), should be `@required={{true}}`
+
+- **`size`: wrong type**
+  - Description: `size` is documented as `@type="number"` but the source type `HdsIconSizes` resolves to the string union `'16' | '24'`; consumers pass a string, not a number.
+  - Source (`index.gts:24`, `types.ts:6-11`):
+    - `size?: HdsIconSizes`, which is `` `${HdsIconSizeValues}` `` resolving to `'16' | '24'`
+  - Docs (`component-api.md:7`):
+    - `@type="number"`
+  -Note:
+    - Passing a number works at runtime due to Handlebars coercion, but since the TypeScript type is '16' | '24', Glint would reject the number if enabled.
+
+---
+
+## IconTile
+
+Source: `packages/components/src/components/hds/icon-tile/index.gts`, `types.ts`
+Docs: `website/docs/components/icon-tile/partials/code/component-api.md`
+
+### IconTile (root)
+
+- **`color`: wrong values**
+  - Description: The docs are missing `"hcp"` and `"vault-radar"` from the `@values` list; both are valid product values in the source enum.
+  - Source (`types.ts:14-28`):
+    - `HdsIconTileProductValues` includes `HCP = 'hcp'` and `'Vault Radar' = 'vault-radar'`
+  - Docs (`component-api.md:7`):
+    - `@values={{array "neutral" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "waypoint"}}`, missing `"hcp"` and `"vault-radar"`
+---
+
+## PageHeader
+
+Source: `packages/components/src/components/hds/page-header/index.gts`, `title.gts`, `subtitle.gts`, `description.gts`, `badges.gts`, `actions.gts`
+Docs: `website/docs/components/page-header/partials/code/component-api.md`
+
+### [PH].Title
+
+- **`close`: extra arg**
+  - Description: The docs document a `close` function arg on `[PH].Title` that does not exist in `HdsPageHeaderTitleSignature`; it appears to be stale copy-paste from the Modal docs.
+  - Source (`title.gts:12-18`):
+    - `HdsPageHeaderTitleSignature` has `Args: HdsTextDisplaySignature['Args']`, no `close` arg
+  - Docs (`component-api.md:22`):
+    - `<C.Property @name="close" @type="function">`
+
+---
+
+## Pagination
+
+Source: `packages/components/src/components/hds/pagination/compact/index.gts`, `numbered/index.gts`, `types.ts`
+Docs: `website/docs/components/pagination/partials/code/component-api.md`
+
+### Pagination::Numbered
+
+- **`showInfo`: missing arg**
+  - Description: `showInfo` controls visibility of the info block and defaults to `true` in source but is not documented.
+  - Source (`numbered/index.gts:61`, `:193`):
+    - `showInfo?: boolean`, default `true` (`this.args.showInfo ?? true`)
+  - Docs (`component-api.md`):
+    - Not documented
+
+- **`showPageNumbers`: missing arg**
+  - Description: `showPageNumbers` controls visibility of the page number list and defaults to `true` in source but is not documented.
+  - Source (`numbered/index.gts:62`, `:196`):
+    - `showPageNumbers?: boolean`, default `true` (`this.args.showPageNumbers ?? true`)
+  - Docs (`component-api.md`):
+    - Not documented
+
+---
+
+## RichTooltip
+
+Source: `packages/components/src/components/hds/rich-tooltip/index.gts`, `toggle.gts`, `bubble.gts`, `types.ts`
+Docs: `website/docs/components/rich-tooltip/partials/code/component-api.md`
+
+### RichTooltip (root)
+
+- **`enableSoftEvents`: extra arg**
+  - Description: The docs expose `enableSoftEvents` as a consumer-facing arg, but the source explicitly omits it from the public `Args` via `Omit<HdsPopoverPrimitiveSignature['Args'], 'enableSoftEvents'>`; it is computed internally from `enableClickEvents` and cannot be passed by consumers.
+  - Source (`index.gts:19`):
+    - `Args: Omit<HdsPopoverPrimitiveSignature['Args'], 'enableSoftEvents'>`, `enableSoftEvents` is excluded
+  - Source (`index.gts:44-46`):
+    - `get enableSoftEvents() { return this.args.enableClickEvents !== true; }`, computed internally, not an arg
+  - Docs (`component-api.md:18-20`):
+    - `<C.Property @name="enableSoftEvents" @type="boolean" @default="true">`
+
+---
+
+## Time
+
+Source: `packages/components/src/components/hds/time/index.gts`, `single.gts`, `range.gts`
+Docs: `website/docs/components/time/partials/code/component-api.md`
+
+### Time (root)
+
+- **`isoUtcString`: potential source bug**
+  - Description: `isoUtcString` is declared in `Args` but the getter `get isoUtcString()` always derives the value from `this.date` via the time service and never reads `this.args.isoUtcString`. The argument is appropriately omitted from the docs currently since it isn't used currently. Should it be removed from the `Args` interface?
+  - Source (`index.gts:32`):
+    - `isoUtcString?: string` declared in `Args`
+  - Source (`index.gts:95-105`):
+    - `get isoUtcString()` ignores `this.args.isoUtcString` entirely
+  - Docs:
+    - Correctly not documented
+
+---
+
+## Tooltip
+
+Source: `packages/components/src/components/hds/tooltip-button/index.gts`, `types.ts`
+Docs: `website/docs/components/tooltip/partials/code/component-api.md`
+
+### TooltipButton
+
+- **`text`: wrong required flag**
+  - Description: `text` is required in source (`text: string`, no `?`) but is not marked `@required={{true}}` in the docs.
+  - Source (`tooltip-button/index.gts:25`):
+    - `text: string`, required
+  - Docs (`component-api.md:6`):
+    - `<C.Property @name="text" @type="string">`, no `@required`
+
+---
+
+
+# Component API Audit Findings - Form components
+
+## Form / Layout
+
+Source: `packages/components/src/components/hds/form/index.gts`, `form/header/index.gts`, `form/header/title.gts`, `form/header/description.gts`, `form/section/index.gts`, `form/section/header.gts`, `form/section/multi-field-group/index.gts`, `form/section/multi-field-group/item.gts`, `form/footer/index.gts`, `form/separator/index.gts`, `form/types.ts`
+Docs: `website/docs/components/form/layout/partials/code/component-api.md`
+
+### Form (root)
+
+- **`sectionMaxWidth`: undocumented default**
+  - Description: The default value of `672px` is not shown. `@default="672px"` is set in the markdown but is ignored at render time because `@valueNote` is also present. The `672px` value comes from the SCSS stylesheet, not from the TypeScript arg, so it should be communicated in the description rather than via `@default`.
+  - Source (`styles/components/form/layout.scss:15`):
+    - `--hds-form-section-max-width: 672px;`, CSS default, independent of the arg
+  - Docs (`component-api.md:42`):
+    - `@valueNote="any valid CSS width (px, rem, etc)" @default="672px"`, `@default` is dead markup here; `672px` never appears on the rendered page
+  - Note:
+    - Have it match the pattern used for documenting `Dropdown` `@width`.
+
+### Form::Header::Title
+
+- **`size`: wrong default**
+  - Description: The docs document a default of `"200"` but the source constant `DEFAULT_SIZE` resolves to `400`.
+  - Source (`header/title.gts:16`, `text/types.ts:48-49`):
+    - `DEFAULT_SIZE = HdsTextSizeValues.FourHundred`, which is `400`
+  - Docs (`component-api.md:79`):
+    - `@default="200"`
+
+---
+
+## Form / Primitives
+
+Source: `packages/components/src/components/hds/form/label/index.gts`, `form/helper-text/index.gts`, `form/error/index.gts`, `form/legend/index.gts`, `form/character-count/index.gts`, `form/indicator/index.gts`, `form/field/index.gts`, `form/fieldset/index.gts`
+Docs: `website/docs/components/form/primitives/partials/code/component-api.md`
+
+### Form::Label
+
+- **`hiddenText`: missing arg**
+  - Description: `Form::Label` accepts a `hiddenText` arg that renders visually hidden accessible text, but it is not documented.
+  - Source (`label/index.gts:20`):
+    - `hiddenText?: string`, renders a `<span class="sr-only">` when present
+  - Docs (`component-api.md:3-21`):
+    - Not documented
+
+### Form::Fieldset
+
+- **`id`: potential source bug**
+  - Description: The docs document a consumer-facing `id` arg, but `id?: string` is missing from `HdsFormFieldsetSignature['Args']`. It has been working at runtime because `getElementId` reads directly from `element.args.id`, but it should be formally declared in `Args`.
+  - Source (`fieldset/index.gts:30-36`):
+    - `id` absent from `Args`
+  - Docs (`component-api.md:176`):
+    - Correctly documented as `<C.Property @name="id" @type="string">`
+
+---
+
+## Form::KeyValueInputs
+
+Source: `packages/components/src/components/hds/form/key-value-inputs/index.gts`, `field.gts`, `add-row-button.gts`, `delete-row-button.gts`, `generic.gts`
+Docs: `website/docs/components/form/key-value-inputs/partials/code/component-api.md`
+
+### [F].AddRowButton
+
+- **`ariaLabel`: missing arg**
+  - Description: `HdsFormKeyValueInputsAddRowButton` accepts an `ariaLabel` arg but it is not documented.
+  - Source (`add-row-button.gts:18`):
+    - `ariaLabel?: string`
+  - Docs (`component-api.md:181-191`):
+    - Not documented
+
+### [R].Field
+
+- **`width`: wrong default**
+  - Description: The docs document the default as `"1f"` (missing the `r`); the actual default applied by the grid layout logic is `"1fr"`.
+  - Source (`index.gts:157`):
+    - `updatedGridTemplateColumns += '1fr ';`, applied when no `dataset['width']` is set
+  - Docs (`component-api.md:135`):
+    - `@default="1f"` (should be `"1fr"`)
+
+---
+
+## Form::MaskedInput
+
+Source: `packages/components/src/components/hds/form/masked-input/base.gts`, `field.gts`
+Docs: `website/docs/components/form/masked-input/partials/code/component-api.md`
+
+### Form::MaskedInput::Base
+
+- **`visibilityToggleAriaLabel`: potential source bug**
+  - Description: The arg accepts only a single static string, so a consumer cannot provide different labels for the masked and unmasked states. Passing any value means the same string is used regardless of state.
+  - Source (`base.gts:83-101`):
+    - `if (this.args.visibilityToggleAriaLabel) { return this.args.visibilityToggleAriaLabel; }`, no mechanism to pass state-dependent overrides
+  - Docs:
+    - Not a docs issue
+
+- **`visibilityToggleAriaMessageText`: potential source bug**
+  - Description: Same limitation as `visibilityToggleAriaLabel`: only a single static string can be provided, with no way to supply different text for the masked and unmasked states.
+  - Source (`base.gts:103-121`):
+    - `if (this.args.visibilityToggleAriaMessageText) { return this.args.visibilityToggleAriaMessageText; }`, no mechanism to pass state-dependent overrides
+  - Docs:
+    - Not a docs issue
+
+---
+
+## Form::RadioCard
+
+Source: `packages/components/src/components/hds/form/radio-card/index.gts`, `group.gts`, `types.ts`
+Docs: `website/docs/components/form/radio-card/partials/code/component-api.md`
+
+### Form::RadioCard::Group
+
+- **`isOptional`: missing arg**
+  - Description: `Form::RadioCard::Group` extends `HdsFormFieldsetSignature['Args']` which includes `isOptional`, but the docs do not document this arg.
+  - Source (`group.gts:22-26`):
+    - `Args: HdsFormFieldsetSignature['Args'] & { ... }`, includes `isOptional?: boolean`
+  - Source (`group.gts:49`):
+    - `@isOptional={{@isOptional}}` is passed to `HdsFormFieldset`
+  - Docs (`component-api.md:68-86`):
+    - No entry for `isOptional`
+
+---
+
+## Form::TextInput
+
+Source: `packages/components/src/components/hds/form/text-input/base.gts`, `field.gts`, `types.ts`
+Docs: `website/docs/components/form/text-input/partials/code/component-api.md`
+
+### Form::TextInput::Field
+
+- **`visibilityToggleAriaLabel`: wrong default**
+  - Description: The docs document a default of `"Show masked content"` but the source default is `"Show password"` (when masked) or `"Hide password"` (when unmasked).
+  - Source (`field.gts:62-68`):
+    - When `_isPasswordMasked` is true: `'Show password'`; when false: `'Hide password'`
+  - Docs (`component-api.md:72`):
+    - `@default="Show masked content"`
+
+- **`visibilityToggleAriaMessageText`: wrong default**
+  - Description: The docs document a default of `"Input content is hidden"` but the source default is `"Password is hidden"` (when masked) or `"Password is visible"` (when unmasked).
+  - Source (`field.gts:70-78`):
+    - When `_isPasswordMasked` is true: `'Password is hidden'`; when false: `'Password is visible'`
+  - Docs (`component-api.md:75`):
+    - `@default="Input content is hidden"`
+
+- **`visibilityToggleAriaLabel`: potential source bug**
+  - Description: Same limitation as `Form::MaskedInput::Base`: only a single static string can be provided, with no way to supply different text for the masked and unmasked states.
+  - Source (`field.gts:60-68`):
+    - `if (this.args.visibilityToggleAriaLabel) { return this.args.visibilityToggleAriaLabel; }`, no mechanism to pass state-dependent overrides
+  - Docs:
+    - Not a docs issue
+
+- **`visibilityToggleAriaMessageText`: potential source bug**
+  - Description: Same limitation as `Form::MaskedInput::Base`: only a single static string can be provided, with no way to supply different text for the masked and unmasked states.
+  - Source (`field.gts:70-78`):
+    - `if (this.args.visibilityToggleAriaMessageText) { return this.args.visibilityToggleAriaMessageText; }`, no mechanism to pass state-dependent overrides
+  - Docs:
+    - Not a docs issue
+
+---
+
+
+# Component API Audit Findings - Layouts
+
+## Layout::Grid
+
+Source: `packages/components/src/components/hds/layout/grid/index.gts`, `item.gts`, `types.ts`
+Docs: `website/docs/layouts/grid/partials/code/component-api.md`
+
+### Layout::Grid (root)
+
+- **`gap`: wrong values**
+  - Description: The docs `@values` list is missing `"24"`; the source enum `HdsLayoutGridGapValues` includes it.
+  - Source (`types.ts:23`):
+    - `'TwentyFour' = '24'` is a valid member of `HdsLayoutGridGapValues`
+  - Docs (`component-api.md:35`):
+    - `@values={{array "0" "4" "8" "12" "16" "32" "48"}}`, `"24"` absent
+
+---
+
+
+# Component API Audit Findings - Utilities
+
+## DismissButton
+
+Source: `packages/components/src/components/hds/dismiss-button/index.gts`
+Docs: `website/docs/utilities/dismiss-button/partials/code/component-api.md`
+
+### DismissButton (root)
+
+- **`ariaLabel`: wrong default**
+  - Description: The docs document the default as `"dismiss"` (lowercase) but the source translation fallback is `"Dismiss"` (capitalized).
+  - Source (`index.gts:26-28`):
+    - `default: 'Dismiss'`
+  - Docs (`component-api.md:6`):
+    - `@default="dismiss"`

--- a/component-api-docs-audit/initial-prompt.md
+++ b/component-api-docs-audit/initial-prompt.md
@@ -16,14 +16,14 @@ The website component API documentation we are checking lives in:
 
 ## Task requirements
 
-All checks apply to **every argument** in both source and docs. Documentation should reflect the consumer experience. Internal implementation details (where a default lives, how a type is represented in TypeScript, the translation service) are not themselves findings. Source code bugs (e.g. an arg declared but never used) are worth noting but are not documentation inconsistencies.
+All checks apply to **every argument** in both source and docs. Documentation should reflect the consumer experience. Internal implementation details (where a default lives, how a type is represented in TypeScript, the translation service) are not themselves findings. 
 
 ### 1. Argument names
 - Arg in source `Args` absent from docs: **missing arg**
 - Arg in docs absent from source `Args`: **extra arg**
 - Name differs between source and docs (camelCase vs kebab-case, typo, abbreviation): **wrong arg name**
 - Never flag private fields, `@tracked` variables, or internal getters, as these are not consumer-facing
-- Exception: link-routing args (`route`, `model`, `models`, `query`, `current-when`, `replace`) are grouped into one docs entry, do not flag
+- Exception: link-routing args (`route`, `model`, `models`, `query`, `current-when`, `replace`) are grouped into one docs entry, do not flag as missing or extra
 
 ### 2. Required/optional flag
 - `arg?:` in source = optional, `arg:` = required
@@ -38,7 +38,6 @@ All checks apply to **every argument** in both source and docs. Documentation sh
 ### 4. Defaults
 - Check in this order: 1. `DEFAULT_*` constant 2. getter (`this.args.foo ?? <value>`) 3. translation string (use the `default:` fallback passed to `hdsIntl.t`)
 - If a value references an enum member, resolve it to its string value
-- Documented `@default` is ok as long as it matches the effective source value, regardless of where in source it lives
 - Documented `@default` that doesn't match source: **wrong default**
 - Documented `@default` with no corresponding source default: **default specified but none exists**
 - No `@default` in docs but a default exists in source: **undocumented default**
@@ -46,16 +45,21 @@ All checks apply to **every argument** in both source and docs. Documentation sh
 
 ### 5. Types
 - `@values` is a docs rendering utility only, never infer type from it
-- Args typed as `HdsFooBarTypes` (template-literal string union) or `HdsFooBarValues` (enum) are correctly documented as `@type="string"`, do not flag
 - Flag genuine mismatches: `number` as `@type="string"`, a function type as `@type="string"`: **wrong type**
-- A `boolean` arg documented with `@values={{array "true" "false"}}` is not a type mismatch, do not flag.
-- An arg typed `number | string` in the source code is a leniency pattern and not a type mismatch, `@type="number"` in docs is correct, do not flag
+- Exception: args typed as `HdsFooBarTypes` (template-literal string union) or `HdsFooBarValues` (enum) are correctly documented as `@type="string"`
+- Exception: a `boolean` arg documented with `@values={{array "true" "false"}}` is not a type mismatch
+- Exception: an arg typed `number | string` in source is a leniency pattern; `@type="number"` in docs is correct
 
 ### 6. Named blocks
 - Mismatch between `Blocks` interface in source and named block entries in docs: **wrong block**
 
-### 7. WithBoundArgs exclusions
-- If a contextual component is yielded with `WithBoundArgs<typeof Foo, 'argA' | 'argB'>`, those args are pre-bound by the parent and should not be documented on the child, do not flag as missing
+### 7. Potential source bugs
+- Source code bugs (e.g. an arg declared but never used) are worth noting under the relevant component but are not documentation inconsistencies, flag it as a **potential source bug**
+- Do not count them in the total issue count, track them separately in the summary table
+
+### 8. Minor docs formatting inconsistencies
+- Small authoring quirks in docs markup that do not cause a source/docs mismatch (e.g. `@required="true"` instead of `@required={{true}}`)
+- Do not count them in the total issue count, track them separately in the summary table
 
 ## Output format
 

--- a/component-api-docs-audit/initial-prompt.md
+++ b/component-api-docs-audit/initial-prompt.md
@@ -1,0 +1,87 @@
+# Component API Documentation Audit
+
+## Overview
+
+The goal is to audit every HDS component and check the type definitions of component arguments in `packages/components/src/components/hds/` with its corresponding API documentation in `website/docs/components/`. The goal is to identify any inconsistencies in the documentation so they can be corrected to more accurately reflect our components to better serve our consumers and ongoing initiatives like the MCP server.
+
+## Relevant Files
+
+For each component, the source of truth definition lives in:
+- `packages/components/src/components/hds/<name>/index.gts`, the `HdsXxxSignature` interface (`Args`, `Blocks`, `Element`)
+- `packages/components/src/components/hds/<name>/types.ts`, exported enum values for each argument
+- `.gts` files for contextual components yielded from the main component
+
+The website component API documentation we are checking lives in:
+- `website/docs/components/<name>/partials/code/component-api.md`
+
+## Task requirements
+
+All checks apply to **every argument** in both source and docs. Documentation should reflect the **consumer experience**. Internal implementation details (where a default lives, how a type is represented in TypeScript, the translation service) are not themselves findings. Source code bugs (e.g. an arg declared but never used) are worth noting but are not documentation inconsistencies.
+
+### 1. Argument names
+- Arg in source `Args` absent from docs: **missing arg**
+- Arg in docs absent from source `Args`: **extra arg**
+- Name differs between source and docs (camelCase vs kebab-case, typo, abbreviation): **wrong arg name**
+- Never flag private fields, `@tracked` variables, or internal getters, as these are not consumer-facing
+- Exception: link-routing args (`route`, `model`, `models`, `query`, `current-when`, `replace`) are grouped into one docs entry, do not flag as missing
+
+### 2. Required/optional flag
+- `arg?:` in source = optional, `arg:` = required
+- Mismatch with `@required={{true}}` in docs: **wrong required flag**
+
+### 3. Enum values
+- Enum member names (e.g. `Light`, `Dark`) are internal. Always resolve to the string values on the right-hand side (e.g. `Light = 'light'` resolves to `'light'`), which is what consumers pass
+- Compare resolved string values against `@values` in docs in both directions
+- Mismatch: **wrong values**
+- Intentionally omitted internal sentinels (e.g. `"default"`): flag for review
+
+### 4. Defaults
+- Check in this order: 1. `DEFAULT_*` constant 2. getter (`this.args.foo ?? <value>`) 3. translation string (use the `default:` fallback passed to `hdsIntl.t`)
+- If a value references an enum member, resolve it to its string value
+- Documented `@default` that matches the effective source value: no issue, regardless of where in source it lives
+- Documented `@default` that doesn't match source: **wrong default**
+- Documented `@default` with no corresponding source default: **default specified but none exists**
+- No `@default` in docs but a default exists in source: **undocumented default**
+
+### 5. Types
+- Args typed as `HdsFooBarTypes` (template-literal string union) or `HdsFooBarValues` (enum) are correctly documented as `@type="string"`, do not flag
+- Flag genuine mismatches: `number` as `@type="string"`, a function type as `@type="string"`, a `boolean` with string values `"true"`/`"false"`: **wrong type**
+
+### 6. Named blocks
+- Mismatch between `Blocks` interface in source and named block entries in docs: **wrong block**
+
+### 7. WithBoundArgs exclusions
+- If a contextual component is yielded with `WithBoundArgs<typeof Foo, 'argA' | 'argB'>`, those args are pre-bound by the parent and should not be documented on the child, do not flag as missing
+
+## Output format
+
+### Summary
+
+At the top of the analysis document, maintain a summary section with the following stats:
+
+- Components with issues out of total components audited (e.g. "7 / 9 audited")
+- Total issue count (excluding potential source bugs)
+- Count of potential source bugs noted separately
+- Count of issues flagged for review, with the arg names listed
+- A table of issue counts by type, with aligned columns, e.g.:
+
+```
+| Issue type                          | Count |
+|-------------------------------------|-------|
+| Wrong default                       | 3     |
+| Wrong type                          | 6     |
+| ...                                 | ...   |
+```
+
+### Findings
+
+For each component, report findings as a structured bulleted list. Only include a component or contextual component if it has at least one issue. Components with no issues should be omitted entirely. Mark uncertain findings "FLAG FOR REVIEW" in the issue type. Do not fix anything, report only
+
+Each issue must follow this structure exactly:
+
+- **`argName`: issue type**
+  - Description: one sentence explaining what is wrong
+  - Source (`file:line`):
+    - what the source defines for this arg
+  - Docs (`file:line`):
+    - what the docs currently say

--- a/component-api-docs-audit/initial-prompt.md
+++ b/component-api-docs-audit/initial-prompt.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The goal is to audit every HDS component and check the type definitions of component arguments in `packages/components/src/components/hds/` with its corresponding API documentation in `website/docs/components/`. The goal is to identify any inconsistencies in the documentation so they can be corrected to more accurately reflect our components to better serve our consumers and ongoing initiatives like the MCP server.
+The objective is to audit all HDS components in `packages/components/src/components/hds/` and verify that their argument type definitions match the API documentation in `website/docs/components/`. The results of the audit will be used to identify and correct any inconsistencies in the documentation.
 
 ## Relevant Files
 

--- a/component-api-docs-audit/initial-prompt.md
+++ b/component-api-docs-audit/initial-prompt.md
@@ -16,14 +16,14 @@ The website component API documentation we are checking lives in:
 
 ## Task requirements
 
-All checks apply to **every argument** in both source and docs. Documentation should reflect the **consumer experience**. Internal implementation details (where a default lives, how a type is represented in TypeScript, the translation service) are not themselves findings. Source code bugs (e.g. an arg declared but never used) are worth noting but are not documentation inconsistencies.
+All checks apply to **every argument** in both source and docs. Documentation should reflect the consumer experience. Internal implementation details (where a default lives, how a type is represented in TypeScript, the translation service) are not themselves findings. Source code bugs (e.g. an arg declared but never used) are worth noting but are not documentation inconsistencies.
 
 ### 1. Argument names
 - Arg in source `Args` absent from docs: **missing arg**
 - Arg in docs absent from source `Args`: **extra arg**
 - Name differs between source and docs (camelCase vs kebab-case, typo, abbreviation): **wrong arg name**
 - Never flag private fields, `@tracked` variables, or internal getters, as these are not consumer-facing
-- Exception: link-routing args (`route`, `model`, `models`, `query`, `current-when`, `replace`) are grouped into one docs entry, do not flag as missing
+- Exception: link-routing args (`route`, `model`, `models`, `query`, `current-when`, `replace`) are grouped into one docs entry, do not flag
 
 ### 2. Required/optional flag
 - `arg?:` in source = optional, `arg:` = required
@@ -38,14 +38,18 @@ All checks apply to **every argument** in both source and docs. Documentation sh
 ### 4. Defaults
 - Check in this order: 1. `DEFAULT_*` constant 2. getter (`this.args.foo ?? <value>`) 3. translation string (use the `default:` fallback passed to `hdsIntl.t`)
 - If a value references an enum member, resolve it to its string value
-- Documented `@default` that matches the effective source value: no issue, regardless of where in source it lives
+- Documented `@default` is ok as long as it matches the effective source value, regardless of where in source it lives
 - Documented `@default` that doesn't match source: **wrong default**
 - Documented `@default` with no corresponding source default: **default specified but none exists**
 - No `@default` in docs but a default exists in source: **undocumented default**
+- Exception: boolean args with no explicit source default may document `@default="false"`
 
 ### 5. Types
+- `@values` is a docs rendering utility only, never infer type from it
 - Args typed as `HdsFooBarTypes` (template-literal string union) or `HdsFooBarValues` (enum) are correctly documented as `@type="string"`, do not flag
-- Flag genuine mismatches: `number` as `@type="string"`, a function type as `@type="string"`, a `boolean` with string values `"true"`/`"false"`: **wrong type**
+- Flag genuine mismatches: `number` as `@type="string"`, a function type as `@type="string"`: **wrong type**
+- A `boolean` arg documented with `@values={{array "true" "false"}}` is not a type mismatch, do not flag.
+- An arg typed `number | string` in the source code is a leniency pattern and not a type mismatch, `@type="number"` in docs is correct, do not flag
 
 ### 6. Named blocks
 - Mismatch between `Blocks` interface in source and named block entries in docs: **wrong block**
@@ -75,7 +79,7 @@ At the top of the analysis document, maintain a summary section with the followi
 
 ### Findings
 
-For each component, report findings as a structured bulleted list. Only include a component or contextual component if it has at least one issue. Components with no issues should be omitted entirely. Mark uncertain findings "FLAG FOR REVIEW" in the issue type. Do not fix anything, report only
+For each component, report findings as a structured bulleted list. Only include a component or contextual component if it has at least one issue. Components with no issues should be omitted entirely. Mark uncertain findings "FLAG FOR REVIEW" in the issue type. Do not fix anything, report only in `final-analysis.md`.
 
 Each issue must follow this structure exactly:
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is just for reviewing the docs attached, do not merge!! 

### :pushpin: Summary

This PR aims to identify any consistencies that may exist between the type definitions of component arguments and their corresponding API documentation. Two documents are attached: `initial-prompt.md` and `final-analysis.md`. 
- `initial-prompt.md` includes AI instructions to audit each HDS component and its contextual components, specifically looking at: argument names, required flags, the `@values` array, default values, and types. 
     - Potential source code issues were also noted.
- `final-analysis.md` presents all of the raised issues by component, with a brief description of the problem and where to look in the source code and component API docs. 
     - Summary statistics on the most common issue types are also noted at the top. 
     - The contents of this file are not Bob's original output, as a second audit was performed afterward to remove any spuriously flagged issues and clean up the document.

Feedback would be appreciated to check if there is any criteria I may have missed or need to edit in `initial-prompt.md` and to make sure the raised issues in `final-analysis.md` are valid. Each issue was manually checked over once already, but some might be incorrectly flagged still based on context and implementation detail that I am missing. I've left in-line comments calling out some issues I wanted a second opinion on, especially for the potential source code bugs that were flagged 👍

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6584](https://hashicorp.atlassian.net/browse/HDS-6584)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6584]: https://hashicorp.atlassian.net/browse/HDS-6584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ