### PR TITLE
`Form::MaskedInput` + `Form::TextInput`:  Documentation updates for a11y fixes

### DIFF
--- a/website/docs/components/form/masked-input/partials/code/component-api.md
+++ b/website/docs/components/form/masked-input/partials/code/component-api.md
@@ -28,11 +28,14 @@ The Masked Input component has two different variants with their own APIs:
   <C.Property @name="isInvalid" @type="boolean" @default="false">
     Applies an “invalid” appearance to the control but doesn’t modify its logical validity.
   </C.Property>
-  <C.Property @name="visibilityToggleAriaLabel" @type="string" @default="Show masked content">
-    Override this value to provide a meaningful `aria-label` for the visibility toggle button.
+  <C.Property @name="visibilityToggleAriaLabel" @type="string" @default="Toggle masked content">
+    Override this value to provide a meaningful `aria-label` for the visibility toggle button. The current pressed state of the toggle button is communicated through the `aria-pressed` attribute.
   </C.Property>
   <C.Property @name="visibilityToggleAriaMessageText" @type="string" @default="Input content is hidden">
-    Override this value to provide a meaningful `aria-live` message when the visibility toggle button is pressed.
+    Override this value to provide a meaningful `aria-live` message when the input content is hidden.
+  </C.Property>
+  <C.Property @name="visibilityToggleAriaMessageTextWhenVisible" @type="string" @default="Input content is visible">
+    Override this value to provide a meaningful `aria-live` message when the input content is visible.
   </C.Property>
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
     If set to `true`, it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to the clipboard.
@@ -81,11 +84,14 @@ The Masked Input component has two different variants with their own APIs:
   <C.Property @name="isOptional" @type="boolean" @default="false">
     Appends an `Optional` indicator next to the label text when user input is optional.
   </C.Property>
-  <C.Property @name="visibilityToggleAriaLabel" @type="string" @default="Show masked content">
-    Override this value to provide a meaningful `aria-label` for the visibility toggle button.
+  <C.Property @name="visibilityToggleAriaLabel" @type="string" @default="Toggle masked content">
+    Override this value to provide a meaningful `aria-label` for the visibility toggle button. The current pressed state of the toggle button is communicated through the `aria-pressed` attribute.
   </C.Property>
   <C.Property @name="visibilityToggleAriaMessageText" @type="string" @default="Input content is hidden">
-    Override this value to provide a meaningful `aria-live` message when the visibility toggle button is pressed.
+    Override this value to provide a meaningful `aria-live` message when the input content is hidden.
+  </C.Property>
+  <C.Property @name="visibilityToggleAriaMessageTextWhenVisible" @type="string" @default="Input content is visible">
+    Override this value to provide a meaningful `aria-live` message when the input content is visible.
   </C.Property>
   <C.Property @name="hasCopyButton" @type="boolean" @default="false">
     If set to `true`, it renders a [`Copy::Button`](/components/copy/button) next to the form control allowing the value of the input to be copied to the clipboard.
@@ -144,3 +150,4 @@ The Masked Input component has two different variants with their own APIs:
     </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>
+

--- a/website/docs/components/form/text-input/partials/code/component-api.md
+++ b/website/docs/components/form/text-input/partials/code/component-api.md
@@ -69,11 +69,14 @@ The Text Input component has two different variants with their own APIs:
   <C.Property @name="hasVisibilityToggle" @type="boolean" @default="true">
     Adds a visibility toggle button if `@type` is set to `password`.
   </C.Property>
-  <C.Property @name="visibilityToggleAriaLabel" @type="string" @default="Show masked content">
-    Override this value to provide a meaningful `aria-label` for the visibility toggle button.
+  <C.Property @name="visibilityToggleAriaLabel" @type="string" @default="Toggle password visibility">
+    Override this value to provide a meaningful `aria-label` for the visibility toggle button. The current pressed state of the toggle button is communicated through the `aria-pressed` attribute.
   </C.Property>
-  <C.Property @name="visibilityToggleAriaMessageText" @type="string" @default="Input content is hidden">
-    Override this value to provide a meaningful `aria-live` message when the visibility toggle button is pressed.
+  <C.Property @name="visibilityToggleAriaMessageText" @type="string" @default="Password is hidden">
+    Override this value to provide a meaningful `aria-live` message when the password is hidden.
+  </C.Property>
+  <C.Property @name="visibilityToggleAriaMessageTextWhenVisible" @type="string" @default="Password is visible">
+    Override this value to provide a meaningful `aria-live` message when the password is visible.
   </C.Property>
   <C.Property @name="...attributes">
     This component supports use of [`...attributes`](https://guides.emberjs.com/release/in-depth-topics/patterns-for-components/#toc_attribute-ordering).
@@ -115,3 +118,4 @@ The Text Input component has two different variants with their own APIs:
     </Doc::ComponentApi>
   </C.Property>
 </Doc::ComponentApi>
+


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge until further notice

### :pushpin: Summary

If merged, this PR would update the component API docs to reflect the fixes in #4118 to `Form::MaskedInput::Base`, `Form::MaskedInput::Field`, and `Form::TextInput::Field`. The `visibilityToggleAriaLabel` and `visibilityToggleAriaMessageText` args were updated, and a new `visibilityToggleAriaMessageTextWhenVisible` arg was added.

### :link: External links

<!-- Issues, RFC, etc. -->
Jira ticket: [HDS-6621](https://hashicorp.atlassian.net/browse/HDS-6621)

***

### :eyes: Component checklist

- [ ] Percy was checked for any visual regression
- [ ] A changelog entry was added via [Changesets](https://github.com/changesets/changesets) if needed (see [templates here](https://hashicorp.atlassian.net/wiki/spaces/HDS/pages/3243114706/Changelog+authoring+best+practices#Templates))

:speech_balloon: Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

<details>

<summary>:clipboard: PCI review checklist</summary>

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  Examples of changes to controls include access controls, encryption, logging, etc.
- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.

</details>

[HDS-6621]: https://hashicorp.atlassian.net/browse/HDS-6621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ