### PR TITLE
`Time`: Remove unused isoUtcString arg

### DIFF
--- a/.changeset/three-schools-agree.md
+++ b/.changeset/three-schools-agree.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/time -->
+`Time` - Remove unused `isoUtcString` arg
+<!-- END -->

--- a/.changeset/three-schools-agree.md
+++ b/.changeset/three-schools-agree.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/time -->
-`Time` - Remove unused `isoUtcString` arg
+`Time` - Remove unused `@isoUtcString` arg
 <!-- END -->

--- a/.changeset/three-schools-agree.md
+++ b/.changeset/three-schools-agree.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/time -->
-`Time` - Remove unused `@isoUtcString` arg
+`Time` - Removed unused `@isoUtcString` argument
 <!-- END -->

--- a/packages/components/component-catalog.json
+++ b/packages/components/component-catalog.json
@@ -12944,11 +12944,6 @@
           "required": false
         },
         {
-          "name": "isoUtcString",
-          "type": "string",
-          "required": false
-        },
-        {
           "name": "startDate",
           "type": "string | Date",
           "required": false

--- a/packages/components/src/components/hds/time/index.gts
+++ b/packages/components/src/components/hds/time/index.gts
@@ -29,7 +29,6 @@ export interface HdsTimeSignature {
       | 'friendly-relative';
     isOpen?: boolean;
     hasTooltip?: boolean;
-    isoUtcString?: string;
   };
   Element: HTMLElement;
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge until further notice

### :pushpin: Summary

If merged, this PR would remove an optional `isoUtcString` arg from the `Time` component signature that is unused within the template. The value is never read currently, since the isoUtcString() getter derives the value from this.startDate and this.endDate instead. 

The arg is not used within any tests or the showcase so no changes were needed there. It's also not documented on the website, so no changes were made there either.

I marked the changeset as a patch, since the arg isn't in use within any [consumer repos](https://github.com/search?q=org%3Ahashicorp+%3CHds%3A%3ATime&type=code&p=1) currently.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6625](https://hashicorp.atlassian.net/browse/HDS-6625)
***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6625]: https://hashicorp.atlassian.net/browse/HDS-6625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ