### PR TITLE
`AppFooter`: Remove unused `color` arg

### DIFF
--- a/.changeset/bumpy-squids-prove.md
+++ b/.changeset/bumpy-squids-prove.md
@@ -2,4 +2,6 @@
 "@hashicorp/design-system-components": patch
 ---
 
+<!-- START components/app-footer -->
 `AppFooter` - Removed unused `@color` property from `[AF].Link` contextual component
+<!-- END -->

--- a/.changeset/bumpy-squids-prove.md
+++ b/.changeset/bumpy-squids-prove.md
@@ -2,4 +2,4 @@
 "@hashicorp/design-system-components": patch
 ---
 
-`AppFooter` - Removed unused `@color` propery from `[AF].Link` contextual component
+`AppFooter` - Removed unused `@color` property from `[AF].Link` contextual component

--- a/.changeset/bumpy-squids-prove.md
+++ b/.changeset/bumpy-squids-prove.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+`AppFooter` - Removed unused `@color` propery from `[AF].Link` contextual component

--- a/packages/components/component-catalog.json
+++ b/packages/components/component-catalog.json
@@ -2567,12 +2567,6 @@
       "element": "HTMLAnchorElement | HTMLButtonElement",
       "args": [
         {
-          "name": "color",
-          "type": "\"primary\" | \"secondary\"",
-          "required": false,
-          "values": ["primary", "secondary"]
-        },
-        {
           "name": "current-when",
           "type": "string | boolean",
           "required": false,

--- a/packages/components/src/components/hds/app-footer/link.gts
+++ b/packages/components/src/components/hds/app-footer/link.gts
@@ -10,13 +10,12 @@ import HdsLinkInline from '../link/inline.gts';
 import HdsTextBody from '../text/body.gts';
 
 import type { HdsInteractiveSignature } from '../interactive/index.gts';
-import type { HdsLinkColors, HdsLinkIconPositions } from '../link/types.ts';
+import type { HdsLinkIconPositions } from '../link/types.ts';
 import type { HdsLinkInlineSignature } from '../link/inline.gts';
 import type { HdsIconSignature } from '../icon/index.gts';
 
 export interface HdsAppFooterLinkSignature {
   Args: HdsInteractiveSignature['Args'] & {
-    color?: HdsLinkColors;
     icon?: HdsIconSignature['Args']['name'];
     iconPosition?: HdsLinkIconPositions;
   };


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge until further notice

### :pushpin: Summary

If merged, this PR would remove an optional `color` argument from the `[AF].Link` signature in `AppFooter` that is unused within the contextual component. The value is never passed currently, since the color arg passed to the wrapped `HdsLinkInline` component is hardcoded to `secondary`. 

The arg is not used within any tests or the showcase so no changes were needed there. It's also not documented on the website, so no changes were made there either.

Even though the arg has no effect on the component and it's not documented, it could be a breaking change if any consumers were somehow passing anything into the  `color` arg. Let me know if my changeset looks okay!

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6622](https://hashicorp.atlassian.net/browse/HDS-6622)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6622]: https://hashicorp.atlassian.net/browse/HDS-6622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ