### PR TITLE
Website - Documentation fixes for app components

### DIFF
--- a/website/docs/components/app-footer/partials/code/component-api.md
+++ b/website/docs/components/app-footer/partials/code/component-api.md
@@ -8,7 +8,7 @@ The base `AppFooter` component includes a copyright notice. It also wraps and co
   <C.Property @name="<[AF].ExtraBefore>" @type="yielded component">
     A generic container yielded as contextual component. Its content is injected before the `<ul>` list of links and items.
   </C.Property>
-  <C.Property @name="<[AF].StatusLink>" @type="yielded component">
+  <C.Property @name="<[AF].StatusLink>" @type="yielded component" @default="&quot;https://status.hashicorp.com&quot;">
     The yielded `AppFooter::StatusLink` contextual component (see below).
   </C.Property>
   <C.Property @name="<[AF].LegalLinks>" @type="yielded component">
@@ -93,7 +93,7 @@ The `AppFooter::LegalLinks` component, yielded as contextual component.
   <C.Property @name="hrefForSecurity" @type="string" @default="&quot;https://www.hashicorp.com/security&quot;">
     Override the default href value with a custom url value.
   </C.Property>
-  <C.Property @name="Accessibility" @type="string" @default="&quot;https://www.hashicorp.com/accessibility&quot;">
+  <C.Property @name="hrefForAccessibility" @type="string" @default="&quot;https://www.hashicorp.com/accessibility&quot;">
     Override the default href value with a custom url value.
   </C.Property>
   <C.Property @name="ariaLabel" @type="string" @default="&quot;Legal links&quot;">

--- a/website/docs/components/app-header/partials/code/component-api.md
+++ b/website/docs/components/app-header/partials/code/component-api.md
@@ -29,7 +29,7 @@
       <C.Property @name="a11yRefocusNavigationText" @type="string">
         Pass-through property for the `navigationText` argument - The text used as navigation message. Defaults to "The page navigation is complete. You may now navigate the page content as you wish.".
       </C.Property>
-      <C.Property @name="a11yRefocusRouteChangeValidator" @type="string">
+      <C.Property @name="a11yRefocusRouteChangeValidator" @type="function">
         Pass-through property for the `routeChangeValidator` argument - Custom function used to define which route changes should trigger the refocusing behavior for the navigator narrator. - For details see [Customizing the definition of a route change](https://github.com/ember-a11y/ember-a11y-refocus#customizing-the-definition-of-a-route-change).
       </C.Property>
       <C.Property @name="a11yRefocusExcludeAllQueryParams" @type="boolean">

--- a/website/docs/components/app-side-nav/partials/code/component-api.md
+++ b/website/docs/components/app-side-nav/partials/code/component-api.md
@@ -127,7 +127,7 @@ The `AppSideNav::List::BackLink` component, yielded as contextual component.
 It internally uses the [`Hds::Interactive`](/utilities/interactive) utility component. For more details about this component API, please refer to [its documentation page](/utilities/interactive?tab=code#component-api).
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="text" @type="string">
+  <C.Property @name="text" @type="string" @required={{true}}>
     The text content for the `AppSideNav::List::BackLink` component.
   </C.Property>
   <C.Property @name="href">
@@ -184,7 +184,7 @@ It internally uses the [`Hds::Interactive`](/utilities/interactive) utility comp
   <C.Property @name="hasSubItems" @type="boolean" @default="false">
     Indicates the existence of sub-item links. If set to `true`, displays a right aligned `chevron-right` icon.
   </C.Property>
-  <C.Property @name="isActive" @values={{array "false" "true" }} @default="false">
+  <C.Property @name="isActive" @type="boolean" @default="false">
     If set to `true`, adds the class name of “active” to the rendered interactive element. Used to indicate the currently active page Link.
   </C.Property>
   <C.Property @name="href">


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the following inconsistencies in the component API docs for `AppFooter`, `AppHeader`, and `AppSideNav`:
- [AppFooter](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR134)
   - [AF].LegalLinks
      - hrefForAccessibility: arg in source is hrefForAccessibility but the docs document it as Accessibility
   - [AF].StatusLink
      - href: source falls back to <https://status.hashicorp.com> when href is absent, but docs do not document this default
- [AppHeader](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR179)
   - a11yRefocusRouteChangeValidator: Docs document this as @type="string" but the type is a callback function @type="function"
- [AppSideNav::List::BackLink](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR196)
   - text: required in source but not marked required in docs
- [AppSideNav::List::Link](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR205)
   - isActive: arg is boolean but @type is not set in the docs
   

AppFooter: 
[before](https://helios.hashicorp.design/components/app-footer?tab=code#appfooter) | [after](https://hds-website-git-app-components-docs-fixes-hashicorp.vercel.app/components/app-footer?tab=code#appfooter)

AppHeader: 
[before](https://helios.hashicorp.design/components/app-header?tab=code#appheader) | [after](https://hds-website-git-app-components-docs-fixes-hashicorp.vercel.app/components/app-header?tab=code#appheader)

AppSideNav: 
[before](https://helios.hashicorp.design/components/app-side-nav?tab=code#appsidenavlist) | [after](https://hds-website-git-app-components-docs-fixes-hashicorp.vercel.app/components/app-side-nav?tab=code#appsidenavlist)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6618](https://hashicorp.atlassian.net/browse/HDS-6618)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6618]: https://hashicorp.atlassian.net/browse/HDS-6618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ