### PR TITLE
Website - Documentation fixes for table components

### DIFF
--- a/website/docs/components/table/advanced-table/partials/code/component-api.md
+++ b/website/docs/components/table/advanced-table/partials/code/component-api.md
@@ -36,7 +36,7 @@ The Advanced Table component itself is where most of the options will be applied
       It is recommended to use the [Application State](/components/application-state) component inside this block.
     </Doc::Banner>
   </C.Property>
-  <C.Property @name="model" @type="array">
+  <C.Property @name="model" @type="array" @required={{true}}>
     The data model to be used by the Advanced Table. **This array should be treated as immutable. Any updates must be made by passing a new array.** The model can have any shape, but for nested rows there are two expected keys.
     <Doc::ComponentApi as |C|>
       <C.Property @name="children" @type="array">
@@ -47,7 +47,7 @@ The Advanced Table component itself is where most of the options will be applied
       </C.Property>
     </Doc::ComponentApi>
   </C.Property>
-  <C.Property @name="columns" @type="array">
+  <C.Property @name="columns" @type="array" @required={{true}}>
     Array `hash` that defines each column with key-value properties that describe each column. Options:
     <Doc::ComponentApi as |C|>
       <C.Property @name="label" @type="string" @required={{true}}>
@@ -98,7 +98,7 @@ The Advanced Table component itself is where most of the options will be applied
   <C.Property @name="hasReorderableColumns" @type="boolean" @default="false">
     If set to `true`, allows users to reorder columns either by clicking and dragging on the column reorder handle with a mouse, or by moving focus to the handle with a keyboard and using the right and left arrow keys.
   </C.Property>
-  <C.Property @name="reorderedMessageText" @type="string" @default="Moved (label) column to (position)">
+  <C.Property @name="reorderedMessageText" @type="string" @default="Moved (label) column to position (position)">
     Customizable text added to `caption` element when a column reorder is performed.
   </C.Property>
   <C.Property @name="hasResizableColumns" @type="boolean" @default="false">
@@ -171,7 +171,7 @@ The Advanced Table component itself is where most of the options will be applied
   <C.Property @name="identityKey" @type="'@identity'|'none'|string" @default="@identity">
     Option to [specify a custom key](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each#:~:text=%3C/ul%3E-,Specifying%20Keys,-In%20order%20to) to the `each` iterator. If `identityKey="none"`, this is interpreted as an `undefined` value for the `@identity` key option.
   </C.Property>
-  <C.Property @name="sortedMessageText" @type="string" @default="Sorted by (label), (asc/desc)ending">
+  <C.Property @name="sortedMessageText" @type="string" @default="Sorted by (label) (asc/desc)ending">
     Customizable text added to `caption` element when a sort is performed.
   </C.Property>
   <C.Property @name="childrenKey" @type="string" @default="children">
@@ -236,10 +236,10 @@ If the `Th` component is passed as the first cell of a body row, `role="rowheade
   <C.Property @name="tooltip" @type="string">
     Text string which will appear in the [`Tooltip`](/components/tooltip). May contain basic HTML tags for formatting text such as `strong` and `em` tags. Not intended for multi-paragraph text or other more complex content. May not contain interactive content such as links or buttons. The `placement` and `offset` are automatically set and can’t be overwritten.
   </C.Property>
-  <C.Property @name="colspan" @type="string">
+  <C.Property @name="colspan" @type="number">
     The number of columns the cell spans. Used to apply the correct grid styles and the aria-rowspan attribute for accessibility.
   </C.Property>
-  <C.Property @name="rowspan" @type="string">
+  <C.Property @name="rowspan" @type="number">
     The number of rows the cell spans. Used to apply the correct grid styles and the aria-rowspan attribute for accessibility.
   </C.Property>
   <C.Property @name="yield">
@@ -261,10 +261,10 @@ Note: This component is not eligible to receive interactions (e.g., it cannot ha
   <C.Property @name="align" @type="enum" @values={{array "left" "center" "right" }} @default="left">
     Determines the horizontal content alignment (sometimes referred to as text alignment) for the cell (make sure it is also set for the column header).
   </C.Property>
-  <C.Property @name="colspan" @type="string">
+  <C.Property @name="colspan" @type="number">
     The number of columns the cell spans. Used to apply the correct grid styles and the aria-rowspan attribute for accessibility.
   </C.Property>
-  <C.Property @name="rowspan" @type="string">
+  <C.Property @name="rowspan" @type="number">
     The number of rows the cell spans. Used to apply the correct grid styles and the aria-rowspan attribute for accessibility.
   </C.Property>
   <C.Property @name="yield">

--- a/website/docs/components/table/table/partials/code/component-api.md
+++ b/website/docs/components/table/table/partials/code/component-api.md
@@ -109,7 +109,7 @@ The Table component itself is where most of the options will be applied. However
   <C.Property @name="identityKey" @type="'@identity'|'none'|string" @default="@identity">
     Option to [specify a custom key](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each#:~:text=%3C/ul%3E-,Specifying%20Keys,-In%20order%20to) to the `each` iterator. If `identityKey="none"`, this is interpreted as an `undefined` value for the `@identity` key option.
   </C.Property>
-  <C.Property @name="sortedMessageText" @type="string" @default="Sorted by (label), (asc/desc)ending">
+  <C.Property @name="sortedMessageText" @type="string" @default="Sorted by (label) (asc/desc)ending">
     Customizable text added to `caption` element when a sort is performed.
   </C.Property>
   <C.Property @name="...attributes">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the following inconsistencies in the component API docs for `AdvancedTable` and `Table`:
- [AdvancedTable](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR54)
    - columns: required in source but not marked required in the docs
    - model: required in source but not marked required in the docs
    - reorderedMessageText: docs default omits the word "position" that appears in the actual default string
    - sortedMessageText: docs default includes a comma after (label) that is not present in the actual default string
- [AdvancedTable::Th](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR84) / [AdvancedTable::Td](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR100)
     - colspan: source defines colspan as number but docs document it as string
     - rowspan: source defines rowspan as number but docs document it as string
- [Table](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR394)
    - sortedMessageText: docs default includes a comma after (label) that is not present in the actual default string

AdvancedTable: 
[before](https://helios.hashicorp.design/components/table/advanced-table?tab=code#advancedtable) | [after](https://hds-website-git-annawanggg-table-components-do-ead5cd-hashicorp.vercel.app/components/table/advanced-table?tab=code#advancedtable)

Table: 
[before](https://helios.hashicorp.design/components/table/table?tab=code#table) | [after](https://hds-website-git-annawanggg-table-components-do-ead5cd-hashicorp.vercel.app/components/table/table?tab=code#table)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6616](https://hashicorp.atlassian.net/browse/HDS-6616)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6616]: https://hashicorp.atlassian.net/browse/HDS-6616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ