### PR TITLE
`Form::KeyValueInputs`: Remove unused `ariaLabel` arg

### DIFF
--- a/.changeset/tidy-towns-divide.md
+++ b/.changeset/tidy-towns-divide.md
@@ -1,0 +1,7 @@
+---
+"@hashicorp/design-system-components": patch
+---
+
+<!-- START components/form/key-value-inputs -->
+`Form::KeyValueInputs` - Remove unused `@ariaLabel` arg from `[F].AddRowButton` contextual component
+<!-- END -->

--- a/.changeset/tidy-towns-divide.md
+++ b/.changeset/tidy-towns-divide.md
@@ -3,5 +3,5 @@
 ---
 
 <!-- START components/form/key-value-inputs -->
-`Form::KeyValueInputs` - Remove unused `@ariaLabel` arg from `[F].AddRowButton` contextual component
+`Form::KeyValueInputs` - Removed unused `@ariaLabel` argument from `[F].AddRowButton` contextual component
 <!-- END -->

--- a/packages/components/component-catalog.json
+++ b/packages/components/component-catalog.json
@@ -6835,11 +6835,6 @@
       "element": "HTMLAnchorElement | HTMLButtonElement",
       "args": [
         {
-          "name": "ariaLabel",
-          "type": "string",
-          "required": false
-        },
-        {
           "name": "onClick",
           "type": "() => void",
           "required": false

--- a/packages/components/src/components/hds/form/key-value-inputs/add-row-button.gts
+++ b/packages/components/src/components/hds/form/key-value-inputs/add-row-button.gts
@@ -15,7 +15,6 @@ import type { HdsButtonSignature } from '../../button/index.gts';
 
 export interface HdsFormKeyValueInputsAddRowButtonSignature {
   Args: {
-    ariaLabel?: string;
     onClick?: () => void;
     text?: HdsButtonSignature['Args']['text'];
   };


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge until further notice

### :pushpin: Summary

If merged, this PR would remove an optional `ariaLabel` arg from the `[F].AddRowButton` signature that is unused within the component template. `[F].AddRowButton` wraps the `HdsButton` component and passes in a `@text` value (with a default value of "Add row"), which gives the button its accessible name.  The component also already provides an `aria-description` giving longer context to screen readers. Thus, the `ariaLabel` arg is not necessary and should be removed. 

The arg is not used within any tests or the showcase so no changes were needed there. It's also not documented on the website, so no changes were made there either.

This would not be a breaking change, as the arg is not used in any [consumer repos](https://github.com/search?q=org%3Ahashicorp+F.AddRowButton&type=code&p=1) currently.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6640](https://hashicorp.atlassian.net/browse/HDS-6640)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6640]: https://hashicorp.atlassian.net/browse/HDS-6640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ