### PR TITLE
[ Project Solar / Phase 1 / Release ]`AppSideNav`: List item and toggle button alignment fixes

### DIFF
--- a/packages/components/src/styles/components/app-side-nav/toggle-button.scss
+++ b/packages/components/src/styles/components/app-side-nav/toggle-button.scss
@@ -12,14 +12,14 @@
 
 .hds-app-side-nav__toggle-button {
   position: absolute;
-  top: var(--hds-app-side-nav-wrapper-padding-vertical); // visually align with :header content
+  top: var(--hds-app-side-nav-toggle-button-position-top); // visually align with :header content
   left: calc(var(--hds-app-side-nav-wrapper-border-width) * -1);
   z-index: 1;
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
   width: var(--hds-var-app-side-nav-toggle-button-width);
-  height: 36px;
+  height: var(--hds-app-side-nav-toggle-button-height);
   padding: 0 4px;
   color: var(--hds-foreground-color-primary);
   background: none;

--- a/packages/components/src/styles/components/app-side-nav/toggle-button.scss
+++ b/packages/components/src/styles/components/app-side-nav/toggle-button.scss
@@ -12,7 +12,7 @@
 
 .hds-app-side-nav__toggle-button {
   position: absolute;
-  top: var(--hds-app-side-nav-toggle-button-position-top); // visually align with :header content
+  top: var(--hds-app-side-nav-toggle-button-top); // visually align with :header content
   left: calc(var(--hds-app-side-nav-wrapper-border-width) * -1);
   z-index: 1;
   display: flex;

--- a/packages/tokens/dist/docs/products/themed-tokens.json
+++ b/packages/tokens/dist/docs/products/themed-tokens.json
@@ -9222,6 +9222,77 @@
         "radius"
       ]
     },
+    "hds-app-side-nav-toggle-button-position-top": {
+      "key": "{app-side-nav.toggle-button.position.top}",
+      "$type": "dimension",
+      "$value": "16px",
+      "unit": "px",
+      "$modes": {
+        "default": "16px",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "{app-side-nav.wrapper.padding.vertical}",
+        "unit": "px",
+        "$modes": {
+          "default": "{app-side-nav.wrapper.padding.vertical}",
+          "cds-g0": "15",
+          "cds-g10": "15",
+          "cds-g90": "15",
+          "cds-g100": "15"
+        },
+        "key": "{app-side-nav.toggle-button.position.top}"
+      },
+      "name": "hds-app-side-nav-toggle-button-position-top",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "position",
+        "top"
+      ]
+    },
+    "hds-app-side-nav-toggle-button-height": {
+      "key": "{app-side-nav.toggle-button.height}",
+      "$type": "dimension",
+      "$value": "36px",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "36",
+        "unit": "px",
+        "$modes": {
+          "default": "36",
+          "cds-g0": "34",
+          "cds-g10": "34",
+          "cds-g90": "34",
+          "cds-g100": "34"
+        },
+        "key": "{app-side-nav.toggle-button.height}"
+      },
+      "name": "hds-app-side-nav-toggle-button-height",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "height"
+      ]
+    },
     "hds-app-side-nav-body-list-margin-vertical": {
       "key": "{app-side-nav.body.list.margin-vertical}",
       "$type": "dimension",
@@ -9417,10 +9488,10 @@
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "original": {
         "$type": "dimension",
@@ -9428,10 +9499,10 @@
         "unit": "px",
         "$modes": {
           "default": "4",
-          "cds-g0": "7",
-          "cds-g10": "7",
-          "cds-g90": "7",
-          "cds-g100": "7"
+          "cds-g0": "4",
+          "cds-g10": "4",
+          "cds-g90": "4",
+          "cds-g100": "4"
         },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },
@@ -43204,6 +43275,77 @@
         "radius"
       ]
     },
+    "hds-app-side-nav-toggle-button-position-top": {
+      "key": "{app-side-nav.toggle-button.position.top}",
+      "$type": "dimension",
+      "$value": "15px",
+      "unit": "px",
+      "$modes": {
+        "default": "16px",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "15",
+        "unit": "px",
+        "$modes": {
+          "default": "{app-side-nav.wrapper.padding.vertical}",
+          "cds-g0": "15",
+          "cds-g10": "15",
+          "cds-g90": "15",
+          "cds-g100": "15"
+        },
+        "key": "{app-side-nav.toggle-button.position.top}"
+      },
+      "name": "hds-app-side-nav-toggle-button-position-top",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "position",
+        "top"
+      ]
+    },
+    "hds-app-side-nav-toggle-button-height": {
+      "key": "{app-side-nav.toggle-button.height}",
+      "$type": "dimension",
+      "$value": "34px",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "34",
+        "unit": "px",
+        "$modes": {
+          "default": "36",
+          "cds-g0": "34",
+          "cds-g10": "34",
+          "cds-g90": "34",
+          "cds-g100": "34"
+        },
+        "key": "{app-side-nav.toggle-button.height}"
+      },
+      "name": "hds-app-side-nav-toggle-button-height",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "height"
+      ]
+    },
     "hds-app-side-nav-body-list-margin-vertical": {
       "key": "{app-side-nav.body.list.margin-vertical}",
       "$type": "dimension",
@@ -43395,25 +43537,25 @@
     "hds-app-side-nav-body-list-item-padding-vertical": {
       "key": "{app-side-nav.body.list-item.padding.vertical}",
       "$type": "dimension",
-      "$value": "7px",
+      "$value": "4px",
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "original": {
         "$type": "dimension",
-        "$value": "7",
+        "$value": "4",
         "unit": "px",
         "$modes": {
           "default": "4",
-          "cds-g0": "7",
-          "cds-g10": "7",
-          "cds-g90": "7",
-          "cds-g100": "7"
+          "cds-g0": "4",
+          "cds-g10": "4",
+          "cds-g90": "4",
+          "cds-g100": "4"
         },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },
@@ -77210,6 +77352,77 @@
         "radius"
       ]
     },
+    "hds-app-side-nav-toggle-button-position-top": {
+      "key": "{app-side-nav.toggle-button.position.top}",
+      "$type": "dimension",
+      "$value": "15px",
+      "unit": "px",
+      "$modes": {
+        "default": "16px",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "15",
+        "unit": "px",
+        "$modes": {
+          "default": "{app-side-nav.wrapper.padding.vertical}",
+          "cds-g0": "15",
+          "cds-g10": "15",
+          "cds-g90": "15",
+          "cds-g100": "15"
+        },
+        "key": "{app-side-nav.toggle-button.position.top}"
+      },
+      "name": "hds-app-side-nav-toggle-button-position-top",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "position",
+        "top"
+      ]
+    },
+    "hds-app-side-nav-toggle-button-height": {
+      "key": "{app-side-nav.toggle-button.height}",
+      "$type": "dimension",
+      "$value": "34px",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "34",
+        "unit": "px",
+        "$modes": {
+          "default": "36",
+          "cds-g0": "34",
+          "cds-g10": "34",
+          "cds-g90": "34",
+          "cds-g100": "34"
+        },
+        "key": "{app-side-nav.toggle-button.height}"
+      },
+      "name": "hds-app-side-nav-toggle-button-height",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "height"
+      ]
+    },
     "hds-app-side-nav-body-list-margin-vertical": {
       "key": "{app-side-nav.body.list.margin-vertical}",
       "$type": "dimension",
@@ -77401,25 +77614,25 @@
     "hds-app-side-nav-body-list-item-padding-vertical": {
       "key": "{app-side-nav.body.list-item.padding.vertical}",
       "$type": "dimension",
-      "$value": "7px",
+      "$value": "4px",
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "original": {
         "$type": "dimension",
-        "$value": "7",
+        "$value": "4",
         "unit": "px",
         "$modes": {
           "default": "4",
-          "cds-g0": "7",
-          "cds-g10": "7",
-          "cds-g90": "7",
-          "cds-g100": "7"
+          "cds-g0": "4",
+          "cds-g10": "4",
+          "cds-g90": "4",
+          "cds-g100": "4"
         },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },
@@ -111216,6 +111429,77 @@
         "radius"
       ]
     },
+    "hds-app-side-nav-toggle-button-position-top": {
+      "key": "{app-side-nav.toggle-button.position.top}",
+      "$type": "dimension",
+      "$value": "15px",
+      "unit": "px",
+      "$modes": {
+        "default": "16px",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "15",
+        "unit": "px",
+        "$modes": {
+          "default": "{app-side-nav.wrapper.padding.vertical}",
+          "cds-g0": "15",
+          "cds-g10": "15",
+          "cds-g90": "15",
+          "cds-g100": "15"
+        },
+        "key": "{app-side-nav.toggle-button.position.top}"
+      },
+      "name": "hds-app-side-nav-toggle-button-position-top",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "position",
+        "top"
+      ]
+    },
+    "hds-app-side-nav-toggle-button-height": {
+      "key": "{app-side-nav.toggle-button.height}",
+      "$type": "dimension",
+      "$value": "34px",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "34",
+        "unit": "px",
+        "$modes": {
+          "default": "36",
+          "cds-g0": "34",
+          "cds-g10": "34",
+          "cds-g90": "34",
+          "cds-g100": "34"
+        },
+        "key": "{app-side-nav.toggle-button.height}"
+      },
+      "name": "hds-app-side-nav-toggle-button-height",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "height"
+      ]
+    },
     "hds-app-side-nav-body-list-margin-vertical": {
       "key": "{app-side-nav.body.list.margin-vertical}",
       "$type": "dimension",
@@ -111407,25 +111691,25 @@
     "hds-app-side-nav-body-list-item-padding-vertical": {
       "key": "{app-side-nav.body.list-item.padding.vertical}",
       "$type": "dimension",
-      "$value": "7px",
+      "$value": "4px",
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "original": {
         "$type": "dimension",
-        "$value": "7",
+        "$value": "4",
         "unit": "px",
         "$modes": {
           "default": "4",
-          "cds-g0": "7",
-          "cds-g10": "7",
-          "cds-g90": "7",
-          "cds-g100": "7"
+          "cds-g0": "4",
+          "cds-g10": "4",
+          "cds-g90": "4",
+          "cds-g100": "4"
         },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },
@@ -145222,6 +145506,77 @@
         "radius"
       ]
     },
+    "hds-app-side-nav-toggle-button-position-top": {
+      "key": "{app-side-nav.toggle-button.position.top}",
+      "$type": "dimension",
+      "$value": "15px",
+      "unit": "px",
+      "$modes": {
+        "default": "16px",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "15",
+        "unit": "px",
+        "$modes": {
+          "default": "{app-side-nav.wrapper.padding.vertical}",
+          "cds-g0": "15",
+          "cds-g10": "15",
+          "cds-g90": "15",
+          "cds-g100": "15"
+        },
+        "key": "{app-side-nav.toggle-button.position.top}"
+      },
+      "name": "hds-app-side-nav-toggle-button-position-top",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "position",
+        "top"
+      ]
+    },
+    "hds-app-side-nav-toggle-button-height": {
+      "key": "{app-side-nav.toggle-button.height}",
+      "$type": "dimension",
+      "$value": "34px",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "original": {
+        "$type": "dimension",
+        "$value": "34",
+        "unit": "px",
+        "$modes": {
+          "default": "36",
+          "cds-g0": "34",
+          "cds-g10": "34",
+          "cds-g90": "34",
+          "cds-g100": "34"
+        },
+        "key": "{app-side-nav.toggle-button.height}"
+      },
+      "name": "hds-app-side-nav-toggle-button-height",
+      "attributes": {
+        "category": "app-side-nav"
+      },
+      "path": [
+        "app-side-nav",
+        "toggle-button",
+        "height"
+      ]
+    },
     "hds-app-side-nav-body-list-margin-vertical": {
       "key": "{app-side-nav.body.list.margin-vertical}",
       "$type": "dimension",
@@ -145413,25 +145768,25 @@
     "hds-app-side-nav-body-list-item-padding-vertical": {
       "key": "{app-side-nav.body.list-item.padding.vertical}",
       "$type": "dimension",
-      "$value": "7px",
+      "$value": "4px",
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "original": {
         "$type": "dimension",
-        "$value": "7",
+        "$value": "4",
         "unit": "px",
         "$modes": {
           "default": "4",
-          "cds-g0": "7",
-          "cds-g10": "7",
-          "cds-g90": "7",
-          "cds-g100": "7"
+          "cds-g0": "4",
+          "cds-g10": "4",
+          "cds-g90": "4",
+          "cds-g100": "4"
         },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },

--- a/packages/tokens/dist/docs/products/themed-tokens.json
+++ b/packages/tokens/dist/docs/products/themed-tokens.json
@@ -9222,8 +9222,8 @@
         "radius"
       ]
     },
-    "hds-app-side-nav-toggle-button-position-top": {
-      "key": "{app-side-nav.toggle-button.position.top}",
+    "hds-app-side-nav-toggle-button-top": {
+      "key": "{app-side-nav.toggle-button.top}",
       "$type": "dimension",
       "$value": "16px",
       "unit": "px",
@@ -9245,16 +9245,15 @@
           "cds-g90": "15",
           "cds-g100": "15"
         },
-        "key": "{app-side-nav.toggle-button.position.top}"
+        "key": "{app-side-nav.toggle-button.top}"
       },
-      "name": "hds-app-side-nav-toggle-button-position-top",
+      "name": "hds-app-side-nav-toggle-button-top",
       "attributes": {
         "category": "app-side-nav"
       },
       "path": [
         "app-side-nav",
         "toggle-button",
-        "position",
         "top"
       ]
     },
@@ -9486,24 +9485,10 @@
       "$type": "dimension",
       "$value": "4px",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "original": {
         "$type": "dimension",
         "$value": "4",
         "unit": "px",
-        "$modes": {
-          "default": "4",
-          "cds-g0": "4",
-          "cds-g10": "4",
-          "cds-g90": "4",
-          "cds-g100": "4"
-        },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },
       "name": "hds-app-side-nav-body-list-item-padding-vertical",
@@ -43275,8 +43260,8 @@
         "radius"
       ]
     },
-    "hds-app-side-nav-toggle-button-position-top": {
-      "key": "{app-side-nav.toggle-button.position.top}",
+    "hds-app-side-nav-toggle-button-top": {
+      "key": "{app-side-nav.toggle-button.top}",
       "$type": "dimension",
       "$value": "15px",
       "unit": "px",
@@ -43298,16 +43283,15 @@
           "cds-g90": "15",
           "cds-g100": "15"
         },
-        "key": "{app-side-nav.toggle-button.position.top}"
+        "key": "{app-side-nav.toggle-button.top}"
       },
-      "name": "hds-app-side-nav-toggle-button-position-top",
+      "name": "hds-app-side-nav-toggle-button-top",
       "attributes": {
         "category": "app-side-nav"
       },
       "path": [
         "app-side-nav",
         "toggle-button",
-        "position",
         "top"
       ]
     },
@@ -43539,24 +43523,10 @@
       "$type": "dimension",
       "$value": "4px",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "original": {
         "$type": "dimension",
         "$value": "4",
         "unit": "px",
-        "$modes": {
-          "default": "4",
-          "cds-g0": "4",
-          "cds-g10": "4",
-          "cds-g90": "4",
-          "cds-g100": "4"
-        },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },
       "name": "hds-app-side-nav-body-list-item-padding-vertical",
@@ -77352,8 +77322,8 @@
         "radius"
       ]
     },
-    "hds-app-side-nav-toggle-button-position-top": {
-      "key": "{app-side-nav.toggle-button.position.top}",
+    "hds-app-side-nav-toggle-button-top": {
+      "key": "{app-side-nav.toggle-button.top}",
       "$type": "dimension",
       "$value": "15px",
       "unit": "px",
@@ -77375,16 +77345,15 @@
           "cds-g90": "15",
           "cds-g100": "15"
         },
-        "key": "{app-side-nav.toggle-button.position.top}"
+        "key": "{app-side-nav.toggle-button.top}"
       },
-      "name": "hds-app-side-nav-toggle-button-position-top",
+      "name": "hds-app-side-nav-toggle-button-top",
       "attributes": {
         "category": "app-side-nav"
       },
       "path": [
         "app-side-nav",
         "toggle-button",
-        "position",
         "top"
       ]
     },
@@ -77616,24 +77585,10 @@
       "$type": "dimension",
       "$value": "4px",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "original": {
         "$type": "dimension",
         "$value": "4",
         "unit": "px",
-        "$modes": {
-          "default": "4",
-          "cds-g0": "4",
-          "cds-g10": "4",
-          "cds-g90": "4",
-          "cds-g100": "4"
-        },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },
       "name": "hds-app-side-nav-body-list-item-padding-vertical",
@@ -111429,8 +111384,8 @@
         "radius"
       ]
     },
-    "hds-app-side-nav-toggle-button-position-top": {
-      "key": "{app-side-nav.toggle-button.position.top}",
+    "hds-app-side-nav-toggle-button-top": {
+      "key": "{app-side-nav.toggle-button.top}",
       "$type": "dimension",
       "$value": "15px",
       "unit": "px",
@@ -111452,16 +111407,15 @@
           "cds-g90": "15",
           "cds-g100": "15"
         },
-        "key": "{app-side-nav.toggle-button.position.top}"
+        "key": "{app-side-nav.toggle-button.top}"
       },
-      "name": "hds-app-side-nav-toggle-button-position-top",
+      "name": "hds-app-side-nav-toggle-button-top",
       "attributes": {
         "category": "app-side-nav"
       },
       "path": [
         "app-side-nav",
         "toggle-button",
-        "position",
         "top"
       ]
     },
@@ -111693,24 +111647,10 @@
       "$type": "dimension",
       "$value": "4px",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "original": {
         "$type": "dimension",
         "$value": "4",
         "unit": "px",
-        "$modes": {
-          "default": "4",
-          "cds-g0": "4",
-          "cds-g10": "4",
-          "cds-g90": "4",
-          "cds-g100": "4"
-        },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },
       "name": "hds-app-side-nav-body-list-item-padding-vertical",
@@ -145506,8 +145446,8 @@
         "radius"
       ]
     },
-    "hds-app-side-nav-toggle-button-position-top": {
-      "key": "{app-side-nav.toggle-button.position.top}",
+    "hds-app-side-nav-toggle-button-top": {
+      "key": "{app-side-nav.toggle-button.top}",
       "$type": "dimension",
       "$value": "15px",
       "unit": "px",
@@ -145529,16 +145469,15 @@
           "cds-g90": "15",
           "cds-g100": "15"
         },
-        "key": "{app-side-nav.toggle-button.position.top}"
+        "key": "{app-side-nav.toggle-button.top}"
       },
-      "name": "hds-app-side-nav-toggle-button-position-top",
+      "name": "hds-app-side-nav-toggle-button-top",
       "attributes": {
         "category": "app-side-nav"
       },
       "path": [
         "app-side-nav",
         "toggle-button",
-        "position",
         "top"
       ]
     },
@@ -145770,24 +145709,10 @@
       "$type": "dimension",
       "$value": "4px",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "original": {
         "$type": "dimension",
         "$value": "4",
         "unit": "px",
-        "$modes": {
-          "default": "4",
-          "cds-g0": "4",
-          "cds-g10": "4",
-          "cds-g90": "4",
-          "cds-g100": "4"
-        },
         "key": "{app-side-nav.body.list-item.padding.vertical}"
       },
       "name": "hds-app-side-nav-body-list-item-padding-vertical",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
@@ -9230,6 +9230,77 @@
     ]
   },
   {
+    "key": "{app-side-nav.toggle-button.position.top}",
+    "$type": "dimension",
+    "$value": "15px",
+    "unit": "px",
+    "$modes": {
+      "default": "16px",
+      "cds-g0": "15",
+      "cds-g10": "15",
+      "cds-g90": "15",
+      "cds-g100": "15"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "15",
+      "unit": "px",
+      "$modes": {
+        "default": "{app-side-nav.wrapper.padding.vertical}",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "key": "{app-side-nav.toggle-button.position.top}"
+    },
+    "name": "hds-app-side-nav-toggle-button-position-top",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "position",
+      "top"
+    ]
+  },
+  {
+    "key": "{app-side-nav.toggle-button.height}",
+    "$type": "dimension",
+    "$value": "34px",
+    "unit": "px",
+    "$modes": {
+      "default": "36",
+      "cds-g0": "34",
+      "cds-g10": "34",
+      "cds-g90": "34",
+      "cds-g100": "34"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "34",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "key": "{app-side-nav.toggle-button.height}"
+    },
+    "name": "hds-app-side-nav-toggle-button-height",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "height"
+    ]
+  },
+  {
     "key": "{app-side-nav.body.list.margin-vertical}",
     "$type": "dimension",
     "$value": "16px",
@@ -9420,25 +9491,25 @@
   {
     "key": "{app-side-nav.body.list-item.padding.vertical}",
     "$type": "dimension",
-    "$value": "7px",
+    "$value": "4px",
     "unit": "px",
     "$modes": {
       "default": "4",
-      "cds-g0": "7",
-      "cds-g10": "7",
-      "cds-g90": "7",
-      "cds-g100": "7"
+      "cds-g0": "4",
+      "cds-g10": "4",
+      "cds-g90": "4",
+      "cds-g100": "4"
     },
     "original": {
       "$type": "dimension",
-      "$value": "7",
+      "$value": "4",
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g0.json
@@ -9230,7 +9230,7 @@
     ]
   },
   {
-    "key": "{app-side-nav.toggle-button.position.top}",
+    "key": "{app-side-nav.toggle-button.top}",
     "$type": "dimension",
     "$value": "15px",
     "unit": "px",
@@ -9252,16 +9252,15 @@
         "cds-g90": "15",
         "cds-g100": "15"
       },
-      "key": "{app-side-nav.toggle-button.position.top}"
+      "key": "{app-side-nav.toggle-button.top}"
     },
-    "name": "hds-app-side-nav-toggle-button-position-top",
+    "name": "hds-app-side-nav-toggle-button-top",
     "attributes": {
       "category": "app-side-nav"
     },
     "path": [
       "app-side-nav",
       "toggle-button",
-      "position",
       "top"
     ]
   },
@@ -9493,24 +9492,10 @@
     "$type": "dimension",
     "$value": "4px",
     "unit": "px",
-    "$modes": {
-      "default": "4",
-      "cds-g0": "4",
-      "cds-g10": "4",
-      "cds-g90": "4",
-      "cds-g100": "4"
-    },
     "original": {
       "$type": "dimension",
       "$value": "4",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },
     "name": "hds-app-side-nav-body-list-item-padding-vertical",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
@@ -9230,6 +9230,77 @@
     ]
   },
   {
+    "key": "{app-side-nav.toggle-button.position.top}",
+    "$type": "dimension",
+    "$value": "15px",
+    "unit": "px",
+    "$modes": {
+      "default": "16px",
+      "cds-g0": "15",
+      "cds-g10": "15",
+      "cds-g90": "15",
+      "cds-g100": "15"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "15",
+      "unit": "px",
+      "$modes": {
+        "default": "{app-side-nav.wrapper.padding.vertical}",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "key": "{app-side-nav.toggle-button.position.top}"
+    },
+    "name": "hds-app-side-nav-toggle-button-position-top",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "position",
+      "top"
+    ]
+  },
+  {
+    "key": "{app-side-nav.toggle-button.height}",
+    "$type": "dimension",
+    "$value": "34px",
+    "unit": "px",
+    "$modes": {
+      "default": "36",
+      "cds-g0": "34",
+      "cds-g10": "34",
+      "cds-g90": "34",
+      "cds-g100": "34"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "34",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "key": "{app-side-nav.toggle-button.height}"
+    },
+    "name": "hds-app-side-nav-toggle-button-height",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "height"
+    ]
+  },
+  {
     "key": "{app-side-nav.body.list.margin-vertical}",
     "$type": "dimension",
     "$value": "16px",
@@ -9420,25 +9491,25 @@
   {
     "key": "{app-side-nav.body.list-item.padding.vertical}",
     "$type": "dimension",
-    "$value": "7px",
+    "$value": "4px",
     "unit": "px",
     "$modes": {
       "default": "4",
-      "cds-g0": "7",
-      "cds-g10": "7",
-      "cds-g90": "7",
-      "cds-g100": "7"
+      "cds-g0": "4",
+      "cds-g10": "4",
+      "cds-g90": "4",
+      "cds-g100": "4"
     },
     "original": {
       "$type": "dimension",
-      "$value": "7",
+      "$value": "4",
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g10.json
@@ -9230,7 +9230,7 @@
     ]
   },
   {
-    "key": "{app-side-nav.toggle-button.position.top}",
+    "key": "{app-side-nav.toggle-button.top}",
     "$type": "dimension",
     "$value": "15px",
     "unit": "px",
@@ -9252,16 +9252,15 @@
         "cds-g90": "15",
         "cds-g100": "15"
       },
-      "key": "{app-side-nav.toggle-button.position.top}"
+      "key": "{app-side-nav.toggle-button.top}"
     },
-    "name": "hds-app-side-nav-toggle-button-position-top",
+    "name": "hds-app-side-nav-toggle-button-top",
     "attributes": {
       "category": "app-side-nav"
     },
     "path": [
       "app-side-nav",
       "toggle-button",
-      "position",
       "top"
     ]
   },
@@ -9493,24 +9492,10 @@
     "$type": "dimension",
     "$value": "4px",
     "unit": "px",
-    "$modes": {
-      "default": "4",
-      "cds-g0": "4",
-      "cds-g10": "4",
-      "cds-g90": "4",
-      "cds-g100": "4"
-    },
     "original": {
       "$type": "dimension",
       "$value": "4",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },
     "name": "hds-app-side-nav-body-list-item-padding-vertical",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
@@ -9230,6 +9230,77 @@
     ]
   },
   {
+    "key": "{app-side-nav.toggle-button.position.top}",
+    "$type": "dimension",
+    "$value": "15px",
+    "unit": "px",
+    "$modes": {
+      "default": "16px",
+      "cds-g0": "15",
+      "cds-g10": "15",
+      "cds-g90": "15",
+      "cds-g100": "15"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "15",
+      "unit": "px",
+      "$modes": {
+        "default": "{app-side-nav.wrapper.padding.vertical}",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "key": "{app-side-nav.toggle-button.position.top}"
+    },
+    "name": "hds-app-side-nav-toggle-button-position-top",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "position",
+      "top"
+    ]
+  },
+  {
+    "key": "{app-side-nav.toggle-button.height}",
+    "$type": "dimension",
+    "$value": "34px",
+    "unit": "px",
+    "$modes": {
+      "default": "36",
+      "cds-g0": "34",
+      "cds-g10": "34",
+      "cds-g90": "34",
+      "cds-g100": "34"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "34",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "key": "{app-side-nav.toggle-button.height}"
+    },
+    "name": "hds-app-side-nav-toggle-button-height",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "height"
+    ]
+  },
+  {
     "key": "{app-side-nav.body.list.margin-vertical}",
     "$type": "dimension",
     "$value": "16px",
@@ -9420,25 +9491,25 @@
   {
     "key": "{app-side-nav.body.list-item.padding.vertical}",
     "$type": "dimension",
-    "$value": "7px",
+    "$value": "4px",
     "unit": "px",
     "$modes": {
       "default": "4",
-      "cds-g0": "7",
-      "cds-g10": "7",
-      "cds-g90": "7",
-      "cds-g100": "7"
+      "cds-g0": "4",
+      "cds-g10": "4",
+      "cds-g90": "4",
+      "cds-g100": "4"
     },
     "original": {
       "$type": "dimension",
-      "$value": "7",
+      "$value": "4",
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g100.json
@@ -9230,7 +9230,7 @@
     ]
   },
   {
-    "key": "{app-side-nav.toggle-button.position.top}",
+    "key": "{app-side-nav.toggle-button.top}",
     "$type": "dimension",
     "$value": "15px",
     "unit": "px",
@@ -9252,16 +9252,15 @@
         "cds-g90": "15",
         "cds-g100": "15"
       },
-      "key": "{app-side-nav.toggle-button.position.top}"
+      "key": "{app-side-nav.toggle-button.top}"
     },
-    "name": "hds-app-side-nav-toggle-button-position-top",
+    "name": "hds-app-side-nav-toggle-button-top",
     "attributes": {
       "category": "app-side-nav"
     },
     "path": [
       "app-side-nav",
       "toggle-button",
-      "position",
       "top"
     ]
   },
@@ -9493,24 +9492,10 @@
     "$type": "dimension",
     "$value": "4px",
     "unit": "px",
-    "$modes": {
-      "default": "4",
-      "cds-g0": "4",
-      "cds-g10": "4",
-      "cds-g90": "4",
-      "cds-g100": "4"
-    },
     "original": {
       "$type": "dimension",
       "$value": "4",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },
     "name": "hds-app-side-nav-body-list-item-padding-vertical",

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
@@ -9230,6 +9230,77 @@
     ]
   },
   {
+    "key": "{app-side-nav.toggle-button.position.top}",
+    "$type": "dimension",
+    "$value": "15px",
+    "unit": "px",
+    "$modes": {
+      "default": "16px",
+      "cds-g0": "15",
+      "cds-g10": "15",
+      "cds-g90": "15",
+      "cds-g100": "15"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "15",
+      "unit": "px",
+      "$modes": {
+        "default": "{app-side-nav.wrapper.padding.vertical}",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "key": "{app-side-nav.toggle-button.position.top}"
+    },
+    "name": "hds-app-side-nav-toggle-button-position-top",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "position",
+      "top"
+    ]
+  },
+  {
+    "key": "{app-side-nav.toggle-button.height}",
+    "$type": "dimension",
+    "$value": "34px",
+    "unit": "px",
+    "$modes": {
+      "default": "36",
+      "cds-g0": "34",
+      "cds-g10": "34",
+      "cds-g90": "34",
+      "cds-g100": "34"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "34",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "key": "{app-side-nav.toggle-button.height}"
+    },
+    "name": "hds-app-side-nav-toggle-button-height",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "height"
+    ]
+  },
+  {
     "key": "{app-side-nav.body.list.margin-vertical}",
     "$type": "dimension",
     "$value": "16px",
@@ -9420,25 +9491,25 @@
   {
     "key": "{app-side-nav.body.list-item.padding.vertical}",
     "$type": "dimension",
-    "$value": "7px",
+    "$value": "4px",
     "unit": "px",
     "$modes": {
       "default": "4",
-      "cds-g0": "7",
-      "cds-g10": "7",
-      "cds-g90": "7",
-      "cds-g100": "7"
+      "cds-g0": "4",
+      "cds-g10": "4",
+      "cds-g90": "4",
+      "cds-g100": "4"
     },
     "original": {
       "$type": "dimension",
-      "$value": "7",
+      "$value": "4",
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },

--- a/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/cds-g90.json
@@ -9230,7 +9230,7 @@
     ]
   },
   {
-    "key": "{app-side-nav.toggle-button.position.top}",
+    "key": "{app-side-nav.toggle-button.top}",
     "$type": "dimension",
     "$value": "15px",
     "unit": "px",
@@ -9252,16 +9252,15 @@
         "cds-g90": "15",
         "cds-g100": "15"
       },
-      "key": "{app-side-nav.toggle-button.position.top}"
+      "key": "{app-side-nav.toggle-button.top}"
     },
-    "name": "hds-app-side-nav-toggle-button-position-top",
+    "name": "hds-app-side-nav-toggle-button-top",
     "attributes": {
       "category": "app-side-nav"
     },
     "path": [
       "app-side-nav",
       "toggle-button",
-      "position",
       "top"
     ]
   },
@@ -9493,24 +9492,10 @@
     "$type": "dimension",
     "$value": "4px",
     "unit": "px",
-    "$modes": {
-      "default": "4",
-      "cds-g0": "4",
-      "cds-g10": "4",
-      "cds-g90": "4",
-      "cds-g100": "4"
-    },
     "original": {
       "$type": "dimension",
       "$value": "4",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },
     "name": "hds-app-side-nav-body-list-item-padding-vertical",

--- a/packages/tokens/dist/docs/products/themed-tokens/default.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/default.json
@@ -9222,6 +9222,77 @@
     ]
   },
   {
+    "key": "{app-side-nav.toggle-button.position.top}",
+    "$type": "dimension",
+    "$value": "16px",
+    "unit": "px",
+    "$modes": {
+      "default": "16px",
+      "cds-g0": "15",
+      "cds-g10": "15",
+      "cds-g90": "15",
+      "cds-g100": "15"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "{app-side-nav.wrapper.padding.vertical}",
+      "unit": "px",
+      "$modes": {
+        "default": "{app-side-nav.wrapper.padding.vertical}",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "key": "{app-side-nav.toggle-button.position.top}"
+    },
+    "name": "hds-app-side-nav-toggle-button-position-top",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "position",
+      "top"
+    ]
+  },
+  {
+    "key": "{app-side-nav.toggle-button.height}",
+    "$type": "dimension",
+    "$value": "36px",
+    "unit": "px",
+    "$modes": {
+      "default": "36",
+      "cds-g0": "34",
+      "cds-g10": "34",
+      "cds-g90": "34",
+      "cds-g100": "34"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "36",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "key": "{app-side-nav.toggle-button.height}"
+    },
+    "name": "hds-app-side-nav-toggle-button-height",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "height"
+    ]
+  },
+  {
     "key": "{app-side-nav.body.list.margin-vertical}",
     "$type": "dimension",
     "$value": "16px",
@@ -9416,10 +9487,10 @@
     "unit": "px",
     "$modes": {
       "default": "4",
-      "cds-g0": "7",
-      "cds-g10": "7",
-      "cds-g90": "7",
-      "cds-g100": "7"
+      "cds-g0": "4",
+      "cds-g10": "4",
+      "cds-g90": "4",
+      "cds-g100": "4"
     },
     "original": {
       "$type": "dimension",
@@ -9427,10 +9498,10 @@
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },

--- a/packages/tokens/dist/docs/products/themed-tokens/default.json
+++ b/packages/tokens/dist/docs/products/themed-tokens/default.json
@@ -9222,7 +9222,7 @@
     ]
   },
   {
-    "key": "{app-side-nav.toggle-button.position.top}",
+    "key": "{app-side-nav.toggle-button.top}",
     "$type": "dimension",
     "$value": "16px",
     "unit": "px",
@@ -9244,16 +9244,15 @@
         "cds-g90": "15",
         "cds-g100": "15"
       },
-      "key": "{app-side-nav.toggle-button.position.top}"
+      "key": "{app-side-nav.toggle-button.top}"
     },
-    "name": "hds-app-side-nav-toggle-button-position-top",
+    "name": "hds-app-side-nav-toggle-button-top",
     "attributes": {
       "category": "app-side-nav"
     },
     "path": [
       "app-side-nav",
       "toggle-button",
-      "position",
       "top"
     ]
   },
@@ -9485,24 +9484,10 @@
     "$type": "dimension",
     "$value": "4px",
     "unit": "px",
-    "$modes": {
-      "default": "4",
-      "cds-g0": "4",
-      "cds-g10": "4",
-      "cds-g90": "4",
-      "cds-g100": "4"
-    },
     "original": {
       "$type": "dimension",
       "$value": "4",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },
     "name": "hds-app-side-nav-body-list-item-padding-vertical",

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -9222,6 +9222,77 @@
     ]
   },
   {
+    "key": "{app-side-nav.toggle-button.position.top}",
+    "$type": "dimension",
+    "$value": "16px",
+    "unit": "px",
+    "$modes": {
+      "default": "16px",
+      "cds-g0": "15",
+      "cds-g10": "15",
+      "cds-g90": "15",
+      "cds-g100": "15"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "{app-side-nav.wrapper.padding.vertical}",
+      "unit": "px",
+      "$modes": {
+        "default": "{app-side-nav.wrapper.padding.vertical}",
+        "cds-g0": "15",
+        "cds-g10": "15",
+        "cds-g90": "15",
+        "cds-g100": "15"
+      },
+      "key": "{app-side-nav.toggle-button.position.top}"
+    },
+    "name": "hds-app-side-nav-toggle-button-position-top",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "position",
+      "top"
+    ]
+  },
+  {
+    "key": "{app-side-nav.toggle-button.height}",
+    "$type": "dimension",
+    "$value": "36px",
+    "unit": "px",
+    "$modes": {
+      "default": "36",
+      "cds-g0": "34",
+      "cds-g10": "34",
+      "cds-g90": "34",
+      "cds-g100": "34"
+    },
+    "original": {
+      "$type": "dimension",
+      "$value": "36",
+      "unit": "px",
+      "$modes": {
+        "default": "36",
+        "cds-g0": "34",
+        "cds-g10": "34",
+        "cds-g90": "34",
+        "cds-g100": "34"
+      },
+      "key": "{app-side-nav.toggle-button.height}"
+    },
+    "name": "hds-app-side-nav-toggle-button-height",
+    "attributes": {
+      "category": "app-side-nav"
+    },
+    "path": [
+      "app-side-nav",
+      "toggle-button",
+      "height"
+    ]
+  },
+  {
     "key": "{app-side-nav.body.list.margin-vertical}",
     "$type": "dimension",
     "$value": "16px",
@@ -9416,10 +9487,10 @@
     "unit": "px",
     "$modes": {
       "default": "4",
-      "cds-g0": "7",
-      "cds-g10": "7",
-      "cds-g90": "7",
-      "cds-g100": "7"
+      "cds-g0": "4",
+      "cds-g10": "4",
+      "cds-g90": "4",
+      "cds-g100": "4"
     },
     "original": {
       "$type": "dimension",
@@ -9427,10 +9498,10 @@
       "unit": "px",
       "$modes": {
         "default": "4",
-        "cds-g0": "7",
-        "cds-g10": "7",
-        "cds-g90": "7",
-        "cds-g100": "7"
+        "cds-g0": "4",
+        "cds-g10": "4",
+        "cds-g90": "4",
+        "cds-g100": "4"
       },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },

--- a/packages/tokens/dist/docs/products/tokens.json
+++ b/packages/tokens/dist/docs/products/tokens.json
@@ -9222,7 +9222,7 @@
     ]
   },
   {
-    "key": "{app-side-nav.toggle-button.position.top}",
+    "key": "{app-side-nav.toggle-button.top}",
     "$type": "dimension",
     "$value": "16px",
     "unit": "px",
@@ -9244,16 +9244,15 @@
         "cds-g90": "15",
         "cds-g100": "15"
       },
-      "key": "{app-side-nav.toggle-button.position.top}"
+      "key": "{app-side-nav.toggle-button.top}"
     },
-    "name": "hds-app-side-nav-toggle-button-position-top",
+    "name": "hds-app-side-nav-toggle-button-top",
     "attributes": {
       "category": "app-side-nav"
     },
     "path": [
       "app-side-nav",
       "toggle-button",
-      "position",
       "top"
     ]
   },
@@ -9485,24 +9484,10 @@
     "$type": "dimension",
     "$value": "4px",
     "unit": "px",
-    "$modes": {
-      "default": "4",
-      "cds-g0": "4",
-      "cds-g10": "4",
-      "cds-g90": "4",
-      "cds-g100": "4"
-    },
     "original": {
       "$type": "dimension",
       "$value": "4",
       "unit": "px",
-      "$modes": {
-        "default": "4",
-        "cds-g0": "4",
-        "cds-g10": "4",
-        "cds-g90": "4",
-        "cds-g100": "4"
-      },
       "key": "{app-side-nav.body.list-item.padding.vertical}"
     },
     "name": "hds-app-side-nav-body-list-item-padding-vertical",

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -263,6 +263,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-foreground-color-faint
   );
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
+  --hds-app-side-nav-toggle-button-height: 36px;
+  --hds-app-side-nav-toggle-button-position-top: var(
+    --hds-app-side-nav-wrapper-padding-vertical
+  );
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
   --hds-app-side-nav-wrapper-surface-color: var(--hds-surface-color-faint);
   --hds-badge-border-radius: var(--hds-border-radius-small);
@@ -1567,7 +1571,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1589,6 +1593,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2455,7 +2461,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2477,6 +2483,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3373,7 +3381,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3395,6 +3403,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4249,7 +4259,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -4271,6 +4281,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -5144,7 +5156,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -5166,6 +5178,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #f4f4f4;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -6019,7 +6033,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -6041,6 +6055,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #262626;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -246,7 +246,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-app-side-nav-body-list-item-margin-top: 2px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 8px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: var(
     --hds-surface-color-interactive-active
   );
@@ -264,7 +263,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
   --hds-app-side-nav-toggle-button-height: 36px;
-  --hds-app-side-nav-toggle-button-position-top: var(
+  --hds-app-side-nav-toggle-button-top: var(
     --hds-app-side-nav-wrapper-padding-vertical
   );
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
@@ -1571,7 +1570,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1594,7 +1592,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2461,7 +2459,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2484,7 +2481,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3381,7 +3378,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3404,7 +3400,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4259,7 +4255,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -4282,7 +4277,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -5156,7 +5151,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -5179,7 +5173,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #f4f4f4;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -6033,7 +6027,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -6056,7 +6049,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #262626;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -6946,6 +6939,7 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     --hds-border-radius-small
   );
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(
     --hds-app-side-nav-body-list-item-padding-horizontal

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
@@ -251,6 +251,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-foreground-color-faint
   );
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
+  --hds-app-side-nav-toggle-button-height: 36px;
+  --hds-app-side-nav-toggle-button-position-top: var(
+    --hds-app-side-nav-wrapper-padding-vertical
+  );
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
   --hds-app-side-nav-wrapper-surface-color: var(--hds-surface-color-faint);
   --hds-badge-border-radius: var(--hds-border-radius-small);
@@ -1555,7 +1559,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1577,6 +1581,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2443,7 +2449,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2465,6 +2471,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3360,7 +3368,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3382,6 +3390,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4235,7 +4245,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -4257,6 +4267,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors--migration/tokens.css
@@ -234,7 +234,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-app-side-nav-body-list-item-margin-top: 2px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 8px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: var(
     --hds-surface-color-interactive-active
   );
@@ -252,7 +251,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
   --hds-app-side-nav-toggle-button-height: 36px;
-  --hds-app-side-nav-toggle-button-position-top: var(
+  --hds-app-side-nav-toggle-button-top: var(
     --hds-app-side-nav-wrapper-padding-vertical
   );
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
@@ -1559,7 +1558,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1582,7 +1580,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2449,7 +2447,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2472,7 +2469,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3368,7 +3365,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3391,7 +3387,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4245,7 +4241,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -4268,7 +4263,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -5154,6 +5149,7 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     --hds-border-radius-small
   );
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(
     --hds-app-side-nav-body-list-item-padding-horizontal

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
@@ -173,7 +173,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -195,6 +195,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -1049,7 +1051,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1071,6 +1073,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -1937,7 +1941,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1959,6 +1963,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2854,7 +2860,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -2876,6 +2882,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3729,7 +3737,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3751,6 +3759,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-css-selectors/tokens.css
@@ -173,7 +173,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -196,7 +195,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -1051,7 +1050,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1074,7 +1072,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -1941,7 +1939,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1964,7 +1961,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2860,7 +2857,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -2883,7 +2879,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3737,7 +3733,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3760,7 +3755,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4645,6 +4640,7 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     --hds-border-radius-small
   );
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(
     --hds-app-side-nav-body-list-item-padding-horizontal

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/common-tokens.css
@@ -54,6 +54,7 @@
   --hds-app-header-home-link-logo-size: 28px;
   --hds-app-side-nav-body-list-item-border-radius: var(--hds-border-radius-small);
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(--hds-app-side-nav-body-list-item-padding-horizontal);
   --hds-app-side-nav-toggle-button-border-radius: var(--hds-border-radius-small);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
@@ -119,13 +119,15 @@
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(141, 141, 141, 0.5);
   --hds-app-side-nav-body-list-item-surface-color-hover: rgba(141, 141, 141, 0.12);
   --hds-app-side-nav-body-list-item-surface-color-selected: rgba(141, 141, 141, 0.2);
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g0/themed-tokens.css
@@ -119,7 +119,6 @@
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(141, 141, 141, 0.5);
   --hds-app-side-nav-body-list-item-surface-color-hover: rgba(141, 141, 141, 0.12);
   --hds-app-side-nav-body-list-item-surface-color-selected: rgba(141, 141, 141, 0.2);
@@ -127,7 +126,7 @@
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/common-tokens.css
@@ -54,6 +54,7 @@
   --hds-app-header-home-link-logo-size: 28px;
   --hds-app-side-nav-body-list-item-border-radius: var(--hds-border-radius-small);
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(--hds-app-side-nav-body-list-item-padding-horizontal);
   --hds-app-side-nav-toggle-button-border-radius: var(--hds-border-radius-small);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
@@ -119,13 +119,15 @@
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(141, 141, 141, 0.5);
   --hds-app-side-nav-body-list-item-surface-color-hover: rgba(141, 141, 141, 0.12);
   --hds-app-side-nav-body-list-item-surface-color-selected: rgba(141, 141, 141, 0.2);
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #f4f4f4;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g10/themed-tokens.css
@@ -119,7 +119,6 @@
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(141, 141, 141, 0.5);
   --hds-app-side-nav-body-list-item-surface-color-hover: rgba(141, 141, 141, 0.12);
   --hds-app-side-nav-body-list-item-surface-color-selected: rgba(141, 141, 141, 0.2);
@@ -127,7 +126,7 @@
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #f4f4f4;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/common-tokens.css
@@ -54,6 +54,7 @@
   --hds-app-header-home-link-logo-size: 28px;
   --hds-app-side-nav-body-list-item-border-radius: var(--hds-border-radius-small);
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(--hds-app-side-nav-body-list-item-padding-horizontal);
   --hds-app-side-nav-toggle-button-border-radius: var(--hds-border-radius-small);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
@@ -119,13 +119,15 @@
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(141, 141, 141, 0.4);
   --hds-app-side-nav-body-list-item-surface-color-hover: rgba(141, 141, 141, 0.16);
   --hds-app-side-nav-body-list-item-surface-color-selected: rgba(141, 141, 141, 0.24);
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g100/themed-tokens.css
@@ -119,7 +119,6 @@
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(141, 141, 141, 0.4);
   --hds-app-side-nav-body-list-item-surface-color-hover: rgba(141, 141, 141, 0.16);
   --hds-app-side-nav-body-list-item-surface-color-selected: rgba(141, 141, 141, 0.24);
@@ -127,7 +126,7 @@
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/common-tokens.css
@@ -54,6 +54,7 @@
   --hds-app-header-home-link-logo-size: 28px;
   --hds-app-side-nav-body-list-item-border-radius: var(--hds-border-radius-small);
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(--hds-app-side-nav-body-list-item-padding-horizontal);
   --hds-app-side-nav-toggle-button-border-radius: var(--hds-border-radius-small);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
@@ -119,13 +119,15 @@
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(141, 141, 141, 0.4);
   --hds-app-side-nav-body-list-item-surface-color-hover: rgba(141, 141, 141, 0.16);
   --hds-app-side-nav-body-list-item-surface-color-selected: rgba(141, 141, 141, 0.24);
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #262626;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/cds-g90/themed-tokens.css
@@ -119,7 +119,6 @@
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(141, 141, 141, 0.4);
   --hds-app-side-nav-body-list-item-surface-color-hover: rgba(141, 141, 141, 0.16);
   --hds-app-side-nav-body-list-item-surface-color-selected: rgba(141, 141, 141, 0.24);
@@ -127,7 +126,7 @@
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #262626;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/common-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/common-tokens.css
@@ -54,6 +54,7 @@
   --hds-app-header-home-link-logo-size: 28px;
   --hds-app-side-nav-body-list-item-border-radius: var(--hds-border-radius-small);
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(--hds-app-side-nav-body-list-item-padding-horizontal);
   --hds-app-side-nav-toggle-button-border-radius: var(--hds-border-radius-small);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
@@ -126,6 +126,8 @@
   --hds-app-side-nav-body-list-item-typography-font-weight: var(--hds-typography-font-weight-medium);
   --hds-app-side-nav-body-list-title-foreground-color: var(--hds-foreground-color-faint);
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
+  --hds-app-side-nav-toggle-button-height: 36px;
+  --hds-app-side-nav-toggle-button-position-top: var(--hds-app-side-nav-wrapper-padding-vertical);
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
   --hds-app-side-nav-wrapper-surface-color: var(--hds-surface-color-faint);
   --hds-badge-border-radius: var(--hds-border-radius-small);

--- a/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-root-selector/default/themed-tokens.css
@@ -119,7 +119,6 @@
   --hds-app-side-nav-body-list-item-indicator-surface-color: var(--hds-foreground-color-action);
   --hds-app-side-nav-body-list-item-margin-top: 2px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 8px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: var(--hds-surface-color-interactive-active);
   --hds-app-side-nav-body-list-item-surface-color-hover: var(--hds-surface-color-interactive-hover);
   --hds-app-side-nav-body-list-item-surface-color-selected: var(--hds-surface-color-strong);
@@ -127,7 +126,7 @@
   --hds-app-side-nav-body-list-title-foreground-color: var(--hds-foreground-color-faint);
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
   --hds-app-side-nav-toggle-button-height: 36px;
-  --hds-app-side-nav-toggle-button-position-top: var(--hds-app-side-nav-wrapper-padding-vertical);
+  --hds-app-side-nav-toggle-button-top: var(--hds-app-side-nav-wrapper-padding-vertical);
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
   --hds-app-side-nav-wrapper-surface-color: var(--hds-surface-color-faint);
   --hds-badge-border-radius: var(--hds-border-radius-small);

--- a/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
@@ -222,6 +222,10 @@
       --hds-foreground-color-faint
     );
     --hds-app-side-nav-body-list-title-padding-vertical: 9px;
+    --hds-app-side-nav-toggle-button-height: 36px;
+    --hds-app-side-nav-toggle-button-position-top: var(
+      --hds-app-side-nav-wrapper-padding-vertical
+    );
     --hds-app-side-nav-wrapper-padding-horizontal: 16px;
     --hds-app-side-nav-wrapper-surface-color: var(--hds-surface-color-faint);
     --hds-badge-border-radius: var(--hds-border-radius-small);
@@ -1574,7 +1578,7 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1596,6 +1600,8 @@
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2464,7 +2470,7 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2486,6 +2492,8 @@
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3384,7 +3392,7 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -3406,6 +3414,8 @@
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4274,7 +4284,7 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -4296,6 +4306,8 @@
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #f4f4f4;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -5164,7 +5176,7 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -5186,6 +5198,8 @@
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #262626;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -6084,7 +6098,7 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -6106,6 +6120,8 @@
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
+++ b/packages/tokens/dist/products/css/themed-tokens/with-scss-mixins/tokens.css
@@ -205,7 +205,6 @@
     );
     --hds-app-side-nav-body-list-item-margin-top: 2px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 8px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: var(
       --hds-surface-color-interactive-active
     );
@@ -223,7 +222,7 @@
     );
     --hds-app-side-nav-body-list-title-padding-vertical: 9px;
     --hds-app-side-nav-toggle-button-height: 36px;
-    --hds-app-side-nav-toggle-button-position-top: var(
+    --hds-app-side-nav-toggle-button-top: var(
       --hds-app-side-nav-wrapper-padding-vertical
     );
     --hds-app-side-nav-wrapper-padding-horizontal: 16px;
@@ -1578,7 +1577,6 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1601,7 +1599,7 @@
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2470,7 +2468,6 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2493,7 +2490,7 @@
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3392,7 +3389,6 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -3415,7 +3411,7 @@
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4284,7 +4280,6 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -4307,7 +4302,7 @@
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #f4f4f4;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -5176,7 +5171,6 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -5199,7 +5193,7 @@
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #262626;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -6098,7 +6092,6 @@
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -6121,7 +6114,7 @@
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -7011,6 +7004,7 @@
       --hds-border-radius-small
     );
     --hds-app-side-nav-body-list-item-content-gap: 8px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-margin-vertical: 16px;
     --hds-app-side-nav-body-list-title-padding-horizontal: var(
       --hds-app-side-nav-body-list-item-padding-horizontal

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -280,6 +280,8 @@
   --hds-app-side-nav-wrapper-padding-horizontal-minimized: 8px;
   --hds-app-side-nav-wrapper-padding-vertical-minimized: 22px;
   --hds-app-side-nav-toggle-button-border-radius: 5px;
+  --hds-app-side-nav-toggle-button-position-top: 16px;
+  --hds-app-side-nav-toggle-button-height: 36px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
   --hds-app-side-nav-body-list-title-padding-horizontal: 8px;

--- a/packages/tokens/dist/products/css/tokens.css
+++ b/packages/tokens/dist/products/css/tokens.css
@@ -280,7 +280,7 @@
   --hds-app-side-nav-wrapper-padding-horizontal-minimized: 8px;
   --hds-app-side-nav-wrapper-padding-vertical-minimized: 22px;
   --hds-app-side-nav-toggle-button-border-radius: 5px;
-  --hds-app-side-nav-toggle-button-position-top: 16px;
+  --hds-app-side-nav-toggle-button-top: 16px;
   --hds-app-side-nav-toggle-button-height: 36px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;

--- a/packages/tokens/src/products/shared/app-side-nav.json
+++ b/packages/tokens/src/products/shared/app-side-nav.json
@@ -62,6 +62,33 @@
           "$type": "dimension",
           "$value": "{border.radius.small}"
         }
+      },
+      "position": {
+        "top": {
+          "$type": "dimension",
+          "$value": "{app-side-nav.wrapper.padding.vertical}",
+          "unit": "px",
+          "$modes": {
+            "default": "{app-side-nav.wrapper.padding.vertical}",
+            "cds-g0": "15",
+            "cds-g10": "15",
+            "cds-g90": "15",
+            "cds-g100": "15"
+          }
+        }
+      },
+      "height": {
+        "$type": "dimension",
+        "$value": "36",
+        "unit": "px",
+        "$modes": {
+          "default": "36",
+          "cds-g0": "34",
+          "cds-g10": "34",
+          "cds-g90": "34",
+          "cds-g100": "34"
+        }
+
       }
     },
     "body": {
@@ -137,10 +164,10 @@
             "unit": "px",
             "$modes": {
               "default": "4",
-              "cds-g0": "7",
-              "cds-g10": "7",
-              "cds-g90": "7",
-              "cds-g100": "7"
+              "cds-g0": "4",
+              "cds-g10": "4",
+              "cds-g90": "4",
+              "cds-g100": "4"
             }
           }
         },

--- a/packages/tokens/src/products/shared/app-side-nav.json
+++ b/packages/tokens/src/products/shared/app-side-nav.json
@@ -63,18 +63,16 @@
           "$value": "{border.radius.small}"
         }
       },
-      "position": {
-        "top": {
-          "$type": "dimension",
-          "$value": "{app-side-nav.wrapper.padding.vertical}",
-          "unit": "px",
-          "$modes": {
-            "default": "{app-side-nav.wrapper.padding.vertical}",
-            "cds-g0": "15",
-            "cds-g10": "15",
-            "cds-g90": "15",
-            "cds-g100": "15"
-          }
+      "top": {
+        "$type": "dimension",
+        "$value": "{app-side-nav.wrapper.padding.vertical}",
+        "unit": "px",
+        "$modes": {
+          "default": "{app-side-nav.wrapper.padding.vertical}",
+          "cds-g0": "15",
+          "cds-g10": "15",
+          "cds-g90": "15",
+          "cds-g100": "15"
         }
       },
       "height": {
@@ -88,7 +86,6 @@
           "cds-g90": "34",
           "cds-g100": "34"
         }
-
       }
     },
     "body": {
@@ -161,14 +158,7 @@
           "vertical": {
             "$type": "dimension",
             "$value": "4",
-            "unit": "px",
-            "$modes": {
-              "default": "4",
-              "cds-g0": "4",
-              "cds-g10": "4",
-              "cds-g90": "4",
-              "cds-g100": "4"
-            }
+            "unit": "px"
           }
         },
         "margin": {

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -2453,14 +2453,14 @@
  */
 .hds-app-side-nav__toggle-button {
   position: absolute;
-  top: var(--hds-app-side-nav-wrapper-padding-vertical);
+  top: var(--hds-app-side-nav-toggle-button-position-top);
   left: calc(var(--hds-app-side-nav-wrapper-border-width) * -1);
   z-index: 1;
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
   width: var(--hds-var-app-side-nav-toggle-button-width);
-  height: 36px;
+  height: var(--hds-app-side-nav-toggle-button-height);
   padding: 0 4px;
   color: var(--hds-foreground-color-primary);
   background: none;

--- a/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components-common.css
@@ -2453,7 +2453,7 @@
  */
 .hds-app-side-nav__toggle-button {
   position: absolute;
-  top: var(--hds-app-side-nav-toggle-button-position-top);
+  top: var(--hds-app-side-nav-toggle-button-top);
   left: calc(var(--hds-app-side-nav-wrapper-border-width) * -1);
   z-index: 1;
   display: flex;

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -284,6 +284,8 @@
   --hds-app-side-nav-wrapper-padding-horizontal-minimized: 8px;
   --hds-app-side-nav-wrapper-padding-vertical-minimized: 22px;
   --hds-app-side-nav-toggle-button-border-radius: 5px;
+  --hds-app-side-nav-toggle-button-position-top: 16px;
+  --hds-app-side-nav-toggle-button-height: 36px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
   --hds-app-side-nav-body-list-title-padding-horizontal: 8px;
@@ -3502,14 +3504,14 @@
  */
 .hds-app-side-nav__toggle-button {
   position: absolute;
-  top: var(--hds-app-side-nav-wrapper-padding-vertical);
+  top: var(--hds-app-side-nav-toggle-button-position-top);
   left: calc(var(--hds-app-side-nav-wrapper-border-width) * -1);
   z-index: 1;
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
   width: var(--hds-var-app-side-nav-toggle-button-width);
-  height: 36px;
+  height: var(--hds-app-side-nav-toggle-button-height);
   padding: 0 4px;
   color: var(--hds-foreground-color-primary);
   background: none;

--- a/showcase/public/assets/styles/@hashicorp/design-system-components.css
+++ b/showcase/public/assets/styles/@hashicorp/design-system-components.css
@@ -284,7 +284,7 @@
   --hds-app-side-nav-wrapper-padding-horizontal-minimized: 8px;
   --hds-app-side-nav-wrapper-padding-vertical-minimized: 22px;
   --hds-app-side-nav-toggle-button-border-radius: 5px;
-  --hds-app-side-nav-toggle-button-position-top: 16px;
+  --hds-app-side-nav-toggle-button-top: 16px;
   --hds-app-side-nav-toggle-button-height: 36px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
@@ -3504,7 +3504,7 @@
  */
 .hds-app-side-nav__toggle-button {
   position: absolute;
-  top: var(--hds-app-side-nav-toggle-button-position-top);
+  top: var(--hds-app-side-nav-toggle-button-top);
   left: calc(var(--hds-app-side-nav-wrapper-border-width) * -1);
   z-index: 1;
   display: flex;

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -263,6 +263,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-foreground-color-faint
   );
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
+  --hds-app-side-nav-toggle-button-height: 36px;
+  --hds-app-side-nav-toggle-button-position-top: var(
+    --hds-app-side-nav-wrapper-padding-vertical
+  );
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
   --hds-app-side-nav-wrapper-surface-color: var(--hds-surface-color-faint);
   --hds-badge-border-radius: var(--hds-border-radius-small);
@@ -1567,7 +1571,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1589,6 +1593,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2455,7 +2461,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2477,6 +2483,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3373,7 +3381,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3395,6 +3403,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4249,7 +4259,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -4271,6 +4281,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -5144,7 +5156,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -5166,6 +5178,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #f4f4f4;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -6019,7 +6033,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -6041,6 +6055,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #262626;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--advanced/tokens.css
@@ -246,7 +246,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-app-side-nav-body-list-item-margin-top: 2px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 8px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: var(
     --hds-surface-color-interactive-active
   );
@@ -264,7 +263,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
   --hds-app-side-nav-toggle-button-height: 36px;
-  --hds-app-side-nav-toggle-button-position-top: var(
+  --hds-app-side-nav-toggle-button-top: var(
     --hds-app-side-nav-wrapper-padding-vertical
   );
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
@@ -1571,7 +1570,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1594,7 +1592,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2461,7 +2459,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2484,7 +2481,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3381,7 +3378,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3404,7 +3400,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4259,7 +4255,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -4282,7 +4277,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -5156,7 +5151,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -5179,7 +5173,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #f4f4f4;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -6033,7 +6027,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -6056,7 +6049,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #262626;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -6946,6 +6939,7 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     --hds-border-radius-small
   );
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(
     --hds-app-side-nav-body-list-item-padding-horizontal

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
@@ -251,6 +251,10 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-foreground-color-faint
   );
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
+  --hds-app-side-nav-toggle-button-height: 36px;
+  --hds-app-side-nav-toggle-button-position-top: var(
+    --hds-app-side-nav-wrapper-padding-vertical
+  );
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
   --hds-app-side-nav-wrapper-surface-color: var(--hds-surface-color-faint);
   --hds-badge-border-radius: var(--hds-border-radius-small);
@@ -1555,7 +1559,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1577,6 +1581,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2443,7 +2449,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2465,6 +2471,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3360,7 +3368,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3382,6 +3390,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4235,7 +4245,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -4257,6 +4267,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors--migration/tokens.css
@@ -234,7 +234,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-app-side-nav-body-list-item-margin-top: 2px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 8px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: var(
     --hds-surface-color-interactive-active
   );
@@ -252,7 +251,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   );
   --hds-app-side-nav-body-list-title-padding-vertical: 9px;
   --hds-app-side-nav-toggle-button-height: 36px;
-  --hds-app-side-nav-toggle-button-position-top: var(
+  --hds-app-side-nav-toggle-button-top: var(
     --hds-app-side-nav-wrapper-padding-vertical
   );
   --hds-app-side-nav-wrapper-padding-horizontal: 16px;
@@ -1559,7 +1558,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1582,7 +1580,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2449,7 +2447,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -2472,7 +2469,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3368,7 +3365,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3391,7 +3387,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4245,7 +4241,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -4268,7 +4263,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -5154,6 +5149,7 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     --hds-border-radius-small
   );
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(
     --hds-app-side-nav-body-list-item-padding-horizontal

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
@@ -173,7 +173,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -195,6 +195,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -1049,7 +1051,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1071,6 +1073,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -1937,7 +1941,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1959,6 +1963,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-typography-font-weight: 600;
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+    --hds-app-side-nav-toggle-button-height: 34px;
+    --hds-app-side-nav-toggle-button-position-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2854,7 +2860,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -2876,6 +2882,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3729,7 +3737,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 7px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3751,6 +3759,8 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-typography-font-weight: 600;
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
+  --hds-app-side-nav-toggle-button-height: 34px;
+  --hds-app-side-nav-toggle-button-position-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);

--- a/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
+++ b/showcase/public/assets/styles/@hashicorp/themed-tokens/with-css-selectors/tokens.css
@@ -173,7 +173,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -196,7 +195,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -1051,7 +1050,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1074,7 +1072,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #161616;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #ffffff;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -1941,7 +1939,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
     --hds-app-side-nav-body-list-item-margin-top: 0px;
     --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-    --hds-app-side-nav-body-list-item-padding-vertical: 4px;
     --hds-app-side-nav-body-list-item-surface-color-active: rgba(
       141,
       141,
@@ -1964,7 +1961,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
     --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
     --hds-app-side-nav-body-list-title-padding-vertical: 7px;
     --hds-app-side-nav-toggle-button-height: 34px;
-    --hds-app-side-nav-toggle-button-position-top: 15px;
+    --hds-app-side-nav-toggle-button-top: 15px;
     --hds-app-side-nav-wrapper-padding-horizontal: 0px;
     --hds-app-side-nav-wrapper-surface-color: #161616;
     --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -2860,7 +2857,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #0f62fe;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -2883,7 +2879,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #161616;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #ffffff;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -3737,7 +3733,6 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-item-indicator-surface-color: #4589ff;
   --hds-app-side-nav-body-list-item-margin-top: 0px;
   --hds-app-side-nav-body-list-item-padding-horizontal: 16px;
-  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-item-surface-color-active: rgba(
     141,
     141,
@@ -3760,7 +3755,7 @@ scoped to its corresponding `:root`/`.hds-theme-*`/`.hds-mode-*` selector.
   --hds-app-side-nav-body-list-title-foreground-color: #f4f4f4;
   --hds-app-side-nav-body-list-title-padding-vertical: 7px;
   --hds-app-side-nav-toggle-button-height: 34px;
-  --hds-app-side-nav-toggle-button-position-top: 15px;
+  --hds-app-side-nav-toggle-button-top: 15px;
   --hds-app-side-nav-wrapper-padding-horizontal: 0px;
   --hds-app-side-nav-wrapper-surface-color: #161616;
   --hds-badge-border-radius: var(--hds-border-radius-rounded);
@@ -4645,6 +4640,7 @@ we redeclare each "computed" variable in every theme scope where its "source" va
     --hds-border-radius-small
   );
   --hds-app-side-nav-body-list-item-content-gap: 8px;
+  --hds-app-side-nav-body-list-item-padding-vertical: 4px;
   --hds-app-side-nav-body-list-margin-vertical: 16px;
   --hds-app-side-nav-body-list-title-padding-horizontal: var(
     --hds-app-side-nav-body-list-item-padding-horizontal


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge, changes will be cherry picked into relevant branches after approval

### :pushpin: Summary

If merged, this PR would fix some alignment issues in the carbonized `AppSideNav` component with the list items and collapse toggle button. In alignment with the Figma designs, all list items (titles and links) should have a height of `36px` in HDS, and a height of `32px` in Carbon. During Carbonization, a token `var(--hds-app-side-nav-body-list-item-height)` was introduced for this, which sets a `min-height: 36px` in HDS and `min-height: 32px` in Carbon. 

In HDS, both `hds-app-side-nav__list-title` and `hds-app-side-nav__list-item-link` respect the `min-height: 36px` constraint. It's aligned with the toggle button, which also has `height: 36px`. 

In Carbon, `hds-app-side-nav__list-title` respects `min-height: 32px`, but `hds-app-side-nav__list-item-link` ends up with a height of `33.99px`. Additionally, the `height` of the toggle button remains `36px`, since it wasn't updated during migration. The inconsistent list item link and toggle button heights create two visual misalignments that can be seen in the screenshots section. 

I was advised to ideally avoid touching the styling of the app side nav body, but, after syncing with Jory, we decided it was best to fix both misalignments, as they are both quite noticeable to consumers. I tried to avoid any changes that could impact text styling and the default `AppSideNav`, so I settled on the following approach to keep the fix as simple and contained as possible
- The value of `var(--hds-app-side-nav-body-list-item-padding-vertical)` was decreased to `4px` from `7px` for the `cds` themes (which matches the original HDS default)
- The height of the `hds-app-side-nav__list-item-link` now comes out to `27.99px`, which allows `min-height: 32px` to kick in, keeping all app side nav list items consistently `32px` in height.

For the toggle button fixes, `top` was set to `15px` and `height` to `34px`. I tried to visualize why in the image below:
<img width="884" height="211" alt="Screenshot 2026-09-04 at 4 36 45 PM" src="https://github.com/user-attachments/assets/590d4e78-b1de-442b-b9a5-9375e9997479" />

Additionally, the following tokens were added to help with theming:
- `--hds-app-side-nav-toggle-button-height`: default value of `36px`, `cds` theme value of `34px`
- `--hds-app-side-nav-toggle-button-position-top`: default value of `16px`, `cds` theme value of `15px`

Apologies for the long PR description, I wanted to lay out as much of my process/reasoning as possible, since I'm still new to the Carbonization initiative. Let me know if there is anything I missed in my approach, and I'd love as much feedback as possible!

### :camera_flash: Screenshots

In Atlas:
<img width="738" height="422" alt="Screenshot 2026-09-04 at 2 02 38 PM" src="https://github.com/user-attachments/assets/ac71ebcf-4091-465e-ad23-d1f6fbd24823" />

In frameless example:
<img width="724" height="163" alt="Screenshot 2026-09-04 at 2 08 20 PM" src="https://github.com/user-attachments/assets/847e6fed-38b1-4384-a346-219bdbf3d66c" />

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6615](https://hashicorp.atlassian.net/browse/HDS-6615)
Figma file: [Jory's exploration of the issue](https://www.figma.com/design/GWMDKHuGr98DFxSptH6vgj/-LJ--Token-Migration?node-id=111661-9535&t=IiMIqzocj0aeNdlF-4)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6615]: https://hashicorp.atlassian.net/browse/HDS-6615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ