### PR TITLE
`Form::Fieldset`: Add missing `id` arg

### DIFF
--- a/.changeset/full-geese-listen.md
+++ b/.changeset/full-geese-listen.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/form/fieldset -->
+`Form::Fieldset` - Add missing `id` argument to support passing a custom ID
+<!-- END -->

--- a/.changeset/full-geese-listen.md
+++ b/.changeset/full-geese-listen.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/form/fieldset -->
-`Form::Fieldset` - Add missing `@id` argument to support passing a custom ID
+`Form::Fieldset` - Add missing `@id` argument to the component signature.
 <!-- END -->

--- a/.changeset/full-geese-listen.md
+++ b/.changeset/full-geese-listen.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/form/fieldset -->
-`Form::Fieldset` - Add missing `id` argument to support passing a custom ID
+`Form::Fieldset` - Add missing `@id` argument to support passing a custom ID
 <!-- END -->

--- a/packages/components/component-catalog.json
+++ b/packages/components/component-catalog.json
@@ -6477,6 +6477,11 @@
       "element": "HTMLElement",
       "args": [
         {
+          "name": "id",
+          "type": "string",
+          "required": false
+        },
+        {
           "name": "extraAriaDescribedBy",
           "type": "string",
           "required": false

--- a/packages/components/component-catalog.json
+++ b/packages/components/component-catalog.json
@@ -6290,13 +6290,13 @@
       "element": "HTMLElement",
       "args": [
         {
-          "name": "id",
+          "name": "extraAriaDescribedBy",
           "type": "string",
           "required": false,
           "inheritedFrom": "hds/form/fieldset"
         },
         {
-          "name": "extraAriaDescribedBy",
+          "name": "id",
           "type": "string",
           "required": false,
           "inheritedFrom": "hds/form/fieldset"
@@ -6483,12 +6483,12 @@
       "element": "HTMLElement",
       "args": [
         {
-          "name": "id",
+          "name": "extraAriaDescribedBy",
           "type": "string",
           "required": false
         },
         {
-          "name": "extraAriaDescribedBy",
+          "name": "id",
           "type": "string",
           "required": false
         },
@@ -7383,13 +7383,13 @@
       "element": "HTMLElement",
       "args": [
         {
-          "name": "id",
+          "name": "extraAriaDescribedBy",
           "type": "string",
           "required": false,
           "inheritedFrom": "hds/form/fieldset"
         },
         {
-          "name": "extraAriaDescribedBy",
+          "name": "id",
           "type": "string",
           "required": false,
           "inheritedFrom": "hds/form/fieldset"
@@ -7552,13 +7552,13 @@
           "values": ["bottom", "left"]
         },
         {
-          "name": "id",
+          "name": "extraAriaDescribedBy",
           "type": "string",
           "required": false,
           "inheritedFrom": "hds/form/fieldset"
         },
         {
-          "name": "extraAriaDescribedBy",
+          "name": "id",
           "type": "string",
           "required": false,
           "inheritedFrom": "hds/form/fieldset"
@@ -10049,13 +10049,13 @@
       "element": "HTMLElement",
       "args": [
         {
-          "name": "id",
+          "name": "extraAriaDescribedBy",
           "type": "string",
           "required": false,
           "inheritedFrom": "hds/form/fieldset"
         },
         {
-          "name": "extraAriaDescribedBy",
+          "name": "id",
           "type": "string",
           "required": false,
           "inheritedFrom": "hds/form/fieldset"

--- a/packages/components/component-catalog.json
+++ b/packages/components/component-catalog.json
@@ -6290,6 +6290,12 @@
       "element": "HTMLElement",
       "args": [
         {
+          "name": "id",
+          "type": "string",
+          "required": false,
+          "inheritedFrom": "hds/form/fieldset"
+        },
+        {
           "name": "extraAriaDescribedBy",
           "type": "string",
           "required": false,
@@ -7377,6 +7383,12 @@
       "element": "HTMLElement",
       "args": [
         {
+          "name": "id",
+          "type": "string",
+          "required": false,
+          "inheritedFrom": "hds/form/fieldset"
+        },
+        {
           "name": "extraAriaDescribedBy",
           "type": "string",
           "required": false,
@@ -7538,6 +7550,12 @@
           "type": "\"left\" | \"bottom\"",
           "required": false,
           "values": ["bottom", "left"]
+        },
+        {
+          "name": "id",
+          "type": "string",
+          "required": false,
+          "inheritedFrom": "hds/form/fieldset"
         },
         {
           "name": "extraAriaDescribedBy",
@@ -10030,6 +10048,12 @@
       "docsPath": "components/form/toggle",
       "element": "HTMLElement",
       "args": [
+        {
+          "name": "id",
+          "type": "string",
+          "required": false,
+          "inheritedFrom": "hds/form/fieldset"
+        },
         {
           "name": "extraAriaDescribedBy",
           "type": "string",

--- a/packages/components/src/components/hds/form/fieldset/index.gts
+++ b/packages/components/src/components/hds/form/fieldset/index.gts
@@ -29,6 +29,7 @@ export const LAYOUT_TYPES: HdsFormFieldsetLayouts[] = Object.values(
 
 export interface HdsFormFieldsetSignature {
   Args: {
+    id?: string;
     extraAriaDescribedBy?: string;
     isOptional?: boolean;
     isRequired?: boolean;

--- a/packages/components/src/components/hds/form/fieldset/index.gts
+++ b/packages/components/src/components/hds/form/fieldset/index.gts
@@ -120,7 +120,11 @@ export default class HdsFormFieldset extends Component<HdsFormFieldsetSignature>
       }}
       <div class="hds-form-group__control-fields-wrapper">
         {{! @glint-expect-error }}
-        {{yield (hash Control=HdsYield id=this.id ariaDescribedBy=this.ariaDescribedBy)}}
+        {{yield
+          (hash
+            Control=HdsYield id=this.id ariaDescribedBy=this.ariaDescribedBy
+          )
+        }}
       </div>
       {{yield
         (hash

--- a/packages/components/src/components/hds/form/fieldset/index.gts
+++ b/packages/components/src/components/hds/form/fieldset/index.gts
@@ -118,14 +118,14 @@ export default class HdsFormFieldset extends Component<HdsFormFieldsetSignature>
           )
         )
       }}
-      <div class="hds-form-group__control-fields-wrapper">
-        {{! @glint-expect-error }}
-        {{yield
-          (hash
-            Control=HdsYield id=this.id ariaDescribedBy=this.ariaDescribedBy
-          )
-        }}
-      </div>
+      {{! @glint-expect-error }}
+      {{#let this.ariaDescribedBy as |ariaDescribedBy|}}
+        <div class="hds-form-group__control-fields-wrapper">
+          {{yield
+            (hash Control=HdsYield id=this.id ariaDescribedBy=ariaDescribedBy)
+          }}
+        </div>
+      {{/let}}
       {{yield
         (hash
           Error=(component

--- a/packages/components/src/components/hds/form/fieldset/index.gts
+++ b/packages/components/src/components/hds/form/fieldset/index.gts
@@ -120,7 +120,7 @@ export default class HdsFormFieldset extends Component<HdsFormFieldsetSignature>
       }}
       <div class="hds-form-group__control-fields-wrapper">
         {{! @glint-expect-error }}
-        {{yield (hash Control=HdsYield ariaDescribedBy=this.ariaDescribedBy)}}
+        {{yield (hash Control=HdsYield id=this.id ariaDescribedBy=this.ariaDescribedBy)}}
       </div>
       {{yield
         (hash

--- a/showcase/tests/integration/components/hds/form/field/index-test.gts
+++ b/showcase/tests/integration/components/hds/form/field/index-test.gts
@@ -113,6 +113,7 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
     assert
       .dom('.hds-form-field__helper-text')
       .hasAttribute('id', `helper-text-${controlId}`);
+    assert.dom('.hds-form-field__control pre').hasAttribute('id', controlId);
     assert
       .dom('.hds-form-field__control pre')
       .hasAttribute(
@@ -154,6 +155,7 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
     assert
       .dom('.hds-form-field__helper-text')
       .hasAttribute('id', `helper-text-${controlId}`);
+    assert.dom('.hds-form-field__control pre').hasAttribute('id', controlId);
     assert
       .dom('.hds-form-field__control pre')
       .hasAttribute(
@@ -194,6 +196,7 @@ module('Integration | Component | hds/form/field/index', function (hooks) {
     assert
       .dom('.hds-form-field__helper-text')
       .hasAttribute('id', `helper-text-${controlId}`);
+    assert.dom('.hds-form-field__control pre').hasAttribute('id', controlId);
     assert
       .dom('.hds-form-field__control pre')
       .hasAttribute(

--- a/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
+++ b/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
@@ -92,6 +92,39 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
       .dom('.hds-form-group__error')
       .hasAttribute('id', `error-${fieldsetId}`);
   });
+  test('it automatically provides all the ID relations between the elements with a custom @id', async function (assert) {
+    await render(
+      <template>
+        <HdsFormFieldset
+          @layout="vertical"
+          id="test-form-fieldset"
+          @id="my-custom-id"
+          as |F|
+        >
+          <F.Legend>This is the legend</F.Legend>
+          <F.HelperText>This is the group helper text</F.HelperText>
+          <F.Control><pre
+              id={{F.id}}
+              aria-describedby={{F.ariaDescribedBy}}
+            >This is a mock control</pre></F.Control>
+          <F.Error>This is the error</F.Error>
+        </HdsFormFieldset>
+      </template>,
+    );
+    const controlId = 'my-custom-id';
+    assert
+      .dom('.hds-form-group__helper-text')
+      .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-group__control-fields-wrapper pre')
+      .hasAttribute(
+        'aria-describedby',
+        `helper-text-${controlId} error-${controlId}`,
+      );
+    assert
+      .dom('.hds-form-group__error')
+      .hasAttribute('id', `error-${controlId}`);
+  });
 
   // REQUIRED AND OPTIONAL
 

--- a/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
+++ b/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
@@ -95,11 +95,7 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
   test('it automatically provides all the ID relations between the elements with a custom @id', async function (assert) {
     await render(
       <template>
-        <HdsFormFieldset
-          @layout="vertical"
-          @id="my-custom-id"
-          as |F|
-        >
+        <HdsFormFieldset @layout="vertical" @id="my-custom-id" as |F|>
           <F.Legend>This is the legend</F.Legend>
           <F.HelperText>This is the group helper text</F.HelperText>
           <F.Control><pre

--- a/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
+++ b/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
@@ -97,7 +97,6 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
       <template>
         <HdsFormFieldset
           @layout="vertical"
-          id="test-form-fieldset"
           @id="my-custom-id"
           as |F|
         >
@@ -112,6 +111,7 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
       </template>,
     );
     const controlId = 'my-custom-id';
+    assert.dom('fieldset').hasAttribute('id', controlId);
     assert
       .dom('.hds-form-group__helper-text')
       .hasAttribute('id', `helper-text-${controlId}`);

--- a/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
+++ b/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
@@ -84,7 +84,7 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
     );
     // the fieldset ID is dynamically generated
     const fieldset = find('fieldset');
-    const fieldsetId = fieldset?.id;
+    const fieldsetId = fieldset?.id ?? '';
     assert
       .dom('.hds-form-group__helper-text')
       .hasAttribute('id', `helper-text-${fieldsetId}`);

--- a/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
+++ b/showcase/tests/integration/components/hds/form/fieldset/index-test.gts
@@ -89,6 +89,9 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
       .dom('.hds-form-group__helper-text')
       .hasAttribute('id', `helper-text-${fieldsetId}`);
     assert
+      .dom('.hds-form-group__control-fields-wrapper pre')
+      .hasAttribute('id', fieldsetId);
+    assert
       .dom('.hds-form-group__error')
       .hasAttribute('id', `error-${fieldsetId}`);
   });
@@ -111,6 +114,9 @@ module('Integration | Component | hds/form/fieldset/index', function (hooks) {
     assert
       .dom('.hds-form-group__helper-text')
       .hasAttribute('id', `helper-text-${controlId}`);
+    assert
+      .dom('.hds-form-group__control-fields-wrapper pre')
+      .hasAttribute('id', controlId);
     assert
       .dom('.hds-form-group__control-fields-wrapper pre')
       .hasAttribute(


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge until further notice

### :pushpin: Summary

If merged, this PR would add an optional `id` argument that is currently missing from the signature. The component has been working at runtime because getElementId in the id() getter generates a GUID if element.args.id is not present. The added arg would allow consumers to set a custom ID when needed, such as for testing or establishing an ARIA relationship from another element. 

The arg is already documented on the website, so no changes were needed there. I added an integration test confirming that the custom `id` value is passed down successfully to its contextual components.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6623](https://hashicorp.atlassian.net/browse/HDS-6623)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6623]: https://hashicorp.atlassian.net/browse/HDS-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ