### PR TITLE
[Project Solar / Phase 1 / Follow-up] Fix for `hds-icon-registry` where `DOMParser` is not available in non-browser environments

### DIFF
--- a/packages/components/src/services/hds-icon-registry.ts
+++ b/packages/components/src/services/hds-icon-registry.ts
@@ -33,8 +33,12 @@ export interface HdsIconDefinition {
 // re-export the ROOT_ID for use in tests
 export { ROOT_ID };
 
+// notice: in non-browser environments (eg. server-side rendering via FastBoot) some or all
+// of these globals are missing, so all the DOM-related logic below has to be skipped
 const HAS_DOM =
-  typeof window !== 'undefined' && typeof document !== 'undefined';
+  typeof window !== 'undefined' &&
+  typeof document !== 'undefined' &&
+  typeof DOMParser !== 'undefined';
 
 // important: if you update this function, update the identical one in `packages/flight-icons/scripts/build-parts/generateBundleSymbolJS.ts` as well (and vice versa)
 export function makeDomSafeId(value: string): string {
@@ -56,7 +60,7 @@ const MAX_CONCURRENT_LOADS = Math.min(
   )
 );
 
-const PARSER = new DOMParser();
+const PARSER = HAS_DOM ? new DOMParser() : null;
 
 export default class HdsIconRegistryService extends Service {
   private _entries = new TrackedMap<string, HdsIconRegistryEntry>();
@@ -261,7 +265,7 @@ export default class HdsIconRegistryService extends Service {
 
       const root = this._getSpriteRoot();
 
-      if (root === null || this._pendingByKey.size === 0) {
+      if (root === null || PARSER === null || this._pendingByKey.size === 0) {
         return;
       }
 


### PR DESCRIPTION
### :pushpin: Summary

I was seeing this error in the CLI when running the `website` application, related to Fastboot. It's quite noisy and risks to hide other actual errors, so I've decided to fix it myself.

<img width="1128" height="731" alt="screenshot_1545" src="https://github.com/user-attachments/assets/7653752e-9cc2-4727-8895-27cab2d6a6af" />

### :hammer_and_wrench: Detailed description

In this PR I have:
- added a check on the `HAS_DOM` variable to include the existence of `DOMParser`
- made the `PARSER` variable return `null` if `HAS_DOM` is false
- added a check to the `_scheduleFlush` (needed by typescript for type safety)

Note: fixed with the help of Copilot (Code Opus 5); here's the dump of the thinking:

> `HdsIconRegistry` instantiated `new DOMParser()` at module scope, so the mere act of importing the service threw `ReferenceError: DOMParser is not defined` in FastBoot — before any component logic ran. The fix adds `typeof DOMParser !== 'undefined'` to the existing `HAS_DOM` feature detection and makes the parser conditional (`HAS_DOM ? new DOMParser() : null`), so importing the module is now side-effect free. In a DOM-less environment the existing `HAS_DOM` guards already short-circuit every load/inject path, so no icons are queued server-side and they hydrate normally in the browser.
>
> One detail: the added `PARSER === null` check in `_scheduleFlush` is technically redundant at runtime (a non-null `root` already implies `HAS_DOM`, which implies a non-null `PARSER`), but TypeScript can't follow that invariant across functions — without it, `PARSER.parseFromString()` fails to compile with `TS18047: 'PARSER' is possibly 'null'`. The explicit check narrows the type and avoids a `!` assertion, at the cost of one comparison per flush.


### :link: External links

Jira ticket: https://hashicorp.atlassian.net/browse/HDS-6653

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>