### PR TITLE
Website - Documentation fixes for components

### DIFF
--- a/website/docs/components/accordion/partials/code/component-api.md
+++ b/website/docs/components/accordion/partials/code/component-api.md
@@ -47,8 +47,8 @@ The `Accordion::Item` component, yielded as contextual component.
       </C.Property>
     </Doc::ComponentApi>
   </C.Property>
-  <C.Property @name="ariaLabel" @type="string" @default="&quot;Toggle display&quot;">
-    Accepts a string. The `ariaLabel` value is applied to the HTML button which controls visibility of the content block content.
+  <C.Property @name="ariaLabel" @type="string">
+    Accepts a string. The `ariaLabel` value is applied to the HTML button which controls visibility of the content block content. If not provided, the accessible name is taken from the toggle block content via `aria-labelledby`.
   </C.Property>
   <C.Property @name="isOpen" @default="false" @type="boolean">
     Toggles the visibility of the content. To display content on page load, set the value to `true`.

--- a/website/docs/components/accordion/partials/code/how-to-use.md
+++ b/website/docs/components/accordion/partials/code/how-to-use.md
@@ -42,7 +42,7 @@ The `@forceState` argument can be used to programmatically control individual Ac
 
 ### Accessible name
 
-The `ariaLabel` value is applied to the HTML button which controls visibility of the content block. The text does not display in the UI. The default value is "Toggle display" but you can set a custom value useful for translated text for example.
+The `@ariaLabel` value is applied to the HTML button which controls visibility of the content block. The text does not display in the UI. You can set a custom value useful for translated text for example. If not provided, the accessible name is taken from the toggle block content via `aria-labelledby`. 
 
 [[code-snippets/accordion-a11y-name]]
 
@@ -61,18 +61,18 @@ The `@titleTag` argument changes the HTML element that wraps the title block of 
 
 ### Open
 
-Set `isOpen` to `true` on an `Accordion::Item` to display its associated content on page load instead of initially hiding it.
+Set `@isOpen` to `true` on an `Accordion::Item` to display its associated content on page load instead of initially hiding it.
 
 [[code-snippets/accordion-open]]
 
 ### Static
 
-Set `isStatic` to `true` on an `Accordion::Item` to remove the ability to interact with the toggle.
+Set `@isStatic` to `true` on an `Accordion::Item` to remove the ability to interact with the toggle.
 
 [[code-snippets/accordion-static]]
 
 ### Contains interactive
 
-By default, the `containsInteractive` property of the `Accordion::Item` is set to `false`, meaning that the entire `Accordion::Item` toggle block can be clicked to hide and show the associated content. If set to `true`, only the chevron button of the `Accordion::Item` is clickable vs. the entire block. This allows you to add other interactive content inside the toggle block if desired.
+By default, the `@containsInteractive` property of the `Accordion::Item` is set to `false`, meaning that the entire `Accordion::Item` toggle block can be clicked to hide and show the associated content. If set to `true`, only the chevron button of the `Accordion::Item` is clickable vs. the entire block. This allows you to add other interactive content inside the toggle block if desired.
 
 [[code-snippets/accordion-contains-interactive-complex]]

--- a/website/docs/components/alert/partials/code/component-api.md
+++ b/website/docs/components/alert/partials/code/component-api.md
@@ -90,7 +90,7 @@ The `Link::Standalone` component, yielded as contextual component inside the `"a
 
 <Doc::ComponentApi as |C|>
   <C.Property>
-    It exposes the same API as the [`Link::Standalone`](/components/link/standalone) component, apart from the `@size` argument, which is pre-defined to be
+    It exposes the same API as the [`Link::Standalone`](/components/link/standalone) component, apart from the `@size` argument, which is pre-defined to be `small`.
   </C.Property>
 </Doc::ComponentApi>
 

--- a/website/docs/components/alert/partials/code/how-to-use.md
+++ b/website/docs/components/alert/partials/code/how-to-use.md
@@ -1,18 +1,18 @@
 ## How to use this component
 
-The most basic invocation requires the `type` argument to be passed, along with the `title` and/or `description` content. By default, a `neutral` Alert is generated.
+The most basic invocation requires the `@type` argument to be passed, along with the `Title` and/or `Description` content. By default, a `neutral` Alert is generated.
 
 [[code-snippets/alert-basic]]
 
 ### Type
 
-A different type of Alert can be invoked using the `type` argument.
+A different type of Alert can be invoked using the `@type` argument.
 
 [[code-snippets/alert-types]]
 
 ### Title and description
 
-Optionally, you can pass only `title` or only `description`.
+Optionally, you can pass only `Title` or only `Description`.
 
 [[code-snippets/alert-title-desc]]
 
@@ -33,7 +33,7 @@ The `@tag` argument changes the HTML element that wraps the title content of `[A
 
 The available color values are `neutral` (the default), `highlight`, `success`, `warning`, and `critical`. Setting a color value will also determine the default icon used in the Alert, although it is customizable. 
 
-The color value will also determine some accessibility features of the component, so this should be taken into consideration when choosing which Alert `color` value to use.
+The color value will also determine some accessibility features of the component, so this should be taken into consideration when choosing which Alert `@color` value to use.
 
 
 If the alert is being used in an informational or promotional way, `neutral` or `highlight` colors should be chosen. 
@@ -44,17 +44,17 @@ The other color values map to accessibility-related roles, and will ensure that 
 
 ### Icons
 
-A different icon can be used in the Alert using the `icon` argument. This accepts any [icon](/icons/library) name.
+A different icon can be used in the Alert using the `@icon` argument. This accepts any [icon](/icons/library) name.
 
 [[code-snippets/alert-icon]]
 
-If you need to hide the icon, pass `false` to the `icon` argument. This is only an option on page and inline Alerts as compact Alerts require an icon.
+If you need to hide the icon, pass `false` to the `@icon` argument. This is only an option on page and inline Alerts as compact Alerts require an icon.
 
 [[code-snippets/alert-no-icon]]
 
 ### Dismissal
 
-To enable dismissibility, pass a callback function to the `onDismiss` argument. This will add a dismiss button to the Alert. When that button is clicked, the callback function will be executed. 
+To enable dismissibility, pass a callback function to the `@onDismiss` argument. This will add a dismiss button to the Alert. When that button is clicked, the callback function will be executed. 
 
 Given the variety of use cases and contexts in which alerts are used across products, application teams will need to implement the callback function.
 

--- a/website/docs/components/application-state/partials/code/how-to-use.md
+++ b/website/docs/components/application-state/partials/code/how-to-use.md
@@ -58,7 +58,7 @@ Application State content, such as text, is left-aligned by default but you can 
 
 #### Left align content container
 
-To turn off centering of the Application State content container, set `isAutoCentered` to “false”.
+To turn off centering of the Application State content container, set `@isAutoCentered` to “false”.
 
 [[code-snippets/application-state-auto-center-false]]
 

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -54,7 +54,7 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
     Callback function invoked (if provided) when the "copy" action succeeds.
   </C.Property>
   <C.Property @name="copySuccessMessageText" @type="string" @default="'Copied to clipboard'">
-    Override this value to provide a meaningful `aria-live` message for the [`Copy::Button`](/components/copy/button) component when the copy action succeeds.
+    Override this value to provide a meaningful `aria-live` message when the "copy" action succeeds.
   </C.Property>
 </Doc::ComponentApi>
 

--- a/website/docs/components/code-block/partials/code/component-api.md
+++ b/website/docs/components/code-block/partials/code/component-api.md
@@ -32,7 +32,7 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
     Used to control whether a copy button for copying the code/text content will be displayed.
   </C.Property>
-    <C.Property @name="copyButtonText" @type="string" @default="'Copy'">
+  <C.Property @name="copyButtonText" @type="string" @default="'Copy'">
     Override this value to provide a meaningful `aria-label` for the [`Copy::Button`](/components/copy/button) component.
   </C.Property>
   <C.Property @name="hasLineNumbers" @type="boolean" @default="true">
@@ -52,6 +52,9 @@ This component uses [prism.js](https://prismjs.com/) under the hood.
   </C.Property>
   <C.Property @name="onCopy" @type="function">
     Callback function invoked (if provided) when the "copy" action succeeds.
+  </C.Property>
+  <C.Property @name="copySuccessMessageText" @type="string" @default="'Copied to clipboard'">
+    Override this value to provide a meaningful `aria-live` message for the [`Copy::Button`](/components/copy/button) component when the copy action succeeds.
   </C.Property>
 </Doc::ComponentApi>
 

--- a/website/docs/components/code-block/partials/code/how-to-use.md
+++ b/website/docs/components/code-block/partials/code/how-to-use.md
@@ -34,19 +34,19 @@ The default `@tag` is `"div"` because the correct value is dependent on the indi
 
 ### Language
 
-The `language` argument sets the syntax highlighting used. We only support the following languages: `bash`, `go`, `hcl`, `json`, `log`, `ruby`, `shell-session`, and `yaml`. If you need additional languages <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>
+The `@language` argument sets the syntax highlighting used. We only support the following languages: `bash`, `go`, `hcl`, `json`, `log`, `ruby`, `shell-session`, and `yaml`. If you need additional languages <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>
 
 [[code-snippets/code-block-language]]
 
 ### Copy button
 
-Set `hasCopyButton` to `true` to display a button for users to copy `CodeBlock` content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the copy button. Set `onCopy` to a callback function that is invoked when the "copy" action succeeds.
+Set `@hasCopyButton` to `true` to display a button for users to copy `CodeBlock` content to their computer clipboard. Use `@copyButtonText` to provide a meaningful and unique label for the copy button.  Set `@onCopy` to a callback function that is invoked when the "copy" action succeeds. Use `@copySuccessMessageText` to provide a meaningful `aria-live` message when the "copy" action succeeds.
 
 [[code-snippets/code-block-copy-button]]
 
 ### Line numbers
 
-Line numbers are displayed by default. Set `hasLineNumbers` to `false` to hide them.
+Line numbers are displayed by default. Set `@hasLineNumbers` to `false` to hide them.
 
 [[code-snippets/code-block-no-line-numbers]]
 
@@ -59,7 +59,7 @@ Due to technical limitations, if the `@value` changes dynamically the line numbe
 
 ### Line wrapping
 
-By default, long lines of code will overflow the `CodeBlock` container requiring users to scroll to view the full content. Setting `hasLineWrapping` to `true` will wrap long lines of code instead.
+By default, long lines of code will overflow the `CodeBlock` container requiring users to scroll to view the full content. Setting `@hasLineWrapping` to `true` will wrap long lines of code instead.
 
 [[code-snippets/code-block-line-wrap]]
 
@@ -71,6 +71,6 @@ Highlight either individual code lines or a range of code lines. (Examples: `2, 
 
 ### Limit height
 
-Code content uses `auto` height by default but you can opt to set a `maxHeight` value to save space. If the content height exceeds the set max height, vertical scrolling is enabled to view the overflowing content and a toggle button is displayed to expand the height and show the Code Block content in its entirety.
+Code content uses `auto` height by default but you can opt to set a `@maxHeight` value to save space. If the content height exceeds the set max height, vertical scrolling is enabled to view the overflowing content and a toggle button is displayed to expand the height and show the Code Block content in its entirety.
 
 [[code-snippets/code-block-max-height]]

--- a/website/docs/components/code-editor/partials/code/component-api.md
+++ b/website/docs/components/code-editor/partials/code/component-api.md
@@ -32,6 +32,9 @@ This component uses [CodeMirror 6](https://codemirror.net/) under the hood.
   <C.Property @name="customExtensions" @type="array">
     Accepts custom CodeMirror 6 extensions. More information about creating extensions can be found in the [CodeMirror documentation](https://codemirror.net/docs/ref/#state.Extension).
   </C.Property>
+  <C.Property @name="extraKeys" @type="object">
+    Accepts an object of custom key bindings to register with the editor. More information about creating keymaps can be found in the [CodeMirror documentation](https://codemirror.net/docs/ref/#view.KeyBinding).
+  </C.Property>
   <C.Property @name="cspNonce" @type="string">
     Provides a Content Security Policy nonce to use when creating the style sheets for the editor. If none is provided, the editor will attempt to extract a nonce from the Content Security Policy.
   </C.Property>

--- a/website/docs/components/code-editor/partials/code/how-to-use.md
+++ b/website/docs/components/code-editor/partials/code/how-to-use.md
@@ -34,37 +34,37 @@ The `@tag` argument changes the HTML element that wraps the `[CE].Title` content
 
 ### Language
 
-The `language` argument sets the syntax highlighting used. We support the following languages: `rego`, `ruby`, `sentinel`, `shell`, `go`, `hcl`, `javascript`, `json`, `markdown`, `sql`, and `yaml`. If you need additional languages, <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>.
+The `@language` argument sets the syntax highlighting used. We support the following languages: `rego`, `ruby`, `sentinel`, `shell`, `go`, `hcl`, `javascript`, `json`, `markdown`, `sql`, and `yaml`. If you need additional languages, <LinkTo class="doc-link-generic" @route="show" @model="about/support">contact the Design Systems Team</LinkTo>.
 
 [[code-snippets/code-editor-language]]
 
 ### Linting
 
-Set `isLintingEnabled` to `true` to enable linting within the editor. Linting is only available when `language` is set to `json`.
+Set `@isLintingEnabled` to `true` to enable linting within the editor. Linting is only available when `language` is set to `json`.
 
 [[code-snippets/code-editor-lint]]
 
 ### Copy button
 
-Set `hasCopyButton` to `true` to display a button for users to copy Code Editor content to their computer clipboard. Use `copyButtonText` to provide a meaningful and unique label for the copy button.
+Set `@hasCopyButton` to `true` to display a button for users to copy Code Editor content to their computer clipboard. Use `@copyButtonText` to provide a meaningful and unique label for the copy button.
 
 [[code-snippets/code-editor-copy-button]]
 
 ### Full screen mode
 
-Set `hasFullScreenButton` to `true` to display a button for users to toggle between a full screen view and normal placement within the page.
+Set `@hasFullScreenButton` to `true` to display a button for users to toggle between a full screen view and normal placement within the page.
 
 [[code-snippets/code-editor-full-screen]]
 
 ### Line wrapping
 
-Set `hasLineWrapping` to `true` to enable line wrapping within the editor.
+Set `@hasLineWrapping` to `true` to enable line wrapping within the editor.
 
 [[code-snippets/code-editor-line-wrap]]
 
 ### Custom extensions
 
-The Code Editor supports valid [CodeMirror 6 extensions](https://codemirror.net/docs/ref/#state.Extension) via the `@customExtensions` argument. This allows you to add custom keymaps, gutter markers, theme overrides, or advanced editor behavior.
+The Code Editor supports valid [CodeMirror 6 extensions](https://codemirror.net/docs/ref/#state.Extension) via the `@customExtensions` argument. This allows you to add gutter markers, theme overrides, or advanced editor behavior. Use `@extraKeys` to add custom [key bindings](https://codemirror.net/docs/ref/#view.KeyBinding).
 
 #### Importing CodeMirror modules
 

--- a/website/docs/components/copy/button/partials/code/how-to-use.md
+++ b/website/docs/components/copy/button/partials/code/how-to-use.md
@@ -1,6 +1,6 @@
 ## How to use this component
 
-The basic invocation requires `text` and `targetToCopy` to be passed:
+The basic invocation requires `@text` and `@targetToCopy` to be passed:
 
 [[code-snippets/copy-button-basic]]
 

--- a/website/docs/components/dropdown/partials/code/component-api.md
+++ b/website/docs/components/dropdown/partials/code/component-api.md
@@ -119,6 +119,9 @@ The `Dropdown::Toggle::Button` component, yielded as contextual component.
   </C.Property>
   <C.Property @name="color" @type="enum" @values={{array "primary" "secondary" }} @default="primary"/>
   <C.Property @name="size" @type="enum" @values={{array "medium" "small" }} @default="medium"/>
+  <C.Property @name="isFullWidth" @type="boolean" @default="false">
+    Indicates that a button should take up the full width of the parent container.
+  </C.Property>
   <C.Property @name="icon" @type="string">
     Acceptable value: any [icon](/icons/library) name.
   </C.Property>

--- a/website/docs/components/filter-bar/partials/code/component-api.md
+++ b/website/docs/components/filter-bar/partials/code/component-api.md
@@ -42,7 +42,7 @@
 The shape of the object for the `@filters` argument. The shape differs depending on the `type` provided.
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="type" @type="enum" @values={{array "single-select" "multi-select" "numerical" "date" "time" "datetime" "generic"}} @required="true">
+  <C.Property @name="type" @type="enum" @values={{array "single-select" "multi-select" "numerical" "date" "time" "datetime" "generic"}} @required={{true}}>
     The type of data being filtered.
   </C.Property>
   <C.Property @name="text" @type="string">

--- a/website/docs/components/filter-bar/partials/code/how-to-use.md
+++ b/website/docs/components/filter-bar/partials/code/how-to-use.md
@@ -14,7 +14,7 @@ All filtering options are available via a dropdown in the Filter Bar. Inside the
 
 Filtering options are passed to the Filter Bar through the `FiltersDropdown` and `FilterGroup` contextual components. In the `FilterGroup`, the `@key`, `@text`, and `@type` arguments are required.
 
-- The `@key` argument sets the key for that filter group in the data object of the `onFilter` callback.
+- The `@key` argument sets the key for that filter group in the data object of the `@onFilter` callback.
 - The `@text` argument sets the text for tab label.
 - The `@type` argument specifies the type of filtering available for the group.
 
@@ -28,7 +28,7 @@ A user can apply, update, or clear filters within the dropdown. The `@onFilter` 
 
 The callback provides a data object of applied filters which come from a user's filter selections. This object can be used to run any filtering operations on a data set, and then be passed back into the `@filters` argument of the Filter Bar to show the applied filters.
 
-Based on the applied filters passed to the `@filters` argument, dismissible [Tags](/components/tab) will be shown for each applied filter. When a Tag is dismissed, the `@onFilter` callback will be triggered, and that filter will be removed from the object.
+Based on the applied filters passed to the `@filters` argument, dismissible [Tags](/components/tag) will be shown for each applied filter. When a Tag is dismissed, the `@onFilter` callback will be triggered, and that filter will be removed from the object.
 
 [[code-snippets/filter-bar-basic]]
 
@@ -85,7 +85,7 @@ The accessibility compliance of any content used for a custom filter is the resp
 
 For filtering support outside of the filter types supported above, an option for more customized filtering is available through the `generic` filter type, and the Generic contextual component inside the `FilterGroup`. The Generic contextual component provides an `updateFilter` argument function that can be used to trigger updates to the filter inside the dropdown.
 
-The dismissible filter tag can be customized by setting `dismissTagText` on the filter. If this is not provided, the dismissible filter tag's text will function similarly to the `single-select` and `multi-select` filter types, where the `value` or `label` is displayed.
+The dismissible filter tag can be customized by setting `@dismissTagText` on the filter. If this is not provided, the dismissible filter tag's text will function similarly to the `single-select` and `multi-select` filter types, where the `value` or `label` is displayed.
 
 The `@onClear` callback can be used to listen to the `FilterGroup` "Clear filter" button, and reset any content inside your filter such as clearing a form input.
 
@@ -95,7 +95,7 @@ The `@onClear` callback can be used to listen to the `FilterGroup` "Clear filter
 
 A `generic` filter can also contain multiple filters, similar to a `multi-select` filter. By passing an array of data to the `data` object each item in the array will be displayed as a distinct filter.
 
-The dismissible filter tag will display the `label` for a given filter, and if the `label` is not provided it will display the `value`. The text can be customized by adding a `dismissTagText` value.
+The dismissible filter tag will display the `label` for a given filter, and if the `label` is not provided it will display the `value`. The text can be customized by adding a `@dismissTagText` value.
 
 [[code-snippets/filter-bar-type-generic-array]]
 

--- a/website/docs/components/icon-tile/partials/code/component-api.md
+++ b/website/docs/components/icon-tile/partials/code/component-api.md
@@ -4,7 +4,7 @@
 
 <Doc::ComponentApi as |C|>
   <C.Property @name="size" @type="enum" @values={{array "small" "medium" "large" }} @default="medium"/>
-  <C.Property @name="color" @type="enum" @values={{array "neutral" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "waypoint" }} @default="neutral">
+  <C.Property @name="color" @type="enum" @values={{array "neutral" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "vault-radar" "waypoint" }} @default="neutral">
     The `@color` parameter is overwritten if a `@logo` parameter is passed, in which case the product “brand“ color is used.
   </C.Property>
   <C.Property @name="logo" @type="enum" @values={{array "hcp" "boundary" "consul" "nomad" "packer" "terraform" "vagrant" "vault" "vault-secrets" "vault-radar" "waypoint" }}>

--- a/website/docs/components/icon/partials/code/component-api.md
+++ b/website/docs/components/icon/partials/code/component-api.md
@@ -1,10 +1,10 @@
 ## Component API
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="name" @type="string" @required="true">
+  <C.Property @name="name" @type="string" @required={{true}}>
     The name of the icon you wish to use. If the value does not match an existing icon name, an error will be thrown. Search for existing icon names in [the Icon library](/icons/library).
   </C.Property>
-  <C.Property @name="size" @type="number" @default="16" @values={{array "16" "24"}}>
+  <C.Property @name="size" @type="'16' | '24'" @default="16" @values={{array "16" "24"}}>
     Sets the size of the icon in pixels. Only two sizes are supported. (Setting a non-standard size will cause the SVG to render at the specified size but it will be invisible.)
   </C.Property>
   <C.Property @name="color" @type="string | CSS color" @values={{array "primary" "strong" "faint" "disabled" "high-contrast" "action" "action-hover" "action-active" "highlight" "highlight-on-surface" "highlight-high-contrast" "success" "success-on-surface" "success-high-contrast" "warning" "warning-on-surface" "warning-high-contrast" "critical" "critical-on-surface" "critical-high-contrast" }}>


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the following inconsistencies in the component API docs:
- [Accordion](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR29)
   - [A].Item
      - ariaLabel: docs claim a hardcoded string default of "Toggle display" that does not exist in source code, actual fallback is a different accessibility mechanism
- [Alert](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR118)
   - [A].LinkStandalone
      - size: description in docs is cut off mid-way
- [CodeBlock](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR237)
   - copySuccessMessageText: arg exists in source but is not documented
- [CodeEditor](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR253)
   - extraKeys: arg exists in source but is not documented
- [Dropdown](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR264)
   - isFullWidth: arg exists in source but is not documented
- [FilterBar](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR280)
   - Filter types
      - type: minor component api doc formatting inconsistency, where the @required attribute uses a string value "true" instead of the boolean {{true}}
- [Icon](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR299)
   - name: minor component api doc formatting inconsistency, where the @required attribute uses a string value "true" instead of the boolean {{true}}
   - size: size is documented as @type="number" but the source type HdsIconSizes resolves to the string union '16' | '24'
- [IconTile](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR322)
   - color: docs missing "vault-radar" from the @values list

Since some of these fixes involved adding missing args to the component API docs and changes to the "How to use" sections, would love suggestions on improving the wording where needed! Also, FYI as I went through the docs for the first half of all HDS components, I also made very minor edits to some of the "How to use" sections adding `@` to any arguments missing it.

Pointing out a few of the bigger changes:
Accordion:
[before](https://helios.hashicorp.design/components/accordion?tab=code#aitem) | [after](https://hds-website-git-annawanggg-component-batch-1-d-b8afab-hashicorp.vercel.app/components/accordion?tab=code#aitem)

CodeBlock:
[before](https://helios.hashicorp.design/components/code-block?tab=code#codeblock) | [after](https://hds-website-git-annawanggg-component-batch-1-d-b8afab-hashicorp.vercel.app/components/code-block?tab=code#codeblock)

CodeEditor:
[before](https://helios.hashicorp.design/components/code-editor?tab=code#codeeditor) | [after](https://hds-website-git-annawanggg-component-batch-1-d-b8afab-hashicorp.vercel.app/components/code-editor?tab=code#codeeditor)

Dropdown:
[before](https://helios.hashicorp.design/components/dropdown?tab=code#dtogglebutton) | [after](https://hds-website-git-annawanggg-component-batch-1-d-b8afab-hashicorp.vercel.app/components/dropdown?tab=code#dtogglebutton)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6619](https://hashicorp.atlassian.net/browse/HDS-6619)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6619]: https://hashicorp.atlassian.net/browse/HDS-6619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ