### PR TITLE
Website - Documentation fixes for form components

### DIFF
--- a/website/docs/components/form/key-value-inputs/partials/code/component-api.md
+++ b/website/docs/components/form/key-value-inputs/partials/code/component-api.md
@@ -132,7 +132,7 @@ The `Form::KeyValueInputs::Field` component, yielded as contextual component, in
   <C.Property @name="isInvalid" @type="boolean">
     Applies an “invalid” appearance to the control but doesn’t modify its logical validity.
   </C.Property>
-  <C.Property @name="width" @type="string" @default="1f">
+  <C.Property @name="width" @type="string" @default="1fr">
     Sets the width of the Field. By default, the field is `1fr` of the CSS grid container.
   </C.Property>
   <C.Property @name="extraAriaDescribedBy" @type="string">

--- a/website/docs/components/form/key-value-inputs/partials/code/how-to-use.md
+++ b/website/docs/components/form/key-value-inputs/partials/code/how-to-use.md
@@ -32,7 +32,7 @@ To display an error for the entire fieldset (the whole group of inputs), use the
 
 [[code-snippets/key-value-inputs-validation]]
 
-To display an error on a single field, set the `isInvalid` argument on the `[R].Field` yielded component, and use the `[F].Error` yielded component.
+To display an error on a single field, set the `@isInvalid` argument on the `[R].Field` yielded component, and use the `[F].Error` yielded component.
 
 [[code-snippets/key-value-inputs-field-validation]]
 
@@ -50,7 +50,7 @@ If there is additional content needed in the header or a need for an unsupported
 
 ### Field width
 
-Fields are equal width by default. Use the Field’s `width` argument to customize field widths.
+Fields are equal width by default. Use the Field’s `@width` argument to customize field widths.
 
 [[code-snippets/key-value-inputs-field-width]]
 
@@ -66,7 +66,7 @@ Below we showcase a couple of examples of common patterns. They should be used a
 
 ### Updating the rows
 
-Consumers are responsible for handling the logic to add or remove a row. To do this, use the `onClick` argument to pass a callback function on the yielded `[F].AddRowButton` in the `:footer` named block or the yielded `[R].DeleteRowButton` in the `:row` named block.
+Consumers are responsible for handling the logic to add or remove a row. To do this, use the `@onClick` argument to pass a callback function on the yielded `[F].AddRowButton` in the `:footer` named block or the yielded `[R].DeleteRowButton` in the `:row` named block.
 
 [[code-snippets/key-value-inputs-update-rows]]
 

--- a/website/docs/components/form/layout/partials/code/component-api.md
+++ b/website/docs/components/form/layout/partials/code/component-api.md
@@ -39,8 +39,8 @@
   <C.Property @name="tag" @type="enum" @values={{array "form" "div"}} @default="form">
     The HTML tag that wraps the `Form` content.
   </C.Property>
-  <C.Property @name="sectionMaxWidth" @type="string" @valueNote="any valid CSS width (px, rem, etc)" @default="672px">
-    The max-width value for `Form Section` components and other direct `Form` child components which include the `FormHeader`, `FormSeparator`, and `FormFooter`.
+  <C.Property @name="sectionMaxWidth" @type="string" @valueNote="any valid CSS width (px, rem, etc)">
+    The max-width value for `Form Section` components and other direct `Form` child components which include the `FormHeader`, `FormSeparator`, and `FormFooter`. By default, the max-width value is `672px`.
   </C.Property>
   <C.Property @name="yield">
     Elements passed as children are yielded as inner content of the element.
@@ -76,7 +76,7 @@
   <C.Property @name="tag" @type="enum" @values={{array "div" "h1" "h2" "h3" "h4" "h5" "h6"}} @default="div">
     A valid HTML tag name to be used to render the `Title` element.
   </C.Property>
-  <C.Property @name="size" @type="string" @values={{array "500" "400" "300" "200" "100" }} @default="200">
+  <C.Property @name="size" @type="string" @values={{array "500" "400" "300" "200" "100" }} @default="400">
     The size of the `Display` text style.
   </C.Property>
   <C.Property @name="yield">

--- a/website/docs/components/form/layout/partials/code/how-to-use.md
+++ b/website/docs/components/form/layout/partials/code/how-to-use.md
@@ -6,7 +6,7 @@ Use the `Form` to contain other Form layout components and form content. This es
 
 [[code-snippets/form-layout-basic execute=false]]
 
-The `Form` renders as an HTML `form` element by default. Use the `tag` argument to optionally use an HTML `div` instead.
+The `Form` renders as an HTML `form` element by default. Use the `@tag` argument to optionally use an HTML `div` instead.
 
 [[code-snippets/form-layout-tag execute=false]]
 
@@ -44,7 +44,7 @@ While the `FormSection` is typically used to contain Form Fields, it can also be
 
 [[code-snippets/form-layout-section]]
 
-Pass an `isFullWidth` argument to override the default max-width of an individual `FormSection` if needed.
+Pass an `@isFullWidth` argument to override the default max-width of an individual `FormSection` if needed.
 
 [[code-snippets/form-layout-section-full-width]]
 
@@ -74,7 +74,7 @@ To lay out related Form Fields or controls in a row, use the `SectionMultiFieldG
 
 [[code-snippets/form-layout-multi-field]]
 
-To control the widths of individual elements within a `SectionMultiFieldGroup`, you can wrap the element with an `Item` and pass in a `width` value. Fields not wrapped with an `Item` will take up the remaining available width.
+To control the widths of individual elements within a `SectionMultiFieldGroup`, you can wrap the element with an `Item` and pass in a `@width` value. Fields not wrapped with an `Item` will take up the remaining available width.
 
 [[code-snippets/form-layout-multi-field-width]]
 

--- a/website/docs/components/form/primitives/partials/code/component-api.md
+++ b/website/docs/components/form/primitives/partials/code/component-api.md
@@ -12,6 +12,9 @@
   <C.Property @name="isOptional" @type="boolean" @default="false">
     Appends an `Optional` indicator next to the label text when user input is optional.
   </C.Property>
+  <C.Property @name="hiddenText" @type="string">
+    Accepts a string. The `hiddenText` value is rendered as visually hidden accessible text.
+  </C.Property>
   <C.Property @name="yield">
     Elements passed as children are yielded as inner content of a `<label>` HTML element.
   </C.Property>

--- a/website/docs/components/form/primitives/partials/code/how-to-use.md
+++ b/website/docs/components/form/primitives/partials/code/how-to-use.md
@@ -2,15 +2,15 @@
 
 ### Form::Label
 
-The default invocation requires text to be passed and a `controlId` argument (the ID of the form control associated with the label).
+The default invocation requires text to be passed and a `@controlId` argument (the ID of the form control associated with the label).
 
 [[code-snippets/form-primitives-basic]]
 
-Pass an `isRequired` argument, when user input is required for the associated form control.
+Pass an `@isRequired` argument, when user input is required for the associated form control.
 
 [[code-snippets/form-primitives-required]]
 
-Pass an `isOptional` argument, when the user input is optional for the associated form control.
+Pass an `@isOptional` argument, when the user input is optional for the associated form control.
 
 [[code-snippets/form-primitives-optional]]
 
@@ -27,9 +27,9 @@ The `<label>` element is linked via `for` attribute to the `<input/select/textar
 
 ### Form::HelperText
 
-The default invocation requires text to be passed and a `controlId` argument.
+The default invocation requires text to be passed and a `@controlId` argument.
 
-The `controlId` value is used to generate an ID, prefixed with `helper-text-`, so that the ID can be referenced in the `aria-describedby` attribute of the form control. If no `controlId` is provided, no ID is generated. If needed, it can be passed directly as an HTML attribute.
+The `@controlId` value is used to generate an ID, prefixed with `helper-text-`, so that the ID can be referenced in the `aria-describedby` attribute of the form control. If no `@controlId` is provided, no ID is generated. If needed, it can be passed directly as an HTML attribute.
 
 [[code-snippets/form-primitives-helper-text]]
 
@@ -46,9 +46,9 @@ Interactive elements in text (associated with the input through `aria-describedb
 
 ### Form::CharacterCount
 
-The default invocation requires a `controlId` argument referencing a valid `<input>` or `<textarea>` element and a `@value` argument storing the value of the associated form control.
+The default invocation requires a `@controlId` argument referencing a valid `<input>` or `<textarea>` element and a `@value` argument storing the value of the associated form control.
 
-The `controlId` value is used to generate an ID, prefixed with `character-count-`, so that the ID can be referenced in the `aria-describedby` attribute of the form control.
+The `@controlId` value is used to generate an ID, prefixed with `character-count-`, so that the ID can be referenced in the `aria-describedby` attribute of the form control.
 
 [[code-snippets/form-primitives-character-count]]
 
@@ -72,9 +72,9 @@ For custom messages, you can use the following arguments to build a relevant mes
 
 ### Form::Error
 
-The default invocation requires text to be passed and a `controlId` argument.
+The default invocation requires text to be passed and a `@controlId` argument.
 
-The `controlId` value will be used to generate an ID, prefixed with `error-`, so that this ID can be referenced in the `aria-describedby` attribute of the form control. If no `controlId` is provided, no ID is generated. If needed, it can be passed directly as an HTML attribute.
+The `@controlId` value will be used to generate an ID, prefixed with `error-`, so that this ID can be referenced in the `aria-describedby` attribute of the form control. If no `@controlId` is provided, no ID is generated. If needed, it can be passed directly as an HTML attribute.
 
 [[code-snippets/form-primitives-error]]
 
@@ -84,17 +84,17 @@ If the error is made up of multiple messages, it’s possible to iterate over a 
 
 ### Form::Indicator
 
-If no `isRequired/isOptional` argument is provided, the component will not render anything.
+If no `@isRequired`/`@isOptional` argument is provided, the component will not render anything.
 
 #### Required
 
-Pass an `isRequired` argument, to render a `Required` Indicator.
+Pass an `@isRequired` argument, to render a `Required` Indicator.
 
 [[code-snippets/form-primitives-indicator-required]]
 
 #### Optional
 
-Pass an `isOptional` argument, to render an `Optional` Indicator.
+Pass an `@isOptional` argument, to render an `Optional` Indicator.
 
 [[code-snippets/form-primitives-indicator-optional]]
 
@@ -106,13 +106,13 @@ The default invocation requires text to be passed.
 
 #### Required
 
-Pass an `isRequired` argument, when user input is required for the associated form control.
+Pass an `@isRequired` argument, when user input is required for the associated form control.
 
 [[code-snippets/form-primitives-legend-required]]
 
 #### Optional
 
-Pass an `isOptional` argument, when user input is optional for the associated form control.
+Pass an `@isOptional` argument, when user input is optional for the associated form control.
 
 [[code-snippets/form-primitives-legend-optional]]
 

--- a/website/docs/components/form/radio-card/partials/code/component-api.md
+++ b/website/docs/components/form/radio-card/partials/code/component-api.md
@@ -80,6 +80,9 @@
   <C.Property @name="isRequired" @type="boolean" @default="false">
     Appends a `Required` indicator next to the legend text and sets the `required` attribute on the controls when user input is required.
   </C.Property>
+  <C.Property @name="isOptional" @type="boolean" @default="false">
+    Appends an `Optional` indicator next to the legend text when user input is optional.
+  </C.Property>
   <C.Property @name="layout" @type="string" @values={{array "horizontal" "vertical" }} @default="horizontal">
     By default, the Radio Cards will be horizontal, one next to another. Set this property to `vertical` to stack them one underneath each other.
   </C.Property>

--- a/website/docs/components/form/super-select/partials/code/how-to-use.md
+++ b/website/docs/components/form/super-select/partials/code/how-to-use.md
@@ -35,7 +35,7 @@ Use `SuperSelect::Multiple` to allow users to select multiple options.
 
 ### Pre-selected options
 
-To pre-select an option, declare a value for the `selected` argument:
+To pre-select an option, declare a value for the `@selected` argument:
 
 [[code-snippets/super-select-single-pre-selected]]
 
@@ -78,21 +78,21 @@ By default, all content of selected options displays in the “trigger”. Visua
 
 To simplify the content displayed in the selected options, use `@selectedItemComponent` to specify a custom component with only the content you wish to display.
 
-An example of a custom `selectedItemComponent`:
+An example of a custom `@selectedItemComponent`:
 
 [[code-snippets/example-selected-item-component execute=false]]
 
-`SuperSelect::Multiple` invocation with `selectedItemComponent` specified:
+`SuperSelect::Multiple` invocation with `@selectedItemComponent` specified:
 
 [[code-snippets/super-select-multiple-selected-item-component]]
 
-`SuperSelect::Single` invocation with `selectedItemComponent` specified:
+`SuperSelect::Single` invocation with `@selectedItemComponent` specified:
 
 [[code-snippets/super-select-single-selected-item-component]]
 
 ### Limiting width
 
-If needed, you can use `dropdownMaxWidth` to limit the width of the dropdown content. Setting a value for `dropdownMaxWidth` automatically sets `matchTriggerWidth` to `false` meaning that the width of the dropdown content will not necessarily match the list of the toggle or trigger element as it does by default.
+If needed, you can use `@dropdownMaxWidth` to limit the width of the dropdown content. Setting a value for `@dropdownMaxWidth` automatically sets `@matchTriggerWidth` to `false` meaning that the width of the dropdown content will not necessarily match the list of the toggle or trigger element as it does by default.
 
 [[code-snippets/super-select-single-width]]
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the following inconsistencies in the component API docs for form components (excluding `MaskedInput` and `TextInput` which will be addressed in a separate ticket):
- [Form](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR447)
   - sectionMaxWidth: default of 672px does not show up currently bc the @default=672px is conflicting with the @valueNote, remove @default and instead communicate default value in the description
- [Form::Header::Title](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR458)
   - size: docs document a default of "200" but the source constant DEFAULT_SIZE resolves to 400
- [Form::Label](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR473)
   - hiddenText: component accepts a hiddenText arg that renders visually hidden accessible text, but it is not documented
- [Form::KeyValueInputs](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR496)
   - [R.]Field
      - width:  docs document the default as "1f", missing the r, the actual default is "1fr"
- [Form::RadioCard::Group](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR549)
   - isOptional: component extends HdsFormFieldsetSignature['Args'] which includes isOptional, but the docs do not document this arg

FYI as I went through the docs for each of the form components, I also made minor edits to some of the "How to use" sections.

Form:
[before](https://helios.hashicorp.design/components/form/layout?tab=code#form-2) | [after](https://hds-website-git-annawanggg-form-components-docs-fixes-hashicorp.vercel.app/components/form/layout?tab=code#form-2)

Form::Label:
[before](https://helios.hashicorp.design/components/form/primitives?tab=code#formlabel-1) | [after](https://hds-website-git-annawanggg-form-components-docs-fixes-hashicorp.vercel.app/components/form/primitives?tab=code#formlabel-1)

Form::RadioCard::Group:
[before](https://helios.hashicorp.design/components/form/radio-card?tab=code#formradiocardgroup) | [after](https://hds-website-git-annawanggg-form-components-docs-fixes-hashicorp.vercel.app/components/form/radio-card?tab=code#formradiocardgroup)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6617](https://hashicorp.atlassian.net/browse/HDS-6617)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6617]: https://hashicorp.atlassian.net/browse/HDS-6617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ