### PR TITLE
fix: bug where `sortBy` is required table/advanced table

### DIFF
--- a/.changeset/orange-friends-argue.md
+++ b/.changeset/orange-friends-argue.md
@@ -1,0 +1,12 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/table/table -->
+`Table` - Fixed an error thrown when using `@model` and `@columns` without providing a `@sortBy` argument. The component was producing a sort key of `"undefined:asc"`, which caused errors on strict model types.
+<!-- END -->
+
+<!-- START components/table/advanced-table -->
+`AdvancedTable` - Fixed an error thrown when using `@model` and `@columns` without providing a `@sortBy` argument. The component was producing a sort key of `"undefined:asc"`, which caused errors on strict model types.
+<!-- END -->
+

--- a/packages/components/src/components/hds/advanced-table/index.gts
+++ b/packages/components/src/components/hds/advanced-table/index.gts
@@ -15,7 +15,7 @@ import { fn, hash } from '@ember/helper';
 import { and, eq, not, notEq } from 'ember-truth-helpers';
 import style from 'ember-style-modifier';
 import { on } from '@ember/modifier';
-import { sortBy } from '@nullvoxpopuli/ember-composable-helpers';
+import { sortBy } from '@nullvoxpopuli/ember-composable-helpers/helpers/sort-by';
 
 import { HdsAdvancedTableThSortOrderValues } from './types.ts';
 import {
@@ -501,7 +501,14 @@ export default class HdsAdvancedTable<
     return this.expandableRowIds.every((id) => this.expandedRowIds.has(id));
   }
 
-  get sortCriteria(): string | HdsAdvancedTableSortingFunction<unknown> {
+  get sortCriteria():
+    | string
+    | HdsAdvancedTableSortingFunction<unknown>
+    | undefined {
+    if (!this.currentSortBy) {
+      return undefined;
+    }
+
     const { columns } = this.args;
 
     const currentColumn = columns.find(
@@ -516,6 +523,16 @@ export default class HdsAdvancedTable<
     } else {
       return `${this.currentSortBy}:${this.currentSortOrder}`;
     }
+  }
+
+  get sortedModel(): T[] {
+    const { model } = this.args;
+    const criteria = this.sortCriteria;
+    if (!criteria) {
+      return model;
+    }
+    // @ts-expect-error: sortBy's type only accepts string[] keys but we also pass HdsAdvancedTableSortingFunction [HDS-4380]
+    return sortBy([criteria, model]);
   }
 
   get isEmpty(): boolean {
@@ -1144,7 +1161,7 @@ export default class HdsAdvancedTable<
                 @childrenKey={{this.childrenKey}}
                 @expandedRowIds={{this.expandedRowIds}}
                 {{! @glint-expect-error: [HDS-4380](https://hashicorp.atlassian.net/browse/HDS-4380) }}
-                @sortedModel={{sortBy this.sortCriteria @model}}
+                @sortedModel={{this.sortedModel}}
                 as |B|
               >
                 {{#each B.rows key="id" as |row index|}}

--- a/packages/components/src/components/hds/table/index.gts
+++ b/packages/components/src/components/hds/table/index.gts
@@ -9,7 +9,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { fn, hash } from '@ember/helper';
 import { eq } from 'ember-truth-helpers';
-import { sortBy } from '@nullvoxpopuli/ember-composable-helpers';
+import { sortBy } from '@nullvoxpopuli/ember-composable-helpers/helpers/sort-by';
 
 import type { WithBoundArgs } from '@glint/template';
 import type Owner from '@ember/owner';
@@ -132,7 +132,10 @@ export default class HdsTable<T = HdsTableModel> extends Component<
     this.sortOrder = this.args.sortOrder ?? HdsTableThSortOrderValues.Asc;
   }
 
-  get getSortCriteria(): string | HdsTableSortingFunction<unknown> {
+  get getSortCriteria(): string | HdsTableSortingFunction<unknown> | undefined {
+    if (!this.sortBy) {
+      return undefined;
+    }
     // get the current column
     const currentColumn = this.args?.columns?.find(
       (column) => column.key === this.sortBy
@@ -147,6 +150,19 @@ export default class HdsTable<T = HdsTableModel> extends Component<
       // otherwise fallback to the default format "sortBy:sortOrder"
       return `${this.sortBy}:${this.sortOrder}`;
     }
+  }
+
+  get sortedModel(): T[] {
+    const { model } = this.args;
+    if (!model) {
+      return [];
+    }
+    const criteria = this.getSortCriteria;
+    if (!criteria) {
+      return model;
+    }
+    // @ts-expect-error: sortBy's type only accepts string[] keys but we also pass HdsTableSortingFunction [HDS-4380]
+    return sortBy([criteria, model]);
   }
 
   get identityKey(): string | undefined {
@@ -460,29 +476,26 @@ export default class HdsTable<T = HdsTableModel> extends Component<
             we yield the Tr/Td/Th elements _and_ the record itself as data
             this means the consumer will *have to* use the data key to access it in their template
           ----------------------------------------------------------------- }}
-          {{! @glint-expect-error: [HDS-4380](https://hashicorp.atlassian.net/browse/HDS-4380) }}
-          {{#let (sortBy this.getSortCriteria @model) as |sortedModel|}}
-            {{#each sortedModel key=this.identityKey as |record index|}}
-              {{yield
-                (hash
-                  Tr=(component
-                    HdsTableTr
-                    selectionScope="row"
-                    isSelectable=@isSelectable
-                    onSelectionChange=this.onSelectionRowChange
-                    didInsert=this.didInsertRowCheckbox
-                    willDestroy=this.willDestroyRowCheckbox
-                    selectionAriaLabelSuffix=@selectionAriaLabelSuffix
-                  )
-                  Th=(component HdsTableTh scope="row")
-                  Td=(component HdsTableTd align=@align)
-                  data=record
-                  rowIndex=index
+          {{#each this.sortedModel key=this.identityKey as |record index|}}
+            {{yield
+              (hash
+                Tr=(component
+                  HdsTableTr
+                  selectionScope="row"
+                  isSelectable=@isSelectable
+                  onSelectionChange=this.onSelectionRowChange
+                  didInsert=this.didInsertRowCheckbox
+                  willDestroy=this.willDestroyRowCheckbox
+                  selectionAriaLabelSuffix=@selectionAriaLabelSuffix
                 )
-                to="body"
-              }}
-            {{/each}}
-          {{/let}}
+                Th=(component HdsTableTh scope="row")
+                Td=(component HdsTableTd align=@align)
+                data=record
+                rowIndex=index
+              )
+              to="body"
+            }}
+          {{/each}}
         {{else}}
           {{yield
             (hash

--- a/showcase/tests/integration/components/hds/advanced-table/index-test.gts
+++ b/showcase/tests/integration/components/hds/advanced-table/index-test.gts
@@ -498,7 +498,7 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
         >
           <:body as |B|>
             <B.Tr @selectionKey={{get B.data "id"}}>
-              <B.Th>{{get B.data "name"}}</B.Th>
+              <B.Td>{{get B.data "name"}}</B.Td>
               <B.Td>{{get B.data "age"}}</B.Td>
               <B.Td>{{get B.data "country"}}</B.Td>
             </B.Tr>

--- a/showcase/tests/integration/components/hds/advanced-table/index-test.gts
+++ b/showcase/tests/integration/components/hds/advanced-table/index-test.gts
@@ -487,4 +487,30 @@ module('Integration | Component | hds/advanced-table/index', function (hooks) {
       )
       .doesNotExist('bottom scroll indicator hidden when table is empty');
   });
+
+  test('it should render the model rows in original order when @model and @columns are used without @sortBy', async function (assert) {
+    await render(
+      <template>
+        <HdsAdvancedTable
+          @model={{DEFAULT_BASIC_MODEL}}
+          @columns={{DEFAULT_BASIC_COLUMNS}}
+          id="data-test-advanced-table"
+        >
+          <:body as |B|>
+            <B.Tr @selectionKey={{get B.data "id"}}>
+              <B.Th>{{get B.data "name"}}</B.Th>
+              <B.Td>{{get B.data "age"}}</B.Td>
+              <B.Td>{{get B.data "country"}}</B.Td>
+            </B.Tr>
+          </:body>
+        </HdsAdvancedTable>
+      </template>,
+    );
+
+    // model should be rendered in original insertion order (no sort applied)
+    const rows = getBodyContent();
+    assert.deepEqual(rows[0]?.[0], 'Bob');
+    assert.deepEqual(rows[1]?.[0], 'Alice');
+    assert.deepEqual(rows[2]?.[0], 'Charlie');
+  });
 });

--- a/showcase/tests/integration/components/hds/table/index-test.gts
+++ b/showcase/tests/integration/components/hds/table/index-test.gts
@@ -324,6 +324,37 @@ module('Integration | Component | hds/table/index', function (hooks) {
     assert.dom('.tippy-content').hasText('More info.');
   });
 
+  test('it should render the model rows in original order when @model and @columns are used without @sortBy', async function (assert) {
+    await render(
+      <template>
+        <HdsTable
+          @model={{DEFAULT_SORTABLE_MODEL}}
+          @columns={{DEFAULT_SORTABLE_COLUMNS}}
+          id="data-test-table"
+        >
+          <:body as |B|>
+            <B.Tr>
+              <B.Td>{{B.data.artist}}</B.Td>
+              <B.Td>{{B.data.album}}</B.Td>
+              <B.Td>{{B.data.year}}</B.Td>
+            </B.Tr>
+          </:body>
+        </HdsTable>
+      </template>,
+    );
+
+    // model should be rendered in original insertion order (no sort applied)
+    assert
+      .dom('#data-test-table tbody tr:nth-child(1) td:nth-child(1)')
+      .hasText('Nick Drake');
+    assert
+      .dom('#data-test-table tbody tr:nth-child(2) td:nth-child(1)')
+      .hasText('The Beatles');
+    assert
+      .dom('#data-test-table tbody tr:nth-child(3) td:nth-child(1)')
+      .hasText('Melanie');
+  });
+
   test('it should render a sortable table with an empty caption if no caption is provided and table is unsorted', async function (assert) {
     await createSortableTable({});
 


### PR DESCRIPTION
> [!IMPORTANT]
> DO NOT MERGE until ready for v8. Needs more testing in products.

### :pushpin: Summary

If merged, this PR would fix an error thrown by Table and AdvancedTable when @model and @columns are used without a @sortBy argument. The components were producing a sort key of "undefined:asc", which caused errors in some environments.

Adds integration tests for both components covering this case.

This was initially filed as a GIthub issue: https://github.com/hashicorp/design-system/issues/4089

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [x] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>