### PR TITLE
Website - Documentation fixes for batch 2 of components

### DIFF
--- a/website/docs/components/card/partials/code/how-to-use.md
+++ b/website/docs/components/card/partials/code/how-to-use.md
@@ -17,7 +17,7 @@ Alternatively, you could use the Card Containers in a CSS `flex` or `grid` conta
 
 To specify which HTML tag to use to render the component, use the `@tag` argument. The default tag is a `div` but you can optionally render the Card as an `li` to be used within a list.
 
-Note: If you choose to use the `Card` as a list item, you must wrap it either in a `ul` or `ol` tag for the markup to be valid. Also note that you are responsible for the related styling for the list and list items.
+_Note: If you choose to use the `Card` as a list item, you must wrap it either in a `ul` or `ol` tag for the markup to be valid. Also note that you are responsible for the related styling for the list and list items._
 
 [[code-snippets/card-container-tag]]
 

--- a/website/docs/components/form/toggle/partials/code/how-to-use.md
+++ b/website/docs/components/form/toggle/partials/code/how-to-use.md
@@ -63,7 +63,7 @@ When helper text is added, the component automatically adds an `aria-describedby
 
 Use the `@isRequired` and `@isOptional` arguments to add a visual indication next to the legend text that the field is "required" or "optional".
 
-Note: While the Toggle component is already normally required by the nature of its use for on/off selection, there may be rare instances in which a Toggle is turned off by default but requires the user to interact with it before submitting a form. For example, for accepting terms and conditions.
+_Note: While the Toggle component is already normally required by the nature of its use for on/off selection, there may be rare instances in which a Toggle is turned off by default but requires the user to interact with it before submitting a form. For example, for accepting terms and conditions._
 
 [[code-snippets/toggle-indicators]]
 

--- a/website/docs/components/page-header/partials/code/component-api.md
+++ b/website/docs/components/page-header/partials/code/component-api.md
@@ -18,9 +18,6 @@ The `PageHeader::Title` component, yielded as contextual component.
   <C.Property @name="yield">
     Elements passed as children are yielded as inner content of an `<h1>` HTML element.
   </C.Property>
-  <C.Property @name="close" @type="function">
-    Function to programmatically close the Modal. If an `onClose` callback function is provided, it will be invoked when the Modal is closed.
-  </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
   </C.Property>

--- a/website/docs/components/pagination/partials/code/component-api.md
+++ b/website/docs/components/pagination/partials/code/component-api.md
@@ -28,6 +28,12 @@ These Pagination sub-elements may be used directly if you need to cover a very s
 <C.Property @name="totalItems" @required={{true}} @type="number">
 Pass the total number of items to be paginated. If no value is defined an error will be thrown.
 </C.Property>
+<C.Property @name="showInfo" @type="boolean" @default="true">
+Used to control the visibility of the informational text.
+</C.Property>
+<C.Property @name="showPageNumbers" @type="boolean" @default="true">
+Used to control the visibility of the page number controls.
+</C.Property>
 <C.Property @name="showLabels" @type="boolean" @default="false">
 Used to control the visibility of the "prev/next" text labels.
 </C.Property>

--- a/website/docs/components/pagination/partials/code/how-to-use.md
+++ b/website/docs/components/pagination/partials/code/how-to-use.md
@@ -27,9 +27,9 @@ In this case, you will have to take care of different things **yourself**
 
 ## Events handling and routing
 
-As described above, the main `Pagination::Numbered` and `Pagination::Compact` components expose an `onPageChange` callback function, invoked whenever a page change occurs. All the "navigation controls" in this cases are `<button>` elements that fire an `onClick` event that calls the `onPageChange` function.
+As described above, the main `Pagination::Numbered` and `Pagination::Compact` components expose an `@onPageChange` callback function, invoked whenever a page change occurs. All the "navigation controls" in this cases are `<button>` elements that fire an `onClick` event that calls the `@onPageChange` function.
 
-This means that if you need to update the URL when the user changes the "page" in the Pagination (eg. to add/remove/update some query parameters), you have to do it within the `onPageChange` callback you provide to the component.
+This means that if you need to update the URL when the user changes the "page" in the Pagination (eg. to add/remove/update some query parameters), you have to do it within the `@onPageChange` callback you provide to the component.
 
 If instead you need to update the URL directly when the user clicks on one of the "navigation control" elements, you have to provide routing parameters (`route/query/model/etc`) to the component; refer to the "Component API" section below for specifications about these parameters (the APIs are slightly different for the two components).
 
@@ -69,9 +69,9 @@ The component exposes two callback functions that can be used to respond to spec
 
 [[code-snippets/pagination-numbered-events]]
 
-The first `onPageChange` function is invoked when a user interacts with a navigation control ("prev/next" or "page number") and so can be used to respond to a "page" change (eg. updating the list of items in the page and/or updating the routing/URL).
+The first `@onPageChange` function is invoked when a user interacts with a navigation control ("prev/next" or "page number") and so can be used to respond to a "page" change (eg. updating the list of items in the page and/or updating the routing/URL).
 
-The second `onPageSizeChange` function is invoked when a user interacts with the "size selector" and so can be used to respond to a "page size" change (eg. updating the number of items listed in the page, updating the routing/URL, and/or updating other elements in the page).
+The second `@onPageSizeChange` function is invoked when a user interacts with the "size selector" and so can be used to respond to a "page size" change (eg. updating the number of items listed in the page, updating the routing/URL, and/or updating other elements in the page).
 
 ### Routing/URL updates
 
@@ -93,15 +93,13 @@ In this case, the component doesn’t update its internal "state" but the value 
 
 The reason for using a consumer-side function to determine the `query` argument is because it’s dynamic (it depends on the value of the `page` variable) and gives consumers the ability to specify their own query parameters (which will likely differ case by case).
 
-Even if the Pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users’ actions (eg. for logging, tracking, etc.).
+Even if the Pagination is based on routing, the `@onPageChange`/`@onPageSizeChange` callbacks are still available and can be used to respond to the users’ actions (eg. for logging, tracking, etc.).
 
 Below you can find an example of an integration between the sortable [`Table`](/components/table/table) component and the `Pagination::Numbered` component that uses query parameters in the URL to preserve the UI state:
 
 [[code-snippets/pagination-numbered-with-table]]
 
 ## How to use Compact Pagination
-
-By default, the basic use of the Pagination provides:
 
 The basic invocation of the Compact Pagination doesn’t require any arguments (apart from the event/routing handlers, see below):
 
@@ -134,7 +132,7 @@ The component exposes a callback function that can be used to respond to page ch
 
 [[code-snippets/pagination-compact-events]]
 
-The `onPageChange` function is invoked when a user interacts with a "prev" or "next" navigation control and so can be used to respond to a "page" change (eg. updating the list of items in the page and/or updating the routing/URL).
+The `@onPageChange` function is invoked when a user interacts with a "prev" or "next" navigation control and so can be used to respond to a "page" change (eg. updating the list of items in the page and/or updating the routing/URL).
 
 ### Routing/URL updates
 
@@ -148,7 +146,7 @@ In this case, the component doesn’t update its internal "state" but the value 
 
 The reason for using a consumer-side function to determine the `query` argument is because it’s dynamic (it depends on the value of the `page/cursor` variable) and gives consumers the ability to specify their own query parameters (which will likely differ case by case).
 
-Even if the Pagination is based on routing, the `onPageChange/onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.).
+Even if the Pagination is based on routing, the `@onPageChange`/`@onPageSizeChange` callbacks are still available and can be used to respond to the users' actions (eg. for logging, tracking, etc.).
 
 Below you can find an example of an integration between the [`Table`](/components/table/table) component and the `Pagination::Compact` component that uses query parameters in the URL to preserve the UI state:
 

--- a/website/docs/components/reveal/partials/code/how-to-use.md
+++ b/website/docs/components/reveal/partials/code/how-to-use.md
@@ -12,6 +12,6 @@ You can display different text on the toggle button when the `Reveal` is open.
 
 ### Open
 
-Set `isOpen` to `true` to display the content on page load instead of initially hiding it.
+Set `@isOpen` to `true` to display the content on page load instead of initially hiding it.
 
 [[code-snippets/reveal-is-open]]

--- a/website/docs/components/rich-tooltip/partials/code/component-api.md
+++ b/website/docs/components/rich-tooltip/partials/code/component-api.md
@@ -15,9 +15,6 @@
     <br />
     _Notice: in this case the tooltip can't be dismissed via `esc` or "click outside" until the end user has interacted with it (it's in a "manual" state)._
   </C.Property>
-  <C.Property @name="enableSoftEvents" @type="boolean" @default="true" @values={{array "true" "false"}}>
-    Assigns "soft" event listeners (`mouseEnter/Leave` + `focusIn/Out`) to the toggle to control the visibility of the tooltip.
-  </C.Property>
   <C.Property @name="enableClickEvents" @type="boolean" @default="false" @values={{array "true" "false"}}>
     Assigns a "click" event listener (`onClick`) to the toggle to control the visibility of the tooltip.
     <br />

--- a/website/docs/components/stepper/indicator/partials/code/how-to-use.md
+++ b/website/docs/components/stepper/indicator/partials/code/how-to-use.md
@@ -5,7 +5,7 @@ There are two types of indicators: `Step::Indicator` and `Task::Indicator`, whic
 
 ## How to use the Stepper::Step::Indicator
 
-Although not required, the basic invocation should include `text` and `status` arguments.
+Although not required, the basic invocation should include `@text` and `@status` arguments.
 
 [[code-snippets/stepper-step-indicator-basic]]
 
@@ -23,7 +23,7 @@ To change the status of the Step Indicator, set the `@status` argument to `incom
 
 ## How to use the Stepper::Task::Indicator
 
-Although not required, the basic invocation should include a `status` argument.
+Although not required, the basic invocation should include a `@status` argument.
 
 [[code-snippets/stepper-task-indicator-basic]]
 

--- a/website/docs/components/table/advanced-table/partials/code/how-to-use.md
+++ b/website/docs/components/table/advanced-table/partials/code/how-to-use.md
@@ -69,7 +69,7 @@ Reset the column to its original width by choosing the "Reset column width" opti
 
 [[code-snippets/advanced-table-resize]]
 
-By default, the minimum and maximum width of each column are set to `150px` and `800px` respectively. This can be overridden if necessary by passing either a `minWidth` or `maxWidth` argument to the `columns` array.
+By default, the minimum and maximum width of each column are set to `150px` and `800px` respectively. This can be overridden if necessary by passing either a `@minWidth` or `@maxWidth` argument to the `@columns` array.
 
 [[code-snippets/advanced-table-resize-customized]]
 
@@ -109,7 +109,7 @@ By default, the sort order is set to ascending. To indicate that the column defi
 To implement a custom sort callback on a column:
 
 1. add a custom function as the value for `sortingFunction` in the column hash.
-2. include a custom `onSort` action in your Table invocation to track the sorting order and use it in the custom sorting function.
+2. include a custom `@onSort` action in your Table invocation to track the sorting order and use it in the custom sorting function.
 
 This is useful for cases where the key might not be A-Z or 0-9 sortable by default, e.g., status, and you’re otherwise unable to influence the shape of the data in the model.
 
@@ -151,9 +151,9 @@ We recommend using functionalities like [pagination](/components/pagination), [s
 
 #### Vertical scrolling
 
-For situations where the default number of rows visible may be high, it can be difficult for users to track which column is which once they scroll. In this case, the `maxHeight` argument can be used to set the maximum height of the Advanced Table which will also add a sticky header. This will make the column headers persist as the user scrolls.
+For situations where the default number of rows visible may be high, it can be difficult for users to track which column is which once they scroll. In this case, the `@maxHeight` argument can be used to set the maximum height of the Advanced Table which will also add a sticky header. This will make the column headers persist as the user scrolls.
 
-If you want to set the `maxHeight` but not have a sticky header, set `hasStickyHeader` to false.
+If you want to set the `@maxHeight` but not have a sticky header, set `@hasStickyHeader` to false.
 
 [[code-snippets/advanced-table-vertical-scroll]]
 
@@ -193,7 +193,7 @@ At this time, the Advanced Table does not support multi-select nested rows. If t
 
 A multi-select Advanced Table includes checkboxes enabling users to select multiple rows for purposes of performing bulk operations. Checking or unchecking the checkbox in the Advanced Table header either selects or deselects the checkboxes on each row in the body. Individual checkboxes in the rows can also be selected or deselected.
 
-Add `isSelectable=true` to create a multi-select Advanced Table. The `onSelectionChange` argument can be used to pass a callback function to receive selection keys when the selected rows change. You must also pass a `selectionKey` to each row which gets passed back through the `onSelectionChange` callback which maps the row selection on the Advanced Table to an item in your data model.
+Add `@isSelectable=true` to create a multi-select Advanced Table. The `@onSelectionChange` argument can be used to pass a callback function to receive selection keys when the selected rows change. You must also pass a `@selectionKey` to each row which gets passed back through the `@onSelectionChange` callback which maps the row selection on the Advanced Table to an item in your data model.
 
 #### Simple multi-select
 
@@ -210,7 +210,7 @@ This is a simple example of an Advanced Table with multi-selection. Notice the `
 
 **Code consideration**
 
-If you want the state of the checkboxes to persist after the model updates, you will need to provide an `identityKey` value.
+If you want the state of the checkboxes to persist after the model updates, you will need to provide an `@identityKey` value.
 !!!
 
 [[code-snippets/advanced-table-multi-select]]
@@ -265,7 +265,7 @@ At a bare minimum we recommend clearly communicating to the user if they have se
 
 Labels within the header cells are intended to provide contextual information about the column’s content to the end user. There may be special cases in which that label is redundant from a visual perspective, because the kind of content can be inferred by looking at it (eg. a contextual dropdown).
 
-In this example we’re visually hiding the label in the last column by passing `isVisuallyHidden=true` to it:
+In this example we’re visually hiding the label in the last column by passing `@isVisuallyHidden=true` to it:
 
 [[code-snippets/advanced-table-hidden-header]]
 

--- a/website/docs/components/table/advanced-table/partials/code/how-to-use.md
+++ b/website/docs/components/table/advanced-table/partials/code/how-to-use.md
@@ -265,7 +265,7 @@ At a bare minimum we recommend clearly communicating to the user if they have se
 
 Labels within the header cells are intended to provide contextual information about the column’s content to the end user. There may be special cases in which that label is redundant from a visual perspective, because the kind of content can be inferred by looking at it (eg. a contextual dropdown).
 
-In this example we’re visually hiding the label in the last column by passing `@isVisuallyHidden=true` to it:
+In this example we’re visually hiding the label in the last column by passing `@isVisuallyHidden={{true}}` to it:
 
 [[code-snippets/advanced-table-hidden-header]]
 

--- a/website/docs/components/table/table/partials/code/how-to-use.md
+++ b/website/docs/components/table/table/partials/code/how-to-use.md
@@ -53,7 +53,7 @@ By default, the sort order is set to ascending. To indicate that the column defi
 To implement a custom sort callback on a column:
 
 1. add a custom function as the value for `sortingFunction` in the column hash,
-2. include a custom `onSort` action in your Table invocation to track the sorting order and use it in the custom sorting function.
+2. include a custom `@onSort` action in your Table invocation to track the sorting order and use it in the custom sorting function.
 
 This is useful for cases where the key might not be A-Z or 0-9 sortable by default, e.g., status, and you’re otherwise unable to influence the shape of the data in the model.
 
@@ -72,15 +72,15 @@ This is a pretty advanced example, intended to cover some edge cases that we enc
 
 The `Hds::Table` exposes (via yielding) some of its internal properties and methods, to allow extremely customized sorting functionalities:
 
-- `setSortBy` is the internal function used to set the `sortBy` and `sortOrder` tracked values
-- `sortBy` is the "key" of the column used for sorting (when the table is sorted)
-- `sortOrder` is the sorting direction (ascending or descending)
+- `@setSortBy` is the internal function used to set the `@sortBy` and `@sortOrder` tracked values
+- `@sortBy` is the "key" of the column used for sorting (when the table is sorted)
+- `@sortOrder` is the sorting direction (ascending or descending)
 
 For more details about these properties refer to the [Component API](#component-api) section below.
 
-In the `<:head>` the `setSortBy` function is invoked when the `<ThSort>` element is clicked to set the values of `sortBy` and `sortOrder` in the table; in turn these values are then used by the `<ThSort>` element to assign the sorting icon via the `@sortOrder` argument.
+In the `<:head>` the `@setSortBy` function is invoked when the `<ThSort>` element is clicked to set the values of `@sortBy` and `@sortOrder` in the table; in turn these values are then used by the `<ThSort>` element to assign the sorting icon via the `@sortOrder` argument.
 
-In the `<:body>` the values of `sortBy` and `sortOrder` are provided instead as arguments to a consumer-side function that takes care of custom sorting the model/data.
+In the `<:body>` the values of `@sortBy` and `@sortOrder` are provided instead as arguments to a consumer-side function that takes care of custom sorting the model/data.
 
 _Notice: in this case for the example we're using the [`call` helper](https://github.com/NullVoxPopuli/ember-composable-helpers?tab=readme-ov-file#call) from [@nullvoxpopuli/ember-composable-helpers](https://github.com/NullVoxPopuli/ember-composable-helpers)._
 
@@ -159,7 +159,7 @@ In this case the table layout is still set to `auto` (default). If instead you w
 
 A multi-select table includes checkboxes enabling users to select multiple rows in a table for purposes of performing bulk operations. Checking or unchecking the checkbox in the table header either selects or deselects the checkboxes on each row in the table body. Individual checkboxes in the rows can also be selected or deselected.
 
-Add `isSelectable=true` to create a multi-select table. The `@onSelectionChange` argument can be used to pass a callback function to receive selection keys when the selected table rows change. You must also pass a `@selectionKey` argument to each row which gets passed back through the `@onSelectionChange` callback which maps the row selection on the table to an item in your data model.
+Add `@isSelectable=true` to create a multi-select table. The `@onSelectionChange` argument can be used to pass a callback function to receive selection keys when the selected table rows change. You must also pass a `@selectionKey` argument to each row which gets passed back through the `@onSelectionChange` callback which maps the row selection on the table to an item in your data model.
 
 #### Multi-select table using a model
 
@@ -167,7 +167,7 @@ Add `isSelectable=true` to create a multi-select table. The `@onSelectionChange`
 
 **Code consideration**
 
-If you want the state of the checkboxes to persist after the model updates, you will need to provide an `identityKey` value.
+If you want the state of the checkboxes to persist after the model updates, you will need to provide an `@identityKey` value.
 !!!
 
 This is a simple example of a table with multi-selection. Notice the `@selectionKey` argument provided to the rows, used by the `@onSelectionChange` callback to provide the list of selected/deselected rows as argument(s) for the invoked function.

--- a/website/docs/components/tag/partials/code/how-to-use.md
+++ b/website/docs/components/tag/partials/code/how-to-use.md
@@ -12,7 +12,7 @@ There are two available colors for a link: `primary` and `secondary`. The defaul
 
 ### Dismiss
 
-In most cases, the Tag should be dismissable. If you don’t provide a callback function to the `onDismiss` argument the dismiss button will not be rendered.
+In most cases, the Tag should be dismissable. If you don’t provide a callback function to the `@onDismiss` argument the dismiss button will not be rendered.
 
 [[code-snippets/tag-no-dismiss]]
 

--- a/website/docs/components/toast/partials/code/how-to-use.md
+++ b/website/docs/components/toast/partials/code/how-to-use.md
@@ -10,29 +10,29 @@ When displaying a Toast in reaction to an action or event that has occurred with
 
 !!!
 
-The basic invocation requires the `type` argument, an `onDismiss` callback function, and the `title` and/or `description` content. By default a `neutral` Toast is generated.
+The basic invocation requires the `@type` argument, an `@onDismiss` callback function, and the `Title` and/or `Description` content. By default a `neutral` Toast is generated.
 
 [[code-snippets/toast-basic]]
 
 ### Title and description
 
-Optionally, you can pass only `title` or only `description`.
+Optionally, you can pass only `Title` or only `Description`.
 
 [[code-snippets/toast-optional-blocks]]
 
 ### Color
 
-A different color can be applied to the Toast using the `color` argument. This will determine the default icon used in the Toast, unless overwritten.
+A different color can be applied to the Toast using the `@color` argument. This will determine the default icon used in the Toast, unless overwritten.
 
 [[code-snippets/toast-color]]
 
 ### Icon
 
-A different icon can be used in the Toast using the `icon` argument. This accepts any [icon](/icons/library) name.
+A different icon can be used in the Toast using the `@icon` argument. This accepts any [icon](/icons/library) name.
 
 [[code-snippets/toast-icon]]
 
-If you need to hide the icon, pass `false` to the `icon` argument.
+If you need to hide the icon, pass `false` to the `@icon` argument.
 
 [[code-snippets/toast-no-icon]]
 

--- a/website/docs/layouts/app-frame/partials/code/how-to-use.md
+++ b/website/docs/layouts/app-frame/partials/code/how-to-use.md
@@ -6,9 +6,7 @@ The `AppFrame` is a pure layout component that can be used to build the top-leve
 
 The `AppFrame::Main` child component includes a default `id` with the value `hds-main` on the HTML `<main>` element it renders. This serves as a target for the `hasA11yRefocus` feature skip link which is built into the [`AppHeader`](/components/app-header?tab=code#appheader) component.
 
-Note: The `AppSideNav` component, which is meant to only be used together with the `AppHeader` and not as standalone navigation, does not include a skip link.
-
-Note: The `AppSideNav` component, which is meant to only be used together with the `AppHeader` and not as standalone navigation, does not include a skip link.
+_Note: The `AppSideNav` component, which is meant to only be used together with the `AppHeader` and not as standalone navigation, does not include a skip link._
 
 ### Basic use
 

--- a/website/docs/layouts/flex/partials/code/how-to-use.md
+++ b/website/docs/layouts/flex/partials/code/how-to-use.md
@@ -17,7 +17,7 @@ The `Layout::Flex` and optional `Layout::Flex::Item` components provide a way to
 
 **Code consideration**
 
-Note: there is no strict need to use the `Layout::Flex::Item` subcomponent; use it only when necessary to tweak the flex styles of an individual child item via the `@basis/@grow/@shrink` arguments. This avoids rendering extra Ember components.
+There is no strict need to use the `Layout::Flex::Item` subcomponent; use it only when necessary to tweak the flex styles of an individual child item via the `@basis/@grow/@shrink` arguments. This avoids rendering extra Ember components.
 !!!
 
 The simplest way to implement a flexbox layout is by using the `Layout::Flex` component to wrap some content.
@@ -30,7 +30,7 @@ Here is an example with four equally sized generic content placeholders:
 
 [[code-snippets/flex-basic-placeholders]]
 
-There are cases in which it is necessary to wrap one or more child elements in a specific `Layout::Flex::Item` (eg. to apply the `@basis/@grow/@shrink` arguments, see below for details).
+There are cases in which it is necessary to wrap one or more child elements in a specific `Layout::Flex::Item` (e.g. to apply the `@basis/@grow/@shrink` arguments, see below for details).
 
 [[code-snippets/flex-item execute=false]]
 
@@ -86,7 +86,7 @@ If you need to provide custom spacing values, see below how you can use a specia
 
 #### Non-standard gap values
 
-If you absolutely have to use non-standard spacing value(s) for the flex `gap`, you can use the internal `--hds-layout-flex-row-gap` and `--hds-layout-flex-column-gap` CSS variables and pass custom values to them (e.g., via a local CSS class or an inline style).
+If you absolutely have to use non-standard spacing value(s) for the flex `@gap`, you can use the internal `--hds-layout-flex-row-gap` and `--hds-layout-flex-column-gap` CSS variables and pass custom values to them (e.g., via a local CSS class or an inline style).
 
 [[code-snippets/flex-custom-gap execute=false]]
 
@@ -98,7 +98,7 @@ If the flex items are wrapping to multiple lines, you have to overwrite both the
 
 Using `flexbox` is one of the simplest ways to control how sets of items are aligned and spaced, and it's done via a set of `justify-*` and `align-*` properties.
 
-In the `Layout::Flex` component this is achieved using the `@justify` and `align` arguments.
+In the `Layout::Flex` component this is achieved using the `@justify` and `@align` arguments.
 
 [[code-snippets/flex-align execute=false]]
 
@@ -175,7 +175,7 @@ By default, flex items use only the space necessary to fit their content. If the
 
 [[code-snippets/flex-default-sizing]]
 
-If we want an item to to grow and occupy the available space, we have to use its `grow` property.
+If we want an item to grow and occupy the available space, we have to use its `@grow` property.
 
 [[code-snippets/flex-grow]]
 

--- a/website/docs/layouts/grid/partials/code/component-api.md
+++ b/website/docs/layouts/grid/partials/code/component-api.md
@@ -32,7 +32,7 @@
     <br /><br />
     <em>Note: we only expose a subset of the values allowed for this property, which cover the most common use cases.</em>
   </C.Property>
-  <C.Property @name="gap" @type="enum" @values={{array "0" "4" "8" "12" "16" "32" "48"}} @default="0">
+  <C.Property @name="gap" @type="enum" @values={{array "0" "4" "8" "12" "16" "24" "32" "48"}} @default="0">
     The gap spacing between rows and columns of the grid. Specify as either a single value or array of two values for setting the row and column spacing separately.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/layouts/grid/partials/code/how-to-use.md
+++ b/website/docs/layouts/grid/partials/code/how-to-use.md
@@ -27,7 +27,7 @@ The simplest way to implement a grid layout is by using the `Layout::Grid` compo
 
 Every child of the **grid container** will be stretched to fit evenly within the underlying grid column tracks behaving as a **grid item** (for details on what this means, refer to the guide linked at the top of the page).
 
-In some cases, it may be necessary to wrap one or more content items within the optional `Layout::Grid::Item` component. i.e., to group content together within a column or row, prevent content from being stretched to fit the underlying grid column width, or to make use of `rowspan` and `colspan` options in order to create more complex layouts. (See below for more details and examples on these features.)
+In some cases, it may be necessary to wrap one or more content items within the optional `Layout::Grid::Item` component. i.e., to group content together within a column or row, prevent content from being stretched to fit the underlying grid column width, or to make use of `@rowspan` and `@colspan` options in order to create more complex layouts. (See below for more details and examples on these features.)
 
 ### Preventing content stretch
 
@@ -77,7 +77,7 @@ If you need to provide custom spacing values, see below how you can use a specia
 
 #### Non-standard gap values
 
-If you absolutely have to use non-standard spacing value(s) for the grid `gap`, you can use the internal `--hds-layout-grid-row-gap` and `--hds-layout-grid-column-gap` CSS variables and pass custom values to them (e.g., via a local CSS variable or an inline style).
+If you absolutely have to use non-standard spacing value(s) for the grid `@gap`, you can use the internal `--hds-layout-grid-row-gap` and `--hds-layout-grid-column-gap` CSS variables and pass custom values to them (e.g., via a local CSS variable or an inline style).
 
 [[code-snippets/grid-spacing-custom execute=false]]
 
@@ -91,15 +91,15 @@ If the grid items are wrapping on multiple lines, you have to overwrite both the
 
 There are two options for controlling `Grid` column widths: `@columnMinWidth` and `@columnWidth`.
 
-- `@columnMinWidth` creates a semi-fluid layout. If there are fewer items than fit in a row, columns will automatically adjust so that their combined widths add up to 100%.  If the combined widths of columns in a row add up to more than 100%, they will automatically wrap to the next row as needed to fit.
+- `@columnMinWidth` creates a semi-fluid layout. If there are fewer items than fit in a row, columns will automatically adjust so that their combined widths add up to 100%. If the combined widths of columns in a row add up to more than 100%, they will automatically wrap to the next row as needed to fit.
 
 - `@columnWidth` creates a more “fixed” layout. The column widths will remain consistent no matter how many items are in a row. It supports optional breakpoints to define responsive views.
 
 #### Column min width
 
-Specify a `columnMinWidth` to create a more fluid, “semi-responsive“ layout.
+Specify a `@columnMinWidth` to create a more fluid, “semi-responsive“ layout.
 
-Note: The `gap` size will be automatically subtracted from the `columnMinWidth`. Take this into account when specifying a min width value.
+_Note: The `@gap` size will be automatically subtracted from the `@columnMinWidth`. Take this into account when specifying a min width value._
 
 ##### Semi-fluid layout behavior using percentage values
 
@@ -109,7 +109,7 @@ The column widths in a single row automatically adjust to maintain a total width
 
 ##### Semi-responsive layout using fixed unit values
 
-Specifying column min-widths using fixed units such as pixels, allows you to create layouts which are “automatically” responsive. To create fully responsive layouts using defined break points, see [`columnWidth`](/layouts/grid#column-width).
+Specifying column min-widths using fixed units such as pixels, allows you to create layouts which are “automatically” responsive. To create fully responsive layouts using defined breakpoints, see [`@columnWidth`](/layouts/grid#column-width).
 
 ###### Grid within a wider view
 
@@ -125,9 +125,9 @@ At the specified column min width, columns are forced to stack in this narrower 
 
 #### Column width
 
-To create column layouts that are more “fixed” vs. fluid, use `columnWidth` to specify a width for the columns. Items will respect the defined width instead of stretching to fill out a single column row.
+To create column layouts that are more “fixed” vs. fluid, use `@columnWidth` to specify a width for the columns. Items will respect the defined width instead of stretching to fill out a single column row.
 
-Note: The `gap` size will be automatically subtracted from the `columnWidth`. Take this into account when specifying width values.
+_Note: The `@gap` size will be automatically subtracted from the `@columnWidth`. Take this into account when specifying width values._
 
 ##### Non-responsive columns
 
@@ -137,9 +137,9 @@ Pass in a single value specifying the column width to create a non-responsive co
 
 ##### Responsive columns
 
-Optionally, instead of a single value, you can pass in an object to the `columnWidth` argument to define responsive column widths for up to five supported views based on the [HDS breakpoint values](/foundations/breakpoints#the-ranges).
+Optionally, instead of a single value, you can pass in an object to the `@columnWidth` argument to define responsive column widths for up to five supported views based on the [HDS breakpoint values](/foundations/breakpoints#the-ranges).
 
-See the [“Responsive layouts” section](/layouts/grid#responsive-layouts) for more details on responsive layout break points and behavior.
+See the [“Responsive layouts” section](/layouts/grid#responsive-layouts) for more details on responsive layout breakpoints and behavior.
 
 ##### With all views defined
 
@@ -161,21 +161,21 @@ Values defined for smaller views are inherited by larger views so you do not nee
 
 Use the `@align` argument to align grid items to the "start", "end", "center" or "stretch" them within the grid parent.
 
-Note: The `Grid` parent will need a height set for the effect to be visible.
+_Note: The `Grid` parent will need a height set for the effect to be visible._
 
 [[code-snippets/grid-align]]
 
 ### Colspan & rowspan
 
-Use the `colspan` and `rowspan` arguments of the `Grid::Item` component to set the number of columns or rows an item should occupy. They both support optional breakpoints to define responsive views.
+Use the `@colspan` and `@rowspan` arguments of the `Grid::Item` component to set the number of columns or rows an item should occupy. They both support optional breakpoints to define responsive views.
 
-Note: By default, if a height is set on the `Grid` parent, grid row heights will stretch proportionally to fill the `Grid`. To instead make a row conform to the minimum height of its content, you can pass an inline style as shown in the example.
+_Note: By default, if a height is set on the `Grid` parent, grid row heights will stretch proportionally to fill the `Grid`. To instead make a row conform to the minimum height of its content, you can pass an inline style as shown in the example._
 
 #### Non-responsive example
 
-Pass in a single value to specify the `colspan` or `rowspan` to create a non-responsive layout.
+Pass in a single value to specify the `@colspan` or `@rowspan` to create a non-responsive layout.
 
-In this example, an underlying 4-column grid is specified by setting a `columnMinWidth` of “25%”. `colspan` and `rowspan` are used to create a flexible layout roughly resembling a typical web page layout.
+In this example, an underlying 4-column grid is specified by setting a `@columnMinWidth` of “25%”. `@colspan` and `@rowspan` are used to create a flexible layout roughly resembling a typical web page layout.
 
 [[code-snippets/grid-span]]
 
@@ -187,9 +187,9 @@ See the [“Responsive layouts” section](/layouts/grid#responsive-layouts) for
 
 !!!
 
-Optionally, instead of a single value, you can pass in an object to the `colspan` or `rowspan` arguments to define values for up to five supported views based on the [HDS breakpoint values](/foundations/breakpoints#the-ranges).
+Optionally, instead of a single value, you can pass in an object to the `@colspan` or `@rowspan` arguments to define values for up to five supported views based on the [HDS breakpoint values](/foundations/breakpoints#the-ranges).
 
-In this example, both the `Grid` `columnWidth` and the `colspan` of 2 items use responsive values so the layout shifts when viewed in small screens. Narrow your browser window to see the responsive behavior.
+In this example, both the `Grid` `@columnWidth` and the `@colspan` of 2 items use responsive values so the layout shifts when viewed in small screens. Narrow your browser window to see the responsive behavior.
 
 [[code-snippets/grid-span-responsive]]
 
@@ -205,7 +205,7 @@ We use a mobile-first layout approach for the responsive views, so values define
 
 ### Responsive features
 
-Responsive layout options are supported by the [`Grid` `columnWidth`](/layouts/grid#column-width) and the [`GridItem` `colspan` and `rowspan`](/layouts/grid#colspan--rowspan) features. There are five supported views based on the [HDS breakpoint values](/foundations/breakpoints#the-ranges).
+Responsive layout options are supported by the [`Grid` `@columnWidth`](/layouts/grid#column-width) and the [`GridItem` `@colspan` and `@rowspan`](/layouts/grid#colspan--rowspan) features. There are five supported views based on the [HDS breakpoint values](/foundations/breakpoints#the-ranges).
 
 ### Supported breakpoints
 
@@ -245,7 +245,7 @@ Wrap content with a `Grid::Item` as needed to achieve more complex layouts.
 
 #### How this layout works
 
-We first establish an underlying grid structure of three columns by setting the `columnWidth` of the `Grid` parent to `33.33%`. The `@colspan` option of the `GridItem` children is then used to make some of them span two of the underlying grid columns creating a more complex layout.
+We first establish an underlying grid structure of three columns by setting the `@columnWidth` of the `Grid` parent to `33.33%`. The `@colspan` option of the `GridItem` children is then used to make some of them span two of the underlying grid columns creating a more complex layout.
 
 It uses a responsive layout so the content items will stack in the smallest view.
 

--- a/website/docs/utilities/dismiss-button/partials/code/component-api.md
+++ b/website/docs/utilities/dismiss-button/partials/code/component-api.md
@@ -3,7 +3,7 @@
 ### DismissButton
 
 <Doc::ComponentApi as |C|>
-  <C.Property @name="ariaLabel" @type="string" @default="dismiss">
+  <C.Property @name="ariaLabel" @type="string" @default="Dismiss">
     Accepts a string.
   </C.Property>
   <C.Property @name="...attributes">

--- a/website/docs/utilities/popover-primitive/partials/code/how-to-use.md
+++ b/website/docs/utilities/popover-primitive/partials/code/how-to-use.md
@@ -66,7 +66,7 @@ For details about how the collision detection works, refer to the [Floating UI >
 
 ### With an arrow
 
-It is possible to account for an arrow element in the positioning of the popover, if an `arrowSelector` (or directly an `arrowElement` reference) is provided to the `anchoredPositionOptions`:
+It is possible to account for an arrow element in the positioning of the popover, if an `arrowSelector` (or directly an `arrowElement` reference) is provided to the `@anchoredPositionOptions`:
 
 [[code-snippets/popover-primitive-arrow execute=false]]
 


### PR DESCRIPTION
### :pushpin: Summary

If merged, this PR would fix the following inconsistencies in the component API docs:
- [PageHeader](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR332)
   - [PH].Title
      - close: docs document a close function arg on [PH].Title that does not exist in the source
- [Pagination::Numbered](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR353)
   - showInfo: arg exists in source and defaults to true but is not documented
   - showPageNumbers: arg exists in source and defaults to true but is not documented
- [RichTooltip](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR376)
   - enableSoftEvents: docs document arg that is explicitly omitted from the source, since it is computed internally and cannot be passed by consumers
- [TooltipButton](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR428)
   - text: required in source but not marked required in the docs
- [Layout::Grid](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR607)
   - gap: docs `@values` list is missing the value "24" from the source
- [DismissButton](https://github.com/hashicorp/design-system/pull/4081/changes#diff-ea27cabbb11c17e34f94905a48e0a4a4130487e8d7fd8afd19692391e0da052dR626)
   - ariaLabel: docs document the default as "dismiss" when the source is "Dismiss"

FYI as I went through the docs for each of the form components, I also made minor edits to some of the "How to use" sections!

Pointing out one of the more notable changes:
Pagination::Numbered
[before](https://helios.hashicorp.design/components/pagination?tab=code#paginationnumbered) | [after](https://hds-website-git-annawanggg-component-batch-2-d-3bf8b4-hashicorp.vercel.app/components/pagination?tab=code#paginationnumbered)

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6620](https://hashicorp.atlassian.net/browse/HDS-6620)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6620]: https://hashicorp.atlassian.net/browse/HDS-6620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ